### PR TITLE
Add prettier errors (no stack traces) with more content.

### DIFF
--- a/bin/handel
+++ b/bin/handel
@@ -72,7 +72,9 @@ function deployAction(handelFile, argv) {
             for (let envDeployResult of envDeployResults) {
                 if (envDeployResult.status !== 'success') {
                     winston.warn(`Error while deploying environment: ${envDeployResult.message}`);
-                    winston.warn(envDeployResult.error);
+                    if(winston.level === 'debug') {
+                        winston.warn(envDeployResult.error);
+                    }
                     success = false;
                 }
             }

--- a/lib/aws/cloudformation-calls.js
+++ b/lib/aws/cloudformation-calls.js
@@ -17,6 +17,27 @@
 const winston = require('winston');
 const AWS = require('aws-sdk');
 
+function getErrorsForFailedStack(cloudFormation, stackId) {
+    var describeParams = {
+        StackName: stackId
+    };
+    return cloudFormation.describeStackEvents(describeParams).promise()
+        .then(describeResponse => {
+            let stackEvents = describeResponse.StackEvents;
+            let failEvents = [];
+            for (let stackEvent of stackEvents) {
+                if (stackEvent.ResourceStatus.includes("FAILED")) {
+                    failEvents.push(stackEvent.ResourceStatusReason);
+                }
+            }
+            return failEvents;
+        });
+}
+
+function getCfErrorMessage(stackName, errors) {
+    return `Errors while creating stack '${stackName}': \n${errors.join('\n')}`
+}
+
 /**
  * Given a stack name, returns the stack, or null if it doesnt exist
  * 
@@ -82,8 +103,15 @@ exports.createStack = function (stackName, templateBody, parameters) {
     winston.debug(`Creating CloudFormation stack ${stackName}`);
     return cloudformation.createStack(params).promise()
         .then(createResult => {
+            let stackId = createResult.StackId;
             winston.debug(`Created CloudFormation stack ${stackName}`);
             return exports.waitForStack(stackName, 'stackCreateComplete')
+                .catch(err => {
+                    return getErrorsForFailedStack(cloudformation, stackId)
+                        .then(errors => {
+                            throw new Error(getCfErrorMessage(stackName, errors));
+                        });
+                });
         });
 }
 
@@ -100,8 +128,15 @@ exports.updateStack = function (stackName, templateBody, parameters) {
     winston.debug(`Updating CloudFormation stack ${stackName}`);
     return cloudformation.updateStack(params).promise()
         .then(createResult => {
+            let stackId = createResult.StackId;
             winston.debug(`Updated CloudFormation stack ${stackName}`);
             return exports.waitForStack(stackName, 'stackUpdateComplete')
+                .catch(err => {
+                    return getErrorsForFailedStack(cloudformation, stackId)
+                        .then(errors => {
+                            throw new Error(getCfErrorMessage(stackName, errors));
+                        });
+                });
         })
         .catch(err => {
             if (err.message.includes('No updates are to be performed')) {
@@ -109,7 +144,7 @@ exports.updateStack = function (stackName, templateBody, parameters) {
                 return exports.getStack(stackName);
             }
             throw err;
-        })
+        });
 }
 
 exports.deleteStack = function (stackName) {

--- a/lib/common/deployers-common.js
+++ b/lib/common/deployers-common.js
@@ -162,6 +162,26 @@ exports.deleteSecurityGroupForService = function (stackName) {
         });
 }
 
+exports.deployCloudFormationStack = function(stackName, cfTemplate, cfParameters, updatesSupported, serviceType) {
+    return cloudformationCalls.getStack(stackName)
+        .then(stack => {
+            if(!stack) {
+                winston.info(`${serviceType} - Creating stack '${stackName}'`);
+                return cloudformationCalls.createStack(stackName, cfTemplate, cfParameters);
+            }
+            else {
+                if(updatesSupported) {
+                    winston.info(`${serviceType} - Updates stack '${stackName}'`);
+                    return cloudformationCalls.updateStack(stackName, cfTemplate, cfParameters);
+                }
+                else {
+                    winston.info(`${serviceType} - Updates not supported for this service type`);
+                    return stack;
+                }
+            }
+        })
+}
+
 exports.unDeployCloudFormationStack = function (serviceContext, serviceType) {
     let stackName = exports.getResourceName(serviceContext);
     winston.info(`${serviceType} - Executing UnDeploy on '${stackName}'`)

--- a/lib/services/apigateway/index.js
+++ b/lib/services/apigateway/index.js
@@ -95,6 +95,14 @@ function getDeployContext(serviceContext) {
     return new DeployContext(serviceContext);
 }
 
+function getRestApiUrl(cfStack, serviceContext) {
+    let restApiId = cloudformationCalls.getOutput("RestApiId", cfStack);
+    let restApiDomain = `${restApiId}.execute-api.${accountConfig.region}.amazonaws.com`;
+    let stageName = serviceContext.environmentName; //Env name is the stage name
+    let restApiUrl = `https://${restApiDomain}/${stageName}/`;
+    return restApiUrl;
+}
+
 
 /**
  * Service Deployer Contract Methods
@@ -139,23 +147,10 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
             return getCompiledApiGatewayTemplate(stackName, ownServiceContext, dependenciesDeployContexts, s3ObjectInfo);
         })
         .then(compiledTemplate => {
-            return cloudformationCalls.getStack(stackName)
-                .then(stack => {
-                    if (!stack) { //Create new API gateway service
-                        winston.info(`API Gateway - Creating new API ${stackName}`);
-                        return cloudformationCalls.createStack(stackName, compiledTemplate, []);
-                    }
-                    else { //Update existing service
-                        winston.info(`API Gateway - Updating existing API ${stackName}`);
-                        return cloudformationCalls.updateStack(stackName, compiledTemplate, []);
-                    }
-                });
+            return deployersCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, "API Gateway");
         })
         .then(deployedStack => {
-            let restApiId = cloudformationCalls.getOutput("RestApiId", deployedStack);
-            let restApiDomain = `${restApiId}.execute-api.${accountConfig.region}.amazonaws.com`;
-            let stageName = ownServiceContext.environmentName; //Env name is the stage name
-            let restApiUrl = `https://${restApiDomain}/${stageName}/`;
+            let restApiUrl = getRestApiUrl(deployedStack, ownServiceContext);
             winston.info(`API Gateway - Deployed service is available at ${restApiUrl}`);
             return getDeployContext(ownServiceContext);
         });

--- a/lib/services/beanstalk/index.js
+++ b/lib/services/beanstalk/index.js
@@ -213,7 +213,6 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
     let stackName = deployersCommon.getResourceName(ownServiceContext);
     winston.info(`Beanstalk - Executing Deploy on ${stackName}`);
 
-
     return deployersCommon.createCustomRole('elasticbeanstalk.amazonaws.com', 'HandelBeanstalkServiceRole', getPolicyStatementsForServiceRole())
         .then(serviceRole => {
             return getEbExtensionScript(dependenciesDeployContexts)
@@ -228,17 +227,7 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
                 });
         })
         .then(compiledBeanstalkTemplate => {
-            return cloudFormationCalls.getStack(stackName)
-                .then(stack => {
-                    if (!stack) {
-                        winston.info(`Beanstalk - Creating Beanstalk app ${stackName}`);
-                        return cloudFormationCalls.createStack(stackName, compiledBeanstalkTemplate, []);
-                    }
-                    else {
-                        winston.info(`Beanstalk - Updating Beanstalk app ${stackName}`);
-                        return cloudFormationCalls.updateStack(stackName, compiledBeanstalkTemplate, []);
-                    }
-                });
+            return deployersCommon.deployCloudFormationStack(stackName, compiledBeanstalkTemplate, [], true, "Beanstalk");
         })
         .then(deployedStack => {
             winston.info(`Beanstalk - Finished deploying Beanstalk app ${stackName}`);

--- a/lib/services/cloudwatchevent/index.js
+++ b/lib/services/cloudwatchevent/index.js
@@ -98,17 +98,7 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
 
     return getCompiledEventRuleTemplate(stackName, ownServiceContext)
         .then(eventRuleTemplate => {
-            return cloudFormationCalls.getStack(stackName)
-                .then(stack => {
-                    if (!stack) {
-                        winston.info(`CloudWatch Events - Creating CloudWatch Events Rule ${stackName}`);
-                        return cloudFormationCalls.createStack(stackName, eventRuleTemplate, []);
-                    }
-                    else {
-                        winston.info(`CloudWatch Events - Updating CloudWatch Events Rule ${stackName}`);
-                        return cloudFormationCalls.updateStack(stackName, eventRuleTemplate, []);
-                    }
-                })
+            return deployersCommon.deployCloudFormationStack(stackName, eventRuleTemplate, [], true, "CloudWatch Events");
         })
         .then(deployedStack => {
             winston.info(`CloudWatchEvents - Finished deploying CloudWatch Events Rule ${stackName}`);

--- a/lib/services/dynamodb/index.js
+++ b/lib/services/dynamodb/index.js
@@ -139,18 +139,9 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
     var stackName = deployersCommon.getResourceName(ownServiceContext);
     winston.info(`DynamoDB - Deploying table ${stackName}`);
 
-    return cloudFormationCalls.getStack(stackName)
-        .then(stack => {
-            if (!stack) { //Create
-                return getCompiledDynamoTemplate(stackName, ownServiceContext)
-                    .then(compiledTemplate => {
-                        return cloudFormationCalls.createStack(stackName, compiledTemplate, []);
-                    });
-            }
-            else {
-                winston.warn("DynamoDB - Updates not suported on DynamoDB");
-                return stack;
-            }
+    return getCompiledDynamoTemplate(stackName, ownServiceContext)
+        .then(compiledTemplate => {
+            return deployersCommon.deployCloudFormationStack(stackName, compiledTemplate, [], false, "DynamoDB");
         })
         .then(deployedStack => {
             winston.info(`DynamoDB - Finished deploying table ${stackName}`);

--- a/lib/services/ecs/index.js
+++ b/lib/services/ecs/index.js
@@ -334,25 +334,13 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
                 });
         })
         .then(compiledTemplate => {
-            return cloudformationCalls.getStack(stackName)
-                .then(stack => {
-                    if (!stack) { //Create 
-                        winston.info(`ECS - Creating new ECS cluster ${stackName}`);
-                        return cloudformationCalls.createStack(stackName, compiledTemplate, []);
-                    }
-                    else { //Update
-                        //TODO - If user data changed, then cycle all instances in a safe manner (https://github.com/colinbjohnson/aws-missing-tools/blob/master/aws-ha-release/aws-ha-release.sh)
-                        winston.info(`ECS - Updating existing ECS cluster ${stackName}`);
-                        return cloudformationCalls.updateStack(stackName, compiledTemplate, []);
-                    }
-                })
-                .then(deployedStack => {
-                    winston.info(`ECS - Finished Deploying Cluster and Serivce ${stackName}`);
-                    let deployContext = new DeployContext(ownServiceContext);
-                    return deployContext;
-                });
+            return deployersCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, "ECS");
+        })
+        .then(deployedStack => {
+            winston.info(`ECS - Finished Deploying Cluster and Serivce ${stackName}`);
+            let deployContext = new DeployContext(ownServiceContext);
+            return deployContext;
         });
-
 }
 
 exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerServiceContext, producerDeployContext) {

--- a/lib/services/efs/index.js
+++ b/lib/services/efs/index.js
@@ -153,25 +153,14 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
     let stackName = deployersCommon.getResourceName(ownServiceContext);
     winston.info(`EFS - Executing Deploy on ${stackName}`);
 
-    return cloudFormationCalls.getStack(stackName)
-        .then(stack => {
-            if (!stack) {
-                winston.info(`EFS - Creating file system ${stackName}`);
-                return getCompiledEfsTemplate(stackName, ownServiceContext, ownPreDeployContext)
-                    .then(compiledTemplate => {
-                        return cloudFormationCalls.createStack(stackName, compiledTemplate, [])
-                            .then(createdStack => {
-                                winston.info(`EFS - Created file system ${stackName}`)
-                                let fileSystemId = getFileSystemIdFromStack(createdStack);
-                                return getDeployContext(ownServiceContext, fileSystemId, accountConfig['region'], stackName);
-                            });
-                    });
-            }
-            else {
-                winston.info(`EFS - Updates are not supported for this service`);
-                let fileSystemId = getFileSystemIdFromStack(stack);
-                return getDeployContext(ownServiceContext, fileSystemId, accountConfig['region'], stackName);
-            }
+    return getCompiledEfsTemplate(stackName, ownServiceContext, ownPreDeployContext)
+        .then(compiledTemplate => {
+            return deployersCommon.deployCloudFormationStack(stackName, compiledTemplate, [], false, "EFS");
+        })
+        .then(deployedStack => {
+            winston.info(`EFS - Finished deploy for '${stackName}'`)
+            let fileSystemId = getFileSystemIdFromStack(deployedStack);
+            return getDeployContext(ownServiceContext, fileSystemId, accountConfig['region'], stackName);
         });
 }
 

--- a/lib/services/lambda/index.js
+++ b/lib/services/lambda/index.js
@@ -142,17 +142,7 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
             return getCompiledLambdaTemplate(stackName, ownServiceContext, dependenciesDeployContexts, s3ArtifactInfo);
         })
         .then(compiledLambdaTemplate => {
-            return cloudFormationCalls.getStack(stackName)
-                .then(stack => {
-                    if (!stack) {
-                        winston.info(`Lambda - Creating Lambda function ${stackName}`);
-                        return cloudFormationCalls.createStack(stackName, compiledLambdaTemplate, []);
-                    }
-                    else {
-                        winston.info(`Lambda - Updating Lambda function ${stackName}`);
-                        return cloudFormationCalls.updateStack(stackName, compiledLambdaTemplate, []);
-                    }
-                })
+            return deployersCommon.deployCloudFormationStack(stackName, compiledLambdaTemplate, [], true, "Lambda");
         })
         .then(deployedStack => {
             winston.info(`Lambda - Finished deploying Lambda function ${stackName}`);

--- a/lib/services/memcached/index.js
+++ b/lib/services/memcached/index.js
@@ -148,17 +148,7 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
 
     return getCompiledMemcachedTemplate(stackName, ownServiceContext, ownPreDeployContext)
         .then(compiledTemplate => {
-            return cloudFormationCalls.getStack(stackName)
-                .then(stack => {
-                    if (!stack) {
-                        winston.info(`Memcached - Creating new Memcached cluster '${stackName}'`);
-                        return cloudFormationCalls.createStack(stackName, compiledTemplate, [])
-                    }
-                    else {
-                        winston.info(`Memcached - Updating existing Memcached cluster '${stackName}'`);
-                        return cloudFormationCalls.updateStack(stackName, compiledTemplate, []);
-                    }
-                });
+            return deployersCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, "Memcached");
         })
         .then(deployedStack => {
             winston.info(`Memcached - Finished Deploy on '${stackName}'`);

--- a/lib/services/redis/index.js
+++ b/lib/services/redis/index.js
@@ -203,17 +203,7 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
 
     return getCompiledRedisTemplate(stackName, ownServiceContext, ownPreDeployContext)
         .then(compiledTemplate => {
-            return cloudFormationCalls.getStack(stackName)
-                .then(stack => {
-                    if (!stack) {
-                        winston.info(`Redis - Creating new Redis instance '${stackName}'`);
-                        return cloudFormationCalls.createStack(stackName, compiledTemplate, [])
-                    }
-                    else {
-                        winston.info(`Redis - Updating existing Redis instance '${stackName}'`);
-                        return cloudFormationCalls.updateStack(stackName, compiledTemplate, []);
-                    }
-                });
+            return deployersCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, "Redis");
         })
         .then(deployedStack => {
             winston.info(`Redis - Finished Deploy on '${stackName}'`);

--- a/lib/services/s3/index.js
+++ b/lib/services/s3/index.js
@@ -122,21 +122,10 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
     let stackName = deployersCommon.getResourceName(ownServiceContext);
     winston.info(`S3 - Deploying S3 bucket ${stackName}`);
 
-    return cloudFormationCalls.getStack(stackName)
-        .then(stack => {
-            return getCompiledS3Template(stackName, ownServiceContext)
-                .then(compiledTemplate => {
-                    if (!stack) { //Create
-                        winston.info(`S3 - Creating S3 bucket ${stackName}`);
-                        return cloudFormationCalls.createStack(stackName, compiledTemplate, []);
-                    }
-                    else {
-                        winston.info(`S3 - Updating S3 bucket ${stackName}`);
-                        return cloudFormationCalls.updateStack(stackName, compiledTemplate, []);
-                    }
-                });
+    return getCompiledS3Template(stackName, ownServiceContext)
+        .then(compiledTemplate => {
+            return deployersCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, "S3");
         })
-
         .then(createdOrUpdatedStack => {
             winston.info(`S3 - Finished deploying S3 bucket ${stackName}`);
             return getDeployContext(ownServiceContext, createdOrUpdatedStack);

--- a/lib/services/s3staticsite/index.js
+++ b/lib/services/s3staticsite/index.js
@@ -58,23 +58,14 @@ function getCompiledS3Template(ownServiceContext, stackName, loggingBucketName) 
 
 function createLoggingBucketIfNotExists() {
     let stackName = "HandelStaticSiteLoggingBucket";
-    return cloudFormationCalls.getStack(stackName)
-        .then(stack => {
-            if (!stack) {
-                let bucketName = `handel-static-site-logging-${accountConfig.region}-${accountConfig.account_id}`;
-                let handlebarsParams = {
-                    bucketName
-                }
+    let bucketName = `handel-static-site-logging-${accountConfig.region}-${accountConfig.account_id}`;
+    let handlebarsParams = {
+        bucketName
+    }
 
-                return handlebarsUtils.compileTemplate(`${__dirname}/s3-static-site-logging-bucket.yml`, handlebarsParams)
-                    .then(compiledTemplate => {
-                        winston.info(`Creating logging bucket for static websites '${bucketName}'`);
-                        return cloudFormationCalls.createStack(stackName, compiledTemplate, []);
-                    });
-            }
-            else {
-                return stack;
-            }
+    return handlebarsUtils.compileTemplate(`${__dirname}/s3-static-site-logging-bucket.yml`, handlebarsParams)
+        .then(compiledTemplate => {
+            return deployersCommon.deployCloudFormationStack(stackName, compiledTemplate, [], false, "Logging Bucket for S3 Static Sites");
         })
         .then(deployedStack => {
             return cloudFormationCalls.getOutput("BucketName", deployedStack);
@@ -91,7 +82,7 @@ exports.check = function (serviceContext) {
     let errors = [];
     let serviceParams = serviceContext.params;
 
-    if(!serviceParams.path_to_code) {
+    if (!serviceParams.path_to_code) {
         errors.push(`S3 Static Site - The 'path_to_code' parameter is required`);
     }
 
@@ -117,17 +108,7 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
             return getCompiledS3Template(ownServiceContext, stackName, loggingBucketName)
         })
         .then(compiledTemplate => {
-            return cloudFormationCalls.getStack(stackName)
-                .then(stack => {
-                    if (!stack) { //Create
-                        winston.info(`S3 Static Site - Creating S3 static site '${stackName}'`);
-                        return cloudFormationCalls.createStack(stackName, compiledTemplate, []);
-                    }
-                    else {
-                        winston.info(`S3 Static Site - Updating S3 static site '${stackName}'`);
-                        return cloudFormationCalls.updateStack(stackName, compiledTemplate, []);
-                    }
-                });
+            return deployersCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, "S3 Static Site");
         })
         .then(createdOrUpdatedStack => {
             let bucketName = cloudFormationCalls.getOutput("BucketName", createdOrUpdatedStack);

--- a/lib/services/sns/index.js
+++ b/lib/services/sns/index.js
@@ -105,17 +105,7 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
 
     return getCompiledSnsTemplate(stackName, ownServiceContext)
         .then(compiledSnsTemplate => {
-            return cloudFormationCalls.getStack(stackName)
-                .then(stack => {
-                    if (!stack) {
-                        winston.info(`SNS - Creating SNS topic ${stackName}`);
-                        return cloudFormationCalls.createStack(stackName, compiledSnsTemplate, []);
-                    }
-                    else {
-                        winston.info(`SNS - Updating SNS topic ${stackName}`);
-                        return cloudFormationCalls.updateStack(stackName, compiledSnsTemplate, []);
-                    }
-                });
+            return deployersCommon.deployCloudFormationStack(stackName, compiledSnsTemplate, [], true, "SNS");
         })
         .then(deployedStack => {
             winston.info(`SNS - Finished deploying SNS topic ${stackName}`);

--- a/lib/services/sqs/index.js
+++ b/lib/services/sqs/index.js
@@ -147,17 +147,7 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
 
     return getCompiledSqsTemplate(stackName, ownServiceContext)
         .then(sqsTemplate => {
-            return cloudFormationCalls.getStack(stackName)
-                .then(stack => {
-                    if (!stack) {
-                        winston.info(`SQS - Creating SQS queue ${stackName}`);
-                        return cloudFormationCalls.createStack(stackName, sqsTemplate, []);
-                    }
-                    else {
-                        winston.info(`SQS - Updating SQS queue ${stackName}`);
-                        return cloudFormationCalls.updateStack(stackName, sqsTemplate, []);
-                    }
-                })
+            return deployersCommon.deployCloudFormationStack(stackName, sqsTemplate, [], true, "SQS");
         })
         .then(deployedStack => {
             winston.info(`SQS - Finished deploying SQS queue ${stackName}`);

--- a/test/common/deployers-common-test.js
+++ b/test/common/deployers-common-test.js
@@ -242,6 +242,41 @@ describe('deployers-common', function () {
         })
     });
 
+    describe('deployCloudFormationStack', function() {
+        it('should create the stack if it doesnt exist yet', function() {
+            let getStackStub = sandbox.stub(cloudformationCalls, 'getStack').returns(Promise.resolve(null));
+            let createStackStub = sandbox.stub(cloudformationCalls, 'createStack').returns(Promise.resolve({}));
+            return deployersCommon.deployCloudFormationStack("FakeStack", "", [], true, "FakeService")
+                .then(deployedStack => {
+                    expect(deployedStack).to.deep.equal({});
+                    expect(getStackStub.callCount).to.equal(1);
+                    expect(createStackStub.callCount).to.equal(1);
+                });
+        });
+
+        it('should update the stack if it exists and updates are supported', function() {
+            let getStackStub = sandbox.stub(cloudformationCalls, 'getStack').returns(Promise.resolve({}));
+            let updateStackStub = sandbox.stub(cloudformationCalls, 'updateStack').returns(Promise.resolve({}));
+            return deployersCommon.deployCloudFormationStack("FakeStack", "", [], true, "FakeService")
+                .then(deployedStack => {
+                    expect(deployedStack).to.deep.equal({});
+                    expect(getStackStub.callCount).to.equal(1);
+                    expect(updateStackStub.callCount).to.equal(1);
+                });
+        });
+
+        it('should just return the stack if it exists and updates are not supported', function() {
+            let getStackStub = sandbox.stub(cloudformationCalls, 'getStack').returns(Promise.resolve({}));
+            let updateStackStub = sandbox.stub(cloudformationCalls, 'updateStack').returns(Promise.resolve(null));
+            return deployersCommon.deployCloudFormationStack("FakeStack", "", [], false, "FakeService")
+                .then(deployedStack => {
+                    expect(deployedStack).to.deep.equal({});
+                    expect(getStackStub.callCount).to.equal(1);
+                    expect(updateStackStub.callCount).to.equal(0);
+                });
+        });
+    });
+
     describe('unDeployCloudFormationStack', function () {
         it('should delete the stack if it exists', function () {
             let getStackStub = sandbox.stub(cloudformationCalls, 'getStack').returns(Promise.resolve({}));

--- a/test/services/beanstalk/beanstalk-test.js
+++ b/test/services/beanstalk/beanstalk-test.js
@@ -16,8 +16,6 @@
  */
 const accountConfig = require('../../../lib/common/account-config')(`${__dirname}/../../test-account-config.yml`).getAccountConfig();
 const beanstalk = require('../../../lib/services/beanstalk');
-const ebextensions = require('../../../lib/services/beanstalk/ebextensions');
-const cloudformationCalls = require('../../../lib/aws/cloudformation-calls');
 const ServiceContext = require('../../../lib/datatypes/service-context');
 const DeployContext = require('../../../lib/datatypes/deploy-context');
 const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
@@ -101,7 +99,7 @@ describe('beanstalk deployer', function () {
             return ownPreDeployContext;
         }
 
-        it('should create the service if it doesnt exist', function () {
+        it('should deploy the service', function () {
             let createCustomRoleStub = sandbox.stub(deployersCommon, 'createCustomRole').returns(Promise.resolve({
                 RoleName: "FakeServiceRole"
             }));
@@ -109,8 +107,7 @@ describe('beanstalk deployer', function () {
                 Bucket: "FakeBucket",
                 Key: "FakeKey"
             }));
-            let getStackStub = sandbox.stub(cloudformationCalls, 'getStack').returns(Promise.resolve(null));
-            let createStackStub = sandbox.stub(cloudformationCalls, 'createStack').returns(Promise.resolve({}));
+            let deployStackStub = sandbox.stub(deployersCommon, 'deployCloudFormationStack').returns(Promise.resolve({}));
 
             let ownServiceContext = getServiceContext();
             let sgGroupId = "FakeSgId";
@@ -120,33 +117,7 @@ describe('beanstalk deployer', function () {
                 .then(deployContext => {
                     expect(createCustomRoleStub.calledOnce).to.be.true;
                     expect(prepareAndUploadDeployableArtifactStub.calledOnce).to.be.true;
-                    expect(getStackStub.calledOnce).to.be.true;
-                    expect(createStackStub.calledOnce).to.be.true;
-                    expect(deployContext).to.be.instanceof(DeployContext);
-                });
-        });
-
-        it('should update the service if it doesnt exist', function () {
-            let createCustomRoleStub = sandbox.stub(deployersCommon, 'createCustomRole').returns(Promise.resolve({
-                RoleName: "FakeServiceRole"
-            }));
-            let prepareAndUploadDeployableArtifactStub = sandbox.stub(deployableArtifact, 'prepareAndUploadDeployableArtifact').returns(Promise.resolve({
-                Bucket: "FakeBucket",
-                Key: "FakeKey"
-            }));
-            let getStackStub = sandbox.stub(cloudformationCalls, 'getStack').returns(Promise.resolve({}));
-            let updateStackStub = sandbox.stub(cloudformationCalls, 'updateStack').returns(Promise.resolve({}));
-
-            let ownServiceContext = getServiceContext();
-            let sgGroupId = "FakeSgId";
-            let ownPreDeployContext = getPreDeployContext(ownServiceContext, sgGroupId);
-
-            return beanstalk.deploy(ownServiceContext, ownPreDeployContext, [])
-                .then(deployContext => {
-                    expect(prepareAndUploadDeployableArtifactStub.calledOnce).to.be.true;
-                    expect(createCustomRoleStub.calledOnce).to.be.true;
-                    expect(getStackStub.calledOnce).to.be.true;
-                    expect(updateStackStub.calledOnce).to.be.true;
+                    expect(deployStackStub.calledOnce).to.be.true;
                     expect(deployContext).to.be.instanceof(DeployContext);
                 });
         });

--- a/test/services/cloudwatchevent/cloudwatchevent-test.js
+++ b/test/services/cloudwatchevent/cloudwatchevent-test.js
@@ -18,6 +18,7 @@ const accountConfig = require('../../../lib/common/account-config')(`${__dirname
 const cloudWatchEvent = require('../../../lib/services/cloudwatchevent');
 const cloudFormationCalls = require('../../../lib/aws/cloudformation-calls');
 const cloudWatchEventsCalls = require('../../../lib/aws/cloudwatch-events-calls');
+const deployersCommon = require('../../../lib/common/deployers-common');
 const ServiceContext = require('../../../lib/datatypes/service-context');
 const ProduceEventsContext = require('../../../lib/datatypes/produce-events-context');
 const DeployContext = require('../../../lib/datatypes/deploy-context');
@@ -91,38 +92,17 @@ describe('cloudwatchevent deployer', function () {
         let preDeployContext = new PreDeployContext(serviceContext);
         let eventRuleArn = "FakeEventRuleArn";
 
-        it('should create a new rule when it doesnt exist', function () {
-            let getStackStub = sandbox.stub(cloudFormationCalls, 'getStack').returns(Promise.resolve(null));
-            let createStackStub = sandbox.stub(cloudFormationCalls, 'createStack').returns(Promise.resolve({
+        it('should deploy the event rule', function () {
+            let deployStackStub = sandbox.stub(deployersCommon, 'deployCloudFormationStack').returns(Promise.resolve({
                 Outputs: [{
                     OutputKey: 'EventRuleArn',
                     OutputValue: eventRuleArn
-                }]
+                }]                
             }));
 
             return cloudWatchEvent.deploy(serviceContext, preDeployContext, [])
                 .then(deployContext => {
-                    expect(getStackStub.calledOnce).to.be.true;
-                    expect(createStackStub.calledOnce).to.be.true;
-                    expect(deployContext).to.be.instanceof(DeployContext);
-                    expect(deployContext.eventOutputs.principal).to.equal("events.amazonaws.com");
-                    expect(deployContext.eventOutputs.eventRuleArn).to.equal(eventRuleArn);
-                });
-        });
-
-        it('should update an existing rule when it exists', function () {
-            let getStackStub = sandbox.stub(cloudFormationCalls, 'getStack').returns(Promise.resolve({}));
-            let updateStackStub = sandbox.stub(cloudFormationCalls, 'updateStack').returns(Promise.resolve({
-                Outputs: [{
-                    OutputKey: 'EventRuleArn',
-                    OutputValue: eventRuleArn
-                }]
-            }));
-
-            return cloudWatchEvent.deploy(serviceContext, preDeployContext, [])
-                .then(deployContext => {
-                    expect(getStackStub.calledOnce).to.be.true;
-                    expect(updateStackStub.calledOnce).to.be.true;
+                    expect(deployStackStub.calledOnce).to.be.true;
                     expect(deployContext).to.be.instanceof(DeployContext);
                     expect(deployContext.eventOutputs.principal).to.equal("events.amazonaws.com");
                     expect(deployContext.eventOutputs.eventRuleArn).to.equal(eventRuleArn);

--- a/test/services/ecs/ecs-test.js
+++ b/test/services/ecs/ecs-test.js
@@ -20,7 +20,6 @@ const deployersCommon = require('../../../lib/common/deployers-common');
 const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../../lib/datatypes/un-bind-context');
 const UnDeployContext = require('../../../lib/datatypes/un-deploy-context');
-const cloudformationCalls = require('../../../lib/aws/cloudformation-calls');
 const ServiceContext = require('../../../lib/datatypes/service-context');
 const DeployContext = require('../../../lib/datatypes/deploy-context');
 const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
@@ -179,41 +178,14 @@ describe('ecs deployer', function () {
 
             //Stub out AWS calls
             let createCustomRoleStub = sandbox.stub(deployersCommon, 'createCustomRole').returns(Promise.resolve({}));
-            let getStackStub = sandbox.stub(cloudformationCalls, 'getStack').returns(Promise.resolve(null));
-            let createStackStub = sandbox.stub(cloudformationCalls, 'createStack').returns(Promise.resolve({}));
+            let deployStackStub = sandbox.stub(deployersCommon, 'deployCloudFormationStack').returns(Promise.resolve({}));
 
             //Run the test
             return ecs.deploy(ownServiceContext, ownPreDeployContext, dependenciesDeployContexts)
                 .then(deployContext => {
                     expect(deployContext).to.be.instanceof(DeployContext);
-                    expect(getStackStub.calledOnce).to.be.true;
+                    expect(deployStackStub.calledOnce).to.be.true;
                     expect(createCustomRoleStub.calledOnce).to.be.true;
-                    expect(createStackStub.calledOnce).to.be.true;
-                });
-        });
-
-        it('should update the CF service stack when it exists', function () {
-            let appName = "FakeApp";
-            let envName = "FakeEnv";
-            let deployVersion = "1";
-
-            let ownServiceContext = getOwnServiceContextForDeploy(appName, envName, deployVersion);
-            let ownPreDeployContext = getOwnPreDeployContextForDeploy(ownServiceContext);
-            let dependenciesDeployContexts = getDependenciesDeployContextsForDeploy(appName, envName, deployVersion);
-
-            //Stub out AWS calls
-            let fakeArn = "FakeArn";
-            let createCustomRoleStub = sandbox.stub(deployersCommon, 'createCustomRole').returns(Promise.resolve({}));
-            let getStackStub = sandbox.stub(cloudformationCalls, 'getStack').returns(Promise.resolve({}));
-            let updateStackStub = sandbox.stub(cloudformationCalls, 'updateStack').returns(Promise.resolve({}));
-
-            //Run the test
-            return ecs.deploy(ownServiceContext, ownPreDeployContext, dependenciesDeployContexts)
-                .then(deployContext => {
-                    expect(deployContext).to.be.instanceof(DeployContext);
-                    expect(getStackStub.calledOnce).to.be.true;
-                    expect(createCustomRoleStub.calledOnce).to.be.true;
-                    expect(updateStackStub.calledOnce).to.be.true;
                 });
         });
     });

--- a/test/services/efs/efs-test.js
+++ b/test/services/efs/efs-test.js
@@ -17,7 +17,6 @@
 const accountConfig = require('../../../lib/common/account-config')(`${__dirname}/../../test-account-config.yml`).getAccountConfig();
 const efs = require('../../../lib/services/efs');
 const ec2Calls = require('../../../lib/aws/ec2-calls');
-const cloudfFormationCalls = require('../../../lib/aws/cloudformation-calls');
 const ServiceContext = require('../../../lib/datatypes/service-context');
 const DeployContext = require('../../../lib/datatypes/deploy-context');
 const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
@@ -119,9 +118,8 @@ describe('efs deployer', function () {
         let dependenciesDeployContexts = [];
         let fileSystemId = "FakeFileSystemId";
 
-        it('should create the file system if it doesnt exist', function () {
-            let getStackStub = sandbox.stub(cloudfFormationCalls, 'getStack').returns(Promise.resolve(null));
-            let createStackStub = sandbox.stub(cloudfFormationCalls, 'createStack').returns(Promise.resolve({
+        it('should deploy the file system', function () {
+            let deployStackStub = sandbox.stub(deployersCommon, 'deployCloudFormationStack').returns(Promise.resolve({
                 Outputs: [{
                     OutputKey: "EFSFileSystemId",
                     OutputValue: fileSystemId
@@ -130,31 +128,7 @@ describe('efs deployer', function () {
 
             return efs.deploy(ownServiceContext, ownPreDeployContext, dependenciesDeployContexts)
                 .then(deployContext => {
-                    expect(getStackStub.calledOnce).to.be.true;
-                    expect(createStackStub.calledOnce).to.be.true;
-                    expect(deployContext).to.be.instanceof(DeployContext);
-                    expect(deployContext.scripts.length).to.equal(1);
-                });
-        });
-
-        it('should not update the file system if it already exists', function () {
-            let getStackStub = sandbox.stub(cloudfFormationCalls, 'getStack').returns(Promise.resolve({
-                Outputs: [{
-                    OutputKey: "EFSFileSystemId",
-                    OutputValue: fileSystemId
-                }]
-            }));
-            let createStackStub = sandbox.stub(cloudfFormationCalls, 'createStack').returns(Promise.resolve({
-                Outputs: [{
-                    OutputKey: "EFSFileSystemId",
-                    OutputValue: fileSystemId
-                }]
-            }));
-
-            return efs.deploy(ownServiceContext, ownPreDeployContext, dependenciesDeployContexts)
-                .then(deployContext => {
-                    expect(getStackStub.calledOnce).to.be.true;
-                    expect(createStackStub.notCalled).to.be.true;
+                    expect(deployStackStub.calledOnce).to.be.true;
                     expect(deployContext).to.be.instanceof(DeployContext);
                     expect(deployContext.scripts.length).to.equal(1);
                 });

--- a/test/services/lambda/lambda-test.js
+++ b/test/services/lambda/lambda-test.js
@@ -137,15 +137,14 @@ describe('lambda deployer', function () {
         }
 
 
-        it('should create the service when it doesnt already exist', function () {
+        it('should deploy the lambda', function () {
             let uploadArtifactStub = sandbox.stub(deployersCommon, 'uploadDeployableArtifactToHandelBucket').returns(Promise.resolve({
                 Key: "FakeKey",
                 Bucket: "FakeBucket"
             }));
-            let getStackStub = sandbox.stub(cloudFormationCalls, 'getStack').returns(Promise.resolve(null));
             let functionArn = "FakeFunctionArn";
             let functionName = "FakeFunction";
-            let createStackStub = sandbox.stub(cloudFormationCalls, 'createStack').returns(Promise.resolve({
+            let deployStackStub = sandbox.stub(deployersCommon, 'deployCloudFormationStack').returns(Promise.resolve({
                 Outputs: [
                     {
                         OutputKey: 'FunctionArn',
@@ -168,44 +167,7 @@ describe('lambda deployer', function () {
                     expect(deployContext.eventOutputs.lambdaArn).to.equal(functionArn);
                     expect(deployContext.eventOutputs.lambdaName).to.equal(functionName);
                     expect(uploadArtifactStub.calledOnce).to.be.true;
-                    expect(getStackStub.calledOnce).to.be.true;
-                    expect(createStackStub.calledOnce).to.be.true;
-                });
-        });
-
-        it('should update the service when it already exists', function () {
-            let uploadArtifactStub = sandbox.stub(deployersCommon, 'uploadDeployableArtifactToHandelBucket').returns(Promise.resolve({
-                Key: "FakeKey",
-                Bucket: "FakeBucket"
-            }));
-            let getStackStub = sandbox.stub(cloudFormationCalls, 'getStack').returns(Promise.resolve({}));
-            let functionArn = "FakeFunctionArn";
-            let functionName = "FakeFunction";
-            let updateStackStub = sandbox.stub(cloudFormationCalls, 'updateStack').returns(Promise.resolve({
-                Outputs: [
-                    {
-                        OutputKey: 'FunctionArn',
-                        OutputValue: functionArn,
-                    },
-                    {
-                        OutputKey: 'FunctionName',
-                        OutputValue: functionName
-                    }
-                ]
-            }));
-
-            let ownServiceContext = getServiceContext();
-            let ownPreDeployContext = getPreDeployContext(ownServiceContext);
-            let dependenciesDeployContexts = getDependenciesDeployContexts();
-
-            return lambda.deploy(ownServiceContext, ownPreDeployContext, dependenciesDeployContexts)
-                .then(deployContext => {
-                    expect(deployContext).to.be.instanceof(DeployContext);
-                    expect(deployContext.eventOutputs.lambdaArn).to.equal(functionArn);
-                    expect(deployContext.eventOutputs.lambdaName).to.equal(functionName);
-                    expect(uploadArtifactStub.calledOnce).to.be.true;
-                    expect(getStackStub.calledOnce).to.be.true;
-                    expect(updateStackStub.calledOnce).to.be.true;
+                    expect(deployStackStub.calledOnce).to.be.true;
                 });
         });
     });

--- a/test/services/postgresql/postgresql-test.js
+++ b/test/services/postgresql/postgresql-test.js
@@ -17,7 +17,6 @@
 const accountConfig = require('../../../lib/common/account-config')(`${__dirname}/../../test-account-config.yml`).getAccountConfig();
 const postgresql = require('../../../lib/services/postgresql');
 const ec2Calls = require('../../../lib/aws/ec2-calls');
-const ssmCalls = require('../../../lib/aws/ssm-calls');
 const cloudFormationCalls = require('../../../lib/aws/cloudformation-calls');
 const ServiceContext = require('../../../lib/datatypes/service-context');
 const DeployContext = require('../../../lib/datatypes/deploy-context');


### PR DESCRIPTION
I got rid of stack traces unless you're in debug mode. I also made
it so failed CloudFormation changes grabs the errors from the stack
so you don't have to go looking for it yourself.

Resolves #155 