### PR TITLE
Various Refactors

### DIFF
--- a/lib/common/delete-phases-common.js
+++ b/lib/common/delete-phases-common.js
@@ -1,0 +1,46 @@
+const accountConfig = require('../common/account-config')().getAccountConfig();
+const ec2Calls = require('../aws/ec2-calls');
+const cloudformationCalls = require('../aws/cloudformation-calls');
+const winston = require('winston');
+const UnDeployContext = require('../datatypes/un-deploy-context');
+const deployPhaseCommon = require('./deploy-phase-common');
+
+exports.unBindAllOnSg = function (stackName) {
+    let sgName = `${stackName}-sg`;
+    return ec2Calls.removeAllIngressFromSg(sgName, accountConfig.vpc)
+        .then(() => {
+            return true;
+        });
+}
+
+exports.deleteSecurityGroupForService = function (stackName) {
+    let sgName = `${stackName}-sg`;
+    return cloudformationCalls.getStack(sgName)
+        .then(stack => {
+            if (stack) {
+                return cloudformationCalls.deleteStack(sgName)
+            }
+            else {
+                return true;
+            }
+        });
+}
+
+exports.unDeployCloudFormationStack = function (serviceContext, serviceType) {
+    let stackName = deployPhaseCommon.getResourceName(serviceContext);
+    winston.info(`${serviceType} - Executing UnDeploy on '${stackName}'`)
+
+    return cloudformationCalls.getStack(stackName)
+        .then(stack => {
+            if (stack) {
+                winston.info(`${serviceType} - Deleting stack '${stackName}'`);
+                return cloudformationCalls.deleteStack(stackName);
+            }
+            else {
+                winston.info(`${serviceType} - Stack '${stackName}' has already been deleted`);
+            }
+        })
+        .then(() => {
+            return new UnDeployContext(serviceContext);
+        });
+}

--- a/lib/common/deploy-phase-common.js
+++ b/lib/common/deploy-phase-common.js
@@ -16,14 +16,11 @@
  */
 const iamCalls = require('../aws/iam-calls');
 const s3Calls = require('../aws/s3-calls');
-const ec2Calls = require('../aws/ec2-calls');
 const cloudformationCalls = require('../aws/cloudformation-calls');
-const UnDeployContext = require('../datatypes/un-deploy-context');
 const winston = require('winston');
 const accountConfig = require('../common/account-config')().getAccountConfig();
 const fs = require('fs');
 const util = require('../common/util');
-const handlebarsUtils = require('../common/handlebars-utils');
 const os = require('os');
 
 /**
@@ -112,65 +109,15 @@ exports.getAllPolicyStatementsForServiceRole = function (ownServicePolicyStateme
     return policyStatementsToConsume;
 }
 
-exports.createSecurityGroupForService = function (stackName, sshBastionIngressPort) {
-    let sgName = `${stackName}-sg`;
-    let handlebarsParams = {
-        groupName: sgName,
-        vpcId: accountConfig.vpc
-    }
-    if (sshBastionIngressPort) {
-        handlebarsParams.sshBastionSg = accountConfig.ssh_bastion_sg;
-        handlebarsParams.sshBastionIngressPort = sshBastionIngressPort;
-    }
-
-    return handlebarsUtils.compileTemplate(`${__dirname}/ec2-sg-template.yml`, handlebarsParams)
-        .then(compiledTemplate => {
-            return cloudformationCalls.getStack(sgName)
-                .then(stack => {
-                    if (!stack) {
-                        return cloudformationCalls.createStack(sgName, compiledTemplate, []);
-                    }
-                    else {
-                        return cloudformationCalls.updateStack(sgName, compiledTemplate, []);
-                    }
-                });
-        })
-        .then(deployedStack => {
-            let groupId = cloudformationCalls.getOutput('GroupId', deployedStack)
-            return ec2Calls.getSecurityGroupById(groupId, accountConfig.vpc);
-        });
-}
-
-exports.unBindAllOnSg = function (stackName) {
-    let sgName = `${stackName}-sg`;
-    return ec2Calls.removeAllIngressFromSg(sgName, accountConfig.vpc)
-        .then(() => {
-            return true;
-        });
-}
-
-exports.deleteSecurityGroupForService = function (stackName) {
-    let sgName = `${stackName}-sg`;
-    return cloudformationCalls.getStack(sgName)
-        .then(stack => {
-            if (stack) {
-                return cloudformationCalls.deleteStack(sgName)
-            }
-            else {
-                return true;
-            }
-        });
-}
-
-exports.deployCloudFormationStack = function(stackName, cfTemplate, cfParameters, updatesSupported, serviceType) {
+exports.deployCloudFormationStack = function (stackName, cfTemplate, cfParameters, updatesSupported, serviceType) {
     return cloudformationCalls.getStack(stackName)
         .then(stack => {
-            if(!stack) {
+            if (!stack) {
                 winston.info(`${serviceType} - Creating stack '${stackName}'`);
                 return cloudformationCalls.createStack(stackName, cfTemplate, cfParameters);
             }
             else {
-                if(updatesSupported) {
+                if (updatesSupported) {
                     winston.info(`${serviceType} - Updates stack '${stackName}'`);
                     return cloudformationCalls.updateStack(stackName, cfTemplate, cfParameters);
                 }
@@ -180,63 +127,6 @@ exports.deployCloudFormationStack = function(stackName, cfTemplate, cfParameters
                 }
             }
         })
-}
-
-exports.unDeployCloudFormationStack = function (serviceContext, serviceType) {
-    let stackName = exports.getResourceName(serviceContext);
-    winston.info(`${serviceType} - Executing UnDeploy on '${stackName}'`)
-
-    return cloudformationCalls.getStack(stackName)
-        .then(stack => {
-            if (stack) {
-                winston.info(`${serviceType} - Deleting stack '${stackName}'`);
-                return cloudformationCalls.deleteStack(stackName);
-            }
-            else {
-                winston.info(`${serviceType} - Stack '${stackName}' has already been deleted`);
-            }
-        })
-        .then(() => {
-            return new UnDeployContext(serviceContext);
-        });
-}
-
-exports.checkRoutingElement = function (serviceContext) {
-    let errors = [];
-    let serviceParams = serviceContext.params;
-    if (serviceParams.routing) {
-        if (!serviceParams.routing.type) {
-            errors.push(`${serviceContext.serviceType} - The 'type' field is required in the 'routing' section`);
-        }
-        else {
-            if (serviceParams.routing.type === 'https' && !serviceParams.routing.https_certificate) {
-                errors.push(`${serviceContext.serviceType} - The 'https_certificate' element is required when you are using 'https' as the routing type`);
-            }
-        }
-    }
-    return errors;
-}
-
-exports.getRoutingInformationForService = function (serviceContext) {
-    let serviceParams = serviceContext.params;
-    if (serviceParams.routing) {
-        let routingInfo = {
-            type: serviceParams.routing.type,
-            timeout: 60,
-            healthCheckPath: '/'
-        };
-        if (serviceParams.routing.timeout) {
-            routingInfo.timeout = serviceParams.routing.timeout;
-        }
-        if (serviceParams.routing.health_check_path) {
-            routingInfo.healthCheckPath = serviceParams.routing.health_check_path;
-        }
-        if (routingInfo.type === 'https') {
-            routingInfo.httpsCertificate = `arn:aws:acm:us-west-2:${accountConfig.account_id}:certificate/${serviceParams.routing.https_certificate}`;
-        }
-        return routingInfo;
-    }
-    return null; //No routing specified
 }
 
 exports.uploadFileToHandelBucket = function (serviceContext, diskFilePath, s3FileName) {

--- a/lib/common/pre-deploy-phase-common.js
+++ b/lib/common/pre-deploy-phase-common.js
@@ -1,0 +1,33 @@
+const handlebarsUtils = require('../common/handlebars-utils');
+const cloudformationCalls = require('../aws/cloudformation-calls');
+const accountConfig = require('../common/account-config')().getAccountConfig();
+const ec2Calls = require('../aws/ec2-calls');
+
+exports.createSecurityGroupForService = function (stackName, sshBastionIngressPort) {
+    let sgName = `${stackName}-sg`;
+    let handlebarsParams = {
+        groupName: sgName,
+        vpcId: accountConfig.vpc
+    }
+    if (sshBastionIngressPort) {
+        handlebarsParams.sshBastionSg = accountConfig.ssh_bastion_sg;
+        handlebarsParams.sshBastionIngressPort = sshBastionIngressPort;
+    }
+
+    return handlebarsUtils.compileTemplate(`${__dirname}/ec2-sg-template.yml`, handlebarsParams)
+        .then(compiledTemplate => {
+            return cloudformationCalls.getStack(sgName)
+                .then(stack => {
+                    if (!stack) {
+                        return cloudformationCalls.createStack(sgName, compiledTemplate, []);
+                    }
+                    else {
+                        return cloudformationCalls.updateStack(sgName, compiledTemplate, []);
+                    }
+                });
+        })
+        .then(deployedStack => {
+            let groupId = cloudformationCalls.getOutput('GroupId', deployedStack)
+            return ec2Calls.getSecurityGroupById(groupId, accountConfig.vpc);
+        });
+}

--- a/lib/common/rds-common.js
+++ b/lib/common/rds-common.js
@@ -1,5 +1,5 @@
 const cloudFormationCalls = require('../aws/cloudformation-calls');
-const deployersCommon = require('../common/deployers-common');
+const deployPhaseCommon = require('../common/deploy-phase-common');
 const DeployContext = require('../datatypes/deploy-context');
 const ssmCalls = require('../aws/ssm-calls');
 
@@ -7,16 +7,16 @@ exports.getDeployContext = function (serviceContext, rdsCfStack) {
     let deployContext = new DeployContext(serviceContext);
 
     //Inject ENV variables to talk to this database
-    let portEnv = deployersCommon.getInjectedEnvVarName(serviceContext, 'ADDRESS');
+    let portEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'ADDRESS');
     let port = cloudFormationCalls.getOutput('DatabaseAddress', rdsCfStack);
     deployContext.environmentVariables[portEnv] = port;
-    let addressEnv = deployersCommon.getInjectedEnvVarName(serviceContext, 'PORT');
+    let addressEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'PORT');
     let address = cloudFormationCalls.getOutput('DatabasePort', rdsCfStack);
     deployContext.environmentVariables[addressEnv] = address;
-    let usernameEnv = deployersCommon.getInjectedEnvVarName(serviceContext, 'USERNAME');
+    let usernameEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'USERNAME');
     let username = cloudFormationCalls.getOutput('DatabaseUsername', rdsCfStack);
     deployContext.environmentVariables[usernameEnv] = username;
-    let dbNameEnv = deployersCommon.getInjectedEnvVarName(serviceContext, 'DATABASE_NAME');
+    let dbNameEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'DATABASE_NAME');
     let dbName = cloudFormationCalls.getOutput('DatabaseName', rdsCfStack);
     deployContext.environmentVariables[dbNameEnv] = dbName;
 
@@ -25,7 +25,7 @@ exports.getDeployContext = function (serviceContext, rdsCfStack) {
 
 exports.addDbCredentialToParameterStore = function (ownServiceContext, dbPassword, deployedStack) {
     //Add credential to EC2 Parameter Store
-    let credentialParamName = deployersCommon.getSsmParamName(ownServiceContext, "db_password");
+    let credentialParamName = deployPhaseCommon.getSsmParamName(ownServiceContext, "db_password");
     return ssmCalls.storeParameter(credentialParamName, 'SecureString', dbPassword)
         .then(() => {
             return deployedStack;
@@ -34,7 +34,7 @@ exports.addDbCredentialToParameterStore = function (ownServiceContext, dbPasswor
 
 exports.deleteParametersFromParameterStore = function (ownServiceContext, unDeployContext) {
     let paramsToDelete = [
-        deployersCommon.getSsmParamName(ownServiceContext, "db_password")
+        deployPhaseCommon.getSsmParamName(ownServiceContext, "db_password")
     ]
     return ssmCalls.deleteParameters(paramsToDelete)
         .then(() => {

--- a/lib/services/apiaccess/index.js
+++ b/lib/services/apiaccess/index.js
@@ -19,11 +19,13 @@ const PreDeployContext = require('../../datatypes/pre-deploy-context');
 const BindContext = require('../../datatypes/bind-context');
 const DeployContext = require('../../datatypes/deploy-context');
 const fs = require('fs');
-const deployersCommon = require('../../common/deployers-common');
+const deployPhaseCommon = require('../../common/deploy-phase-common');
 const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../datatypes/un-bind-context');
 const UnDeployContext = require('../../datatypes/un-deploy-context');
 const util = require('../../common/util');
+
+const SERVICE_NAME = "API Access";
 
 function getDeployContext(serviceContext) {
     let serviceParams = serviceContext.params;
@@ -53,13 +55,13 @@ exports.check = function (serviceContext) {
 
     let serviceParams = serviceContext.params;
     if (!serviceParams.aws_services) {
-        errors.push("API Access - The 'aws_services' parameter is required.");
+        errors.push(`${SERVICE_NAME} - The 'aws_services' parameter is required.`);
     }
     else {
         for (let service of serviceParams.aws_services) {
             let statementsPath = `${__dirname}/${service}-statements.json`;
             if (!fs.existsSync(statementsPath)) {
-                errors.push(`API Access - The 'aws_service' value '${service}' is not supported`);
+                errors.push(`${SERVICE_NAME} - The 'aws_service' value '${service}' is not supported`);
             }
         }
     }
@@ -69,45 +71,45 @@ exports.check = function (serviceContext) {
 
 
 exports.preDeploy = function (serviceContext) {
-    winston.info(`API Access - PreDeploy is not required for this service, skipping it`);
+    winston.info(`${SERVICE_NAME} - PreDeploy is not required for this service, skipping it`);
     return Promise.resolve(new PreDeployContext(serviceContext));
 }
 
 
 exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    winston.info(`API Access - Bind is not required for this service, skipping it`);
+    winston.info(`${SERVICE_NAME} - Bind is not required for this service, skipping it`);
     return Promise.resolve(new BindContext(ownServiceContext, dependentOfServiceContext));
 }
 
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
-    let stackName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`API Access - Deploying api access ${stackName}`);
+    let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Deploying ${SERVICE_NAME} '${stackName}'`);
 
     return Promise.resolve(getDeployContext(ownServiceContext))
 }
 
 exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerServiceContext, producerDeployContext) {
-    return Promise.reject(new Error("The API Access service doesn't consume events from other services"));
+    return Promise.reject(new Error(`The ${SERVICE_NAME} service doesn't consume events from other services`));
 }
 
 
 exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext) {
-    return Promise.reject(new Error("The API Access service doesn't currently produce events for other services"));
+    return Promise.reject(new Error(`The ${SERVICE_NAME} service doesn't currently produce events for other services`));
 }
 
 exports.unPreDeploy = function (ownServiceContext) {
-    winston.info(`API Access - UnPreDeploy is not required for this service`);
+    winston.info(`${SERVICE_NAME} - UnPreDeploy is not required for this service`);
     return Promise.resolve(new UnPreDeployContext(ownServiceContext));
 }
 
 exports.unBind = function (ownServiceContext) {
-    winston.info(`API Access - UnBind is not required for this service`);
+    winston.info(`${SERVICE_NAME} - UnBind is not required for this service`);
     return Promise.resolve(new UnBindContext(ownServiceContext));
 }
 
 exports.unDeploy = function (ownServiceContext) {
-    winston.info(`API Access - Nothing to delete for this service`);
+    winston.info(`${SERVICE_NAME} - Nothing to delete for this service`);
     return Promise.resolve(new UnDeployContext(ownServiceContext));
 }
 

--- a/lib/services/apigateway/index.js
+++ b/lib/services/apigateway/index.js
@@ -22,28 +22,30 @@ const UnBindContext = require('../../datatypes/un-bind-context');
 const cloudformationCalls = require('../../aws/cloudformation-calls');
 const util = require('../../common/util');
 const handlebarsUtils = require('../../common/handlebars-utils');
-const deployersCommon = require('../../common/deployers-common');
+const deployPhaseCommon = require('../../common/deploy-phase-common');
+const deletePhasesCommon = require('../../common/delete-phases-common');
 const uuid = require('uuid');
 const accountConfig = require('../../common/account-config')().getAccountConfig();
 const winston = require('winston');
 const _ = require('lodash');
 
+const SERVICE_NAME = "API Gateway";
 
 function uploadDeployableArtifactToS3(serviceContext) {
     let s3FileName = `apigateway-deployable-${uuid()}.zip`;
-    winston.info(`API Gateway - Uploading deployable artifact to S3: ${s3FileName}`);
-    return deployersCommon.uploadDeployableArtifactToHandelBucket(serviceContext, s3FileName)
+    winston.info(`${SERVICE_NAME} - Uploading deployable artifact to S3: ${s3FileName}`);
+    return deployPhaseCommon.uploadDeployableArtifactToHandelBucket(serviceContext, s3FileName)
         .then(s3ArtifactInfo => {
-            winston.info(`API Gateway - Uploaded deployable artifact to S3: ${s3FileName}`);
+            winston.info(`${SERVICE_NAME} - Uploaded deployable artifact to S3: ${s3FileName}`);
             return s3ArtifactInfo;
         });
 }
 
 function getPolicyStatementsForLambdaRole(serviceContext, dependenciesDeployContexts) {
     let ownPolicyStatements = JSON.parse(util.readFileSync(`${__dirname}/lambda-role-statements.json`));
-    ownPolicyStatements = ownPolicyStatements.concat(deployersCommon.getAppSecretsAccessPolicyStatements(serviceContext));
+    ownPolicyStatements = ownPolicyStatements.concat(deployPhaseCommon.getAppSecretsAccessPolicyStatements(serviceContext));
 
-    return deployersCommon.getAllPolicyStatementsForServiceRole(ownPolicyStatements, dependenciesDeployContexts);
+    return deployPhaseCommon.getAllPolicyStatementsForServiceRole(ownPolicyStatements, dependenciesDeployContexts);
 }
 
 function getEnvVarsForService(serviceContext, dependenciesDeployContexts) {
@@ -52,9 +54,9 @@ function getEnvVarsForService(serviceContext, dependenciesDeployContexts) {
     if (serviceContext.params.environment_variables) {
         returnEnvVars = _.assign(returnEnvVars, serviceContext.params.environment_variables);
     }
-    let dependenciesEnvVars = deployersCommon.getEnvVarsFromDependencyDeployContexts(dependenciesDeployContexts);
+    let dependenciesEnvVars = deployPhaseCommon.getEnvVarsFromDependencyDeployContexts(dependenciesDeployContexts);
     returnEnvVars = _.assign(returnEnvVars, dependenciesEnvVars);
-    let handelInjectedEnvVars = deployersCommon.getEnvVarsFromServiceContext(serviceContext);
+    let handelInjectedEnvVars = deployPhaseCommon.getEnvVarsFromServiceContext(serviceContext);
     returnEnvVars = _.assign(returnEnvVars, handelInjectedEnvVars);
 
     return returnEnvVars;
@@ -115,67 +117,67 @@ exports.check = function (serviceContext) {
 
     let params = serviceContext.params;
     if (!params.path_to_code) {
-        checkErrors.push("API Gateway - 'path_to_code' parameter is required");
+        checkErrors.push(`${SERVICE_NAME} - 'path_to_code' parameter is required`);
     }
     if (!params.lambda_runtime) {
-        checkErrors.push("API Gateway - 'lambda_runtime' parameter is required");
+        checkErrors.push(`${SERVICE_NAME} - 'lambda_runtime' parameter is required`);
     }
     if (!params.handler_function) {
-        checkErrors.push("API Gateway - 'handler_function' parameter is required");
+        checkErrors.push(`${SERVICE_NAME} - 'handler_function' parameter is required`);
     }
 
     return checkErrors;
 }
 
 exports.preDeploy = function (serviceContext) {
-    winston.info(`API Gateway - PreDeploy not currently required for this service, skipping it`);
+    winston.info(`${SERVICE_NAME} - PreDeploy not currently required for this service, skipping it`);
     //TODO - Once VPC support is enabled, create a security group for the Lambda
     return Promise.resolve(new PreDeployContext(serviceContext));
 }
 
 exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    winston.info(`API Gateway - Bind not currently required for this service, skipping it`);
+    winston.info(`${SERVICE_NAME} - Bind not currently required for this service, skipping it`);
     return Promise.resolve(new BindContext(ownServiceContext, dependentOfServiceContext));
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
-    let stackName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`API Gateway - Deploying service ${stackName}`);
+    let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Deploying service ${stackName}`);
 
     return uploadDeployableArtifactToS3(ownServiceContext)
         .then(s3ObjectInfo => {
             return getCompiledApiGatewayTemplate(stackName, ownServiceContext, dependenciesDeployContexts, s3ObjectInfo);
         })
         .then(compiledTemplate => {
-            return deployersCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, "API Gateway");
+            return deployPhaseCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, SERVICE_NAME);
         })
         .then(deployedStack => {
             let restApiUrl = getRestApiUrl(deployedStack, ownServiceContext);
-            winston.info(`API Gateway - Deployed service is available at ${restApiUrl}`);
+            winston.info(`${SERVICE_NAME} - Deployed service is available at ${restApiUrl}`);
             return getDeployContext(ownServiceContext);
         });
 }
 
 exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerServiceContext, producerDeployContext) {
-    return Promise.reject(new Error("The API Gateway service doesn't consume events from other services"));
+    return Promise.reject(new Error(`The ${SERVICE_NAME} service doesn't consume events from other services`));
 }
 
 exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext) {
-    return Promise.reject(new Error("The API Gateway service doesn't produce events for other services"));
+    return Promise.reject(new Error(`The ${SERVICE_NAME} service doesn't produce events for other services`));
 }
 
 exports.unPreDeploy = function (ownServiceContext) {
-    winston.info(`API Gateway - UnPreDeploy is not required for this service`);
+    winston.info(`${SERVICE_NAME} - UnPreDeploy is not required for this service`);
     return Promise.resolve(new UnPreDeployContext(ownServiceContext));
 }
 
 exports.unBind = function (ownServiceContext) {
-    winston.info(`API Gateway - UnBind is not required for this service`);
+    winston.info(`${SERVICE_NAME} - UnBind is not required for this service`);
     return Promise.resolve(new UnBindContext(ownServiceContext));
 }
 
 exports.unDeploy = function (ownServiceContext) {
-    return deployersCommon.unDeployCloudFormationStack(ownServiceContext, 'API Gateway');
+    return deletePhasesCommon.unDeployCloudFormationStack(ownServiceContext, SERVICE_NAME);
 }
 
 exports.producedEventsSupportedServices = [];

--- a/lib/services/beanstalk/deployable-artifact.js
+++ b/lib/services/beanstalk/deployable-artifact.js
@@ -4,7 +4,7 @@ const winston = require('winston');
 const uuid = require('uuid');
 const util = require('../../common/util');
 const os = require('os');
-const deployersCommon = require('../../common/deployers-common');
+const deployPhaseCommon = require('../../common/deploy-phase-common');
 const path = require('path');
 
 
@@ -25,7 +25,7 @@ function makeTmpDir() {
 function uploadDeployableArtifactToS3(serviceContext, fileToUpload, fileExtension) {
     let s3FileName = `beanstalk-deployable-${uuid()}.${fileExtension}`;
     winston.info(`Uploading deployable artifact to S3: ${s3FileName}`);
-    return deployersCommon.uploadFileToHandelBucket(serviceContext, fileToUpload, s3FileName)
+    return deployPhaseCommon.uploadFileToHandelBucket(serviceContext, fileToUpload, s3FileName)
         .then(s3ObjectInfo => {
             winston.info(`Uploaded deployable artifact to S3: ${s3FileName}`);
             return s3ObjectInfo;

--- a/lib/services/beanstalk/index.js
+++ b/lib/services/beanstalk/index.js
@@ -20,13 +20,16 @@ const PreDeployContext = require('../../datatypes/pre-deploy-context');
 const BindContext = require('../../datatypes/bind-context');
 const DeployContext = require('../../datatypes/deploy-context');
 const accountConfig = require('../../common/account-config')().getAccountConfig();
-const cloudFormationCalls = require('../../aws/cloudformation-calls');
-const deployersCommon = require('../../common/deployers-common');
+const deployPhaseCommon = require('../../common/deploy-phase-common');
+const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
+const deletePhasesCommon = require('../../common/delete-phases-common');
 const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../datatypes/un-bind-context');
 const deployableArtifact = require('./deployable-artifact');
 const util = require('../../common/util');
 const _ = require('lodash');
+
+const SERVICE_NAME = "Beanstalk";
 
 function getEbConfigurationOption(namespace, optionName, value) {
     return {
@@ -38,8 +41,8 @@ function getEbConfigurationOption(namespace, optionName, value) {
 
 function getEnvVariablesToInject(serviceContext, dependenciesDeployContexts) {
     let serviceParams = serviceContext.params;
-    let envVarsToInject = deployersCommon.getEnvVarsFromDependencyDeployContexts(dependenciesDeployContexts);
-    envVarsToInject = _.assign(envVarsToInject, deployersCommon.getEnvVarsFromServiceContext(serviceContext));
+    let envVarsToInject = deployPhaseCommon.getEnvVarsFromDependencyDeployContexts(dependenciesDeployContexts);
+    envVarsToInject = _.assign(envVarsToInject, deployPhaseCommon.getEnvVarsFromServiceContext(serviceContext));
 
     if (serviceParams.environment_variables) {
         envVarsToInject = _.assign(envVarsToInject, serviceParams.environment_variables);
@@ -167,10 +170,10 @@ function getPolicyStatementsForInstanceRole(serviceContext, dependenciesDeployCo
             return JSON.parse(compiledPolicyStatements);
         })
         .then(ownPolicyStatements => {
-            return ownPolicyStatements.concat(deployersCommon.getAppSecretsAccessPolicyStatements(serviceContext));
+            return ownPolicyStatements.concat(deployPhaseCommon.getAppSecretsAccessPolicyStatements(serviceContext));
         })
         .then(ownPolicyStatements => {
-            return deployersCommon.getAllPolicyStatementsForServiceRole(ownPolicyStatements, dependenciesDeployContexts);
+            return deployPhaseCommon.getAllPolicyStatementsForServiceRole(ownPolicyStatements, dependenciesDeployContexts);
         });
 }
 
@@ -192,12 +195,12 @@ exports.check = function (serviceContext) {
 }
 
 exports.preDeploy = function (serviceContext) {
-    let sgName = deployersCommon.getResourceName(serviceContext);
-    winston.info(`Beanstalk - Executing PreDeploy on ${sgName}`);
+    let sgName = deployPhaseCommon.getResourceName(serviceContext);
+    winston.info(`${SERVICE_NAME} - Executing PreDeploy on ${sgName}`);
 
-    return deployersCommon.createSecurityGroupForService(sgName, 22)
+    return preDeployPhaseCommon.createSecurityGroupForService(sgName, 22)
         .then(securityGroup => {
-            winston.info(`Beanstalk - Finished PreDeploy on ${sgName}`);
+            winston.info(`${SERVICE_NAME} - Finished PreDeploy on ${sgName}`);
             let preDeployContext = new PreDeployContext(serviceContext);
             preDeployContext.securityGroups.push(securityGroup);
             return preDeployContext;
@@ -205,15 +208,15 @@ exports.preDeploy = function (serviceContext) {
 }
 
 exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    winston.info(`Beanstalk - Bind is not required for this service, skipping it`);
+    winston.info(`${SERVICE_NAME} - Bind is not required for this service, skipping it`);
     return Promise.resolve(new BindContext(ownServiceContext, dependentOfServiceContext));
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
-    let stackName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`Beanstalk - Executing Deploy on ${stackName}`);
+    let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Executing Deploy on ${stackName}`);
 
-    return deployersCommon.createCustomRole('elasticbeanstalk.amazonaws.com', 'HandelBeanstalkServiceRole', getPolicyStatementsForServiceRole())
+    return deployPhaseCommon.createCustomRole('elasticbeanstalk.amazonaws.com', 'HandelBeanstalkServiceRole', getPolicyStatementsForServiceRole())
         .then(serviceRole => {
             return getEbExtensionScript(dependenciesDeployContexts)
                 .then(ebextensionContent => {
@@ -227,40 +230,40 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
                 });
         })
         .then(compiledBeanstalkTemplate => {
-            return deployersCommon.deployCloudFormationStack(stackName, compiledBeanstalkTemplate, [], true, "Beanstalk");
+            return deployPhaseCommon.deployCloudFormationStack(stackName, compiledBeanstalkTemplate, [], true, SERVICE_NAME);
         })
         .then(deployedStack => {
-            winston.info(`Beanstalk - Finished deploying Beanstalk app ${stackName}`);
+            winston.info(`${SERVICE_NAME} - Finished deploying '${stackName}'`);
             return getDeployContext(ownServiceContext, deployedStack);
         });
 }
 
 exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerServiceContext, producerDeployContext) {
-    return Promise.reject(new Error("The Beanstalk service doesn't consume events from other services"));
+    return Promise.reject(new Error(`The ${SERVICE_NAME} service doesn't consume events from other services`));
 }
 
 exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext) {
-    return Promise.reject(new Error("The Beanstalk service doesn't produce events for other services"));
+    return Promise.reject(new Error(`The ${SERVICE_NAME} service doesn't produce events for other services`));
 }
 
 exports.unPreDeploy = function (ownServiceContext) {
-    let sgName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`Beanstalk - Executing UnPreDeploy on ${sgName}`);
+    let sgName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Executing UnPreDeploy on ${sgName}`);
 
-    return deployersCommon.deleteSecurityGroupForService(sgName)
+    return deletePhasesCommon.deleteSecurityGroupForService(sgName)
         .then(success => {
-            winston.info(`Beanstalk - Finished UnPreDeploy on ${sgName}`);
+            winston.info(`${SERVICE_NAME} - Finished UnPreDeploy on ${sgName}`);
             return new UnPreDeployContext(ownServiceContext);
         });
 }
 
 exports.unBind = function (ownServiceContext) {
-    winston.info(`Beanstalk - UnBind is not required for this service`);
+    winston.info(`${SERVICE_NAME} - UnBind is not required for this service`);
     return Promise.resolve(new UnBindContext(ownServiceContext));
 }
 
 exports.unDeploy = function (ownServiceContext) {
-    return deployersCommon.unDeployCloudFormationStack(ownServiceContext, 'Beanstalk');
+    return deletePhasesCommon.unDeployCloudFormationStack(ownServiceContext, SERVICE_NAME);
 }
 
 exports.producedEventsSupportedServices = [];

--- a/lib/services/cloudwatchevent/index.js
+++ b/lib/services/cloudwatchevent/index.js
@@ -24,9 +24,12 @@ const UnBindContext = require('../../datatypes/un-bind-context');
 const ProduceEventsContext = require('../../datatypes/produce-events-context');
 const cloudWatchEventsCalls = require('../../aws/cloudwatch-events-calls');
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
-const deployersCommon = require('../../common/deployers-common');
+const deployPhaseCommon = require('../../common/deploy-phase-common');
+const deletePhasesCommon = require('../../common/delete-phases-common');
 const handlebarsUtils = require('../../common/handlebars-utils');
 const yaml = require('js-yaml');
+
+const SERVICE_NAME = "CloudWatch Events";
 
 function getDeployContext(serviceContext, deployedStack) {
     let deployContext = new DeployContext(serviceContext);
@@ -76,104 +79,95 @@ exports.check = function (serviceContext) {
 
     //Require 'schedule' or 'event_pattern'
     if (!serviceParams.schedule && !serviceParams.event_pattern) {
-        errors.push(`CloudWatch Events - You must specify at least one of the 'schedule' or 'event_pattern' parameters`);
+        errors.push(`${SERVICE_NAME} - You must specify at least one of the 'schedule' or 'event_pattern' parameters`);
     }
 
     return errors;
 }
 
 exports.preDeploy = function (serviceContext) {
-    winston.info(`CloudWatch Events - PreDeploy is not required for this service, skipping it`);
+    winston.info(`${SERVICE_NAME} - PreDeploy is not required for this service, skipping it`);
     return Promise.resolve(new PreDeployContext(serviceContext));
 }
 
 exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    winston.info(`CloudWatch Events - Bind is not required for this service, skipping it`);
+    winston.info(`${SERVICE_NAME} - Bind is not required for this service, skipping it`);
     return Promise.resolve(new BindContext(ownServiceContext, dependentOfServiceContext));
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
-    let stackName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`CloudWatch Events - Deploying CloudWatch Events Rule ${stackName}`);
+    let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Deploying event rule ${stackName}`);
 
     return getCompiledEventRuleTemplate(stackName, ownServiceContext)
         .then(eventRuleTemplate => {
-            return deployersCommon.deployCloudFormationStack(stackName, eventRuleTemplate, [], true, "CloudWatch Events");
+            return deployPhaseCommon.deployCloudFormationStack(stackName, eventRuleTemplate, [], true, SERVICE_NAME);
         })
         .then(deployedStack => {
-            winston.info(`CloudWatchEvents - Finished deploying CloudWatch Events Rule ${stackName}`);
+            winston.info(`${SERVICE_NAME} - Finished deploying event rule ${stackName}`);
             return getDeployContext(ownServiceContext, deployedStack);
         });
 }
 
 exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerServiceContext, producerDeployContext) {
-    return Promise.reject(new Error("The CloudWatch Events service doesn't consume events from other services"));
+    return Promise.reject(new Error(`The ${SERVICE_NAME} service doesn't consume events from other services`));
 }
 
 exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext) {
     return new Promise((resolve, reject) => {
-        winston.info(`CloudWatch Events - Producing events from '${ownServiceContext.serviceName}' for consumer ${consumerServiceContext.serviceName}`);
+        winston.info(`${SERVICE_NAME} - Producing events from '${ownServiceContext.serviceName}' for consumer ${consumerServiceContext.serviceName}`);
 
-        let ruleName = deployersCommon.getResourceName(ownServiceContext);
+        let ruleName = deployPhaseCommon.getResourceName(ownServiceContext);
         let consumerServiceType = consumerServiceContext.serviceType;
-        let targetId = deployersCommon.getResourceName(consumerServiceContext);
+        let targetId = deployPhaseCommon.getResourceName(consumerServiceContext);
         let targetArn;
         let input;
         if (consumerServiceType === 'lambda') {
             targetArn = consumerDeployContext.eventOutputs.lambdaArn;
-            let eventConsumerConfig = deployersCommon.getEventConsumerConfigParams(ownServiceContext, consumerServiceContext);
+            let eventConsumerConfig = deployPhaseCommon.getEventConsumerConfigParams(ownServiceContext, consumerServiceContext);
             if (!eventConsumerConfig) { throw new Error(`No event_consumer config found in producer service for '${consumerServiceContext.serviceName}'`); }
             input = eventConsumerConfig.event_input;
         }
         else {
-            return reject(new Error(`CloudWatch Events - Unsupported event consumer type given: ${consumerServiceType}`));
+            return reject(new Error(`${SERVICE_NAME} - Unsupported event consumer type given: ${consumerServiceType}`));
         }
 
         cloudWatchEventsCalls.addTarget(ruleName, targetArn, targetId, input)
             .then(targetId => {
-                winston.info(`CloudWatch Events - Configured production of events from '${ownServiceContext.serviceName}' for consumer '${consumerServiceContext.serviceName}'`)
+                winston.info(`${SERVICE_NAME} - Configured production of events from '${ownServiceContext.serviceName}' for consumer '${consumerServiceContext.serviceName}'`)
                 return resolve(new ProduceEventsContext(ownServiceContext, consumerServiceContext));
             });
     });
 }
 
 exports.unPreDeploy = function (ownServiceContext) {
-    winston.info(`CloudWatch Events - UnPreDeploy is not required for this service`);
+    winston.info(`${SERVICE_NAME} - UnPreDeploy is not required for this service`);
     return Promise.resolve(new UnPreDeployContext(ownServiceContext));
 }
 
 exports.unBind = function (ownServiceContext) {
-    winston.info(`CloudWatch Events - UnBind is not required for this service`);
+    winston.info(`${SERVICE_NAME} - UnBind is not required for this service`);
     return Promise.resolve(new UnBindContext(ownServiceContext));
 }
 
 exports.unDeploy = function (ownServiceContext) {
-    let stackName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`CloudWatch Events - Executing UnDeploy on Events Rule '${stackName}'`)
+    let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Executing UnDeploy on Events Rule '${stackName}'`)
 
 
     return cloudWatchEventsCalls.getRule(stackName)
         .then(rule => {
             if (rule) {
-                winston.info(`CloudWatch Events - Removing targets from event rule '${stackName}'`);
+                winston.info(`${SERVICE_NAME} - Removing targets from event rule '${stackName}'`);
                 return cloudWatchEventsCalls.removeAllTargets(stackName)
             }
             else {
-                winston.info(`CloudWatch Events - Rule '${stackName}' has already been deleted`);
+                winston.info(`${SERVICE_NAME} - Rule '${stackName}' has already been deleted`);
                 return true;
             }
         })
         .then(success => {
-            return cloudFormationCalls.getStack(stackName)
-                .then(stack => {
-                    if (stack) {
-                        winston.info(`CloudWatch Events - Deleting events rule stack '${stackName}'`);
-                        return cloudFormationCalls.deleteStack(stackName);
-                    }
-                    else {
-                        winston.info(`CloudWatch Events - Stack '${stackName}' has already been deleted`);
-                    }
-                });
+            return deletePhasesCommon.unDeployCloudFormationStack(ownServiceContext, SERVICE_NAME);
         })
         .then(() => {
             return new UnDeployContext(ownServiceContext);

--- a/lib/services/dynamodb/index.js
+++ b/lib/services/dynamodb/index.js
@@ -16,7 +16,8 @@
  */
 const winston = require('winston');
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
-const deployersCommon = require('../../common/deployers-common');
+const deployPhaseCommon = require('../../common/deploy-phase-common');
+const deletePhasesCommon = require('../../common/delete-phases-common');
 const handlebarsUtils = require('../../common/handlebars-utils');
 const accountConfig = require('../../common/account-config')().getAccountConfig();
 const PreDeployContext = require('../../datatypes/pre-deploy-context');
@@ -24,10 +25,12 @@ const BindContext = require('../../datatypes/bind-context');
 const DeployContext = require('../../datatypes/deploy-context');
 const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../datatypes/un-bind-context');
-const keyTypeToAttributeType = {
+
+const KEY_TYPE_TO_ATTRIBUTE_TYPE = {
     String: "S",
     Number: "N"
 }
+const SERVICE_NAME = "DynamoDB";
 
 function getTablePolicyForDependentServices(tableName) {
     return {
@@ -64,7 +67,7 @@ function getDeployContext(serviceContext, cfStack) {
     deployContext.policies.push(getTablePolicyForDependentServices(tableName));
 
     //Inject env vars
-    let tableNameEnv = deployersCommon.getInjectedEnvVarName(serviceContext, 'TABLE_NAME');
+    let tableNameEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'TABLE_NAME');
     deployContext.environmentVariables[tableNameEnv] = tableName;
 
     return deployContext;
@@ -85,7 +88,7 @@ function getCompiledDynamoTemplate(stackName, ownServiceContext) {
     let handlebarsParams = {
         tableName: stackName,
         partitionKeyName: serviceParams.partition_key.name,
-        partitionKeyType: keyTypeToAttributeType[serviceParams.partition_key.type],
+        partitionKeyType: KEY_TYPE_TO_ATTRIBUTE_TYPE[serviceParams.partition_key.type],
         readCapacityUnits,
         writeCapacityUnits
     }
@@ -93,7 +96,7 @@ function getCompiledDynamoTemplate(stackName, ownServiceContext) {
     //Add sort key if provided
     if (serviceParams.sort_key) {
         handlebarsParams.sortKeyName = serviceParams.sort_key.name,
-            handlebarsParams.sortKeyType = keyTypeToAttributeType[serviceParams.sort_key.type]
+            handlebarsParams.sortKeyType = KEY_TYPE_TO_ATTRIBUTE_TYPE[serviceParams.sort_key.type]
     }
 
     return handlebarsUtils.compileTemplate(`${__dirname}/dynamodb-template.yml`, handlebarsParams);
@@ -111,14 +114,14 @@ exports.check = function (serviceContext) {
     let params = serviceContext.params;
 
     if (!params.partition_key) {
-        errors.push("DynamoDB - partition_key section is required");
+        errors.push(`${SERVICE_NAME} - partition_key section is required`);
     }
     else {
         if (!params.partition_key.name) {
-            errors.push("DynamoDB - name field in partition_key is required");
+            errors.push(`${SERVICE_NAME} - name field in partition_key is required`);
         }
         if (!params.partition_key.type) {
-            errors.push("DynamoDB - type field in partition_key is required");
+            errors.push(`${SERVICE_NAME} - type field in partition_key is required`);
         }
     }
 
@@ -126,49 +129,49 @@ exports.check = function (serviceContext) {
 }
 
 exports.preDeploy = function (serviceContext) {
-    winston.info(`DynamoDB - PreDeploy not required for this service, skipping it`);
+    winston.info(`${SERVICE_NAME} - PreDeploy not required for this service, skipping it`);
     return Promise.resolve(new PreDeployContext(serviceContext));
 }
 
 exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    winston.info(`DynamoDB - Bind not required for this service, skipping it`);
+    winston.info(`${SERVICE_NAME} - Bind not required for this service, skipping it`);
     return Promise.resolve(new BindContext(ownServiceContext, dependentOfServiceContext));
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
-    var stackName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`DynamoDB - Deploying table ${stackName}`);
+    var stackName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Deploying table ${stackName}`);
 
     return getCompiledDynamoTemplate(stackName, ownServiceContext)
         .then(compiledTemplate => {
-            return deployersCommon.deployCloudFormationStack(stackName, compiledTemplate, [], false, "DynamoDB");
+            return deployPhaseCommon.deployCloudFormationStack(stackName, compiledTemplate, [], false, SERVICE_NAME);
         })
         .then(deployedStack => {
-            winston.info(`DynamoDB - Finished deploying table ${stackName}`);
+            winston.info(`${SERVICE_NAME} - Finished deploying table ${stackName}`);
             return getDeployContext(ownServiceContext, deployedStack);
         });
 }
 
 exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerServiceContext, producerDeployContext) {
-    return Promise.reject(new Error("The DynamoDB service doesn't consume events from other services"));
+    return Promise.reject(new Error(`The ${SERVICE_NAME} service doesn't consume events from other services`));
 }
 
 exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext) {
-    return Promise.reject(new Error("The DynamoDB service doesn't produce events for other services"));
+    return Promise.reject(new Error(`The ${SERVICE_NAME} service doesn't produce events for other services`));
 }
 
 exports.unPreDeploy = function (ownServiceContext) {
-    winston.info(`DynamoDB - UnPreDeploy is not required for this service`);
+    winston.info(`${SERVICE_NAME} - UnPreDeploy is not required for this service`);
     return Promise.resolve(new UnPreDeployContext(ownServiceContext));
 }
 
 exports.unBind = function (ownServiceContext) {
-    winston.info(`DynamoDB - UnBind is not required for this service`);
+    winston.info(`${SERVICE_NAME} - UnBind is not required for this service`);
     return Promise.resolve(new UnBindContext(ownServiceContext));
 }
 
 exports.unDeploy = function (ownServiceContext) {
-    return deployersCommon.unDeployCloudFormationStack(ownServiceContext, 'DynamoDB');
+    return deletePhasesCommon.unDeployCloudFormationStack(ownServiceContext, SERVICE_NAME);
 }
 
 exports.producedEventsSupportedServices = [];

--- a/lib/services/ecs/index.js
+++ b/lib/services/ecs/index.js
@@ -21,11 +21,13 @@ const DeployContext = require('../../datatypes/deploy-context');
 const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../datatypes/un-bind-context');
 const accountConfig = require('../../common/account-config')().getAccountConfig();
-const deployersCommon = require('../../common/deployers-common');
+const deployPhaseCommon = require('../../common/deploy-phase-common');
+const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
+const deletePhasesCommon = require('../../common/delete-phases-common');
 const handlebarsUtils = require('../../common/handlebars-utils');
-const cloudformationCalls = require('../../aws/cloudformation-calls');
 const _ = require('lodash');
 
+const SERVICE_NAME = "ECS";
 //Values are specified in MiB
 const EC2_INSTANCE_MEMORY_MAP = {
     "t2.nano": "500",
@@ -86,7 +88,7 @@ const EC2_INSTANCE_MEMORY_MAP = {
 function getInstanceCountForCluster(instanceType, containerInstances, containerMaxMemory) {
     let instanceMemory = EC2_INSTANCE_MEMORY_MAP[instanceType];
     if (!instanceMemory) {
-        throw new Error(`ECS - Unhandled instance type specified: ${instanceType}`);
+        throw new Error(`${SERVICE_NAME} - Unhandled instance type specified: ${instanceType}`);
     }
     let maxInstanceMemoryToUse = instanceMemory * .5; //Fill up instances to 50% of capacity (allows for deployments)
 
@@ -139,7 +141,7 @@ function createEcsServiceRoleIfNotExists() {
         }
     ]
 
-    return deployersCommon.createCustomRole(trustedService, roleName, policyStatementsToConsume)
+    return deployPhaseCommon.createCustomRole(trustedService, roleName, policyStatementsToConsume)
         .then(role => {
             return role;
         });
@@ -149,7 +151,7 @@ function getDependenciesDeployContextMountPoints(dependenciesDeployContexts) {
     let mountPoints = [];
     for (let deployContext of dependenciesDeployContexts) {
         if (deployContext['serviceType'] === 'efs') { //Only EFS is supported as an external service mount point for now
-            let envVarKey = deployersCommon.getInjectedEnvVarName(deployContext, 'MOUNT_DIR');
+            let envVarKey = deployPhaseCommon.getInjectedEnvVarName(deployContext, 'MOUNT_DIR');
 
             mountPoints.push({
                 mountDir: deployContext.environmentVariables[envVarKey],
@@ -161,9 +163,9 @@ function getDependenciesDeployContextMountPoints(dependenciesDeployContexts) {
 }
 
 function getTaskRoleStatements(serviceContext, dependenciesDeployContexts) {
-    let ownPolicyStatements = deployersCommon.getAppSecretsAccessPolicyStatements(serviceContext);
+    let ownPolicyStatements = deployPhaseCommon.getAppSecretsAccessPolicyStatements(serviceContext);
 
-    return deployersCommon.getAllPolicyStatementsForServiceRole(ownPolicyStatements, dependenciesDeployContexts);
+    return deployPhaseCommon.getAllPolicyStatementsForServiceRole(ownPolicyStatements, dependenciesDeployContexts);
 }
 
 function getCompiledEcsTemplate(stackName, clusterName, ownServiceContext, ownPreDeployContext, dependenciesDeployContexts, userDataScript, ecsServiceRole) {
@@ -228,11 +230,11 @@ function getCompiledEcsTemplate(stackName, clusterName, ownServiceContext, ownPr
     }
 
     //Inject env vars defined by dependencies
-    let dependenciesEnvVars = deployersCommon.getEnvVarsFromDependencyDeployContexts(dependenciesDeployContexts);
+    let dependenciesEnvVars = deployPhaseCommon.getEnvVarsFromDependencyDeployContexts(dependenciesDeployContexts);
     handlebarsParams.environmentVariables = _.assign(handlebarsParams.environmentVariables, dependenciesEnvVars);
 
     //Inject env vars from Handel file
-    let handelInjectedEnvVars = deployersCommon.getEnvVarsFromServiceContext(ownServiceContext);
+    let handelInjectedEnvVars = deployPhaseCommon.getEnvVarsFromServiceContext(ownServiceContext);
     handlebarsParams.environmentVariables = _.assign(handlebarsParams.environmentVariables, handelInjectedEnvVars);
 
     //Add volumes and mount points
@@ -255,7 +257,7 @@ function getCompiledEcsTemplate(stackName, clusterName, ownServiceContext, ownPr
     }
 
     //Add routing if specified
-    let routingInfo = deployersCommon.getRoutingInformationForService(ownServiceContext);
+    let routingInfo = getRoutingInformationForService(ownServiceContext);
     if (routingInfo) {
         handlebarsParams.routingInfo = routingInfo;
     }
@@ -281,6 +283,44 @@ function getShortenedClusterName(serviceContext) {
     return `${serviceContext.appName.substring(0, 21)}-${serviceContext.environmentName.substring(0, 4)}-${serviceContext.serviceName.substring(0, 9)}`;
 }
 
+function checkRoutingElement(serviceContext) {
+    let errors = [];
+    let serviceParams = serviceContext.params;
+    if (serviceParams.routing) {
+        if (!serviceParams.routing.type) {
+            errors.push(`${serviceContext.serviceType} - The 'type' field is required in the 'routing' section`);
+        }
+        else {
+            if (serviceParams.routing.type === 'https' && !serviceParams.routing.https_certificate) {
+                errors.push(`${serviceContext.serviceType} - The 'https_certificate' element is required when you are using 'https' as the routing type`);
+            }
+        }
+    }
+    return errors;
+}
+
+function getRoutingInformationForService(serviceContext) {
+    let serviceParams = serviceContext.params;
+    if (serviceParams.routing) {
+        let routingInfo = {
+            type: serviceParams.routing.type,
+            timeout: 60,
+            healthCheckPath: '/'
+        };
+        if (serviceParams.routing.timeout) {
+            routingInfo.timeout = serviceParams.routing.timeout;
+        }
+        if (serviceParams.routing.health_check_path) {
+            routingInfo.healthCheckPath = serviceParams.routing.health_check_path;
+        }
+        if (routingInfo.type === 'https') {
+            routingInfo.httpsCertificate = `arn:aws:acm:us-west-2:${accountConfig.account_id}:certificate/${serviceParams.routing.https_certificate}`;
+        }
+        return routingInfo;
+    }
+    return null; //No routing specified
+}
+
 
 /**
  * Service Deployer Contract Methods
@@ -293,23 +333,23 @@ exports.check = function (serviceContext) {
     let params = serviceContext.params;
     if (params.routing) {
         if (!params.port_mappings || params.port_mappings.length === 0) {
-            errors.push("ECS - 'port_mappings' parameter is required when you specify the 'routing' element");
+            errors.push("${SERVICE_NAME} - 'port_mappings' parameter is required when you specify the 'routing' element");
         }
     }
 
     //Check the routing element (if present)
-    errors = errors.concat(deployersCommon.checkRoutingElement(serviceContext));
+    errors = errors.concat(checkRoutingElement(serviceContext));
 
     return errors;
 }
 
 exports.preDeploy = function (serviceContext) {
-    let sgName = deployersCommon.getResourceName(serviceContext);
-    winston.info(`ECS - Executing PreDeploy on ${sgName}`);
+    let sgName = deployPhaseCommon.getResourceName(serviceContext);
+    winston.info(`${SERVICE_NAME} - Executing PreDeploy on ${sgName}`);
 
-    return deployersCommon.createSecurityGroupForService(sgName, 22)
+    return preDeployPhaseCommon.createSecurityGroupForService(sgName, 22)
         .then(securityGroup => {
-            winston.info(`ECS - Finished PreDeploy on ${sgName}`);
+            winston.info(`${SERVICE_NAME} - Finished PreDeploy on ${sgName}`);
             let preDeployContext = new PreDeployContext(serviceContext);
             preDeployContext.securityGroups.push(securityGroup);
             return preDeployContext;
@@ -317,13 +357,13 @@ exports.preDeploy = function (serviceContext) {
 }
 
 exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    winston.info(`ECS - Bind not required for this service, skipping it`);
+    winston.info(`${SERVICE_NAME} - Bind not required for this service, skipping it`);
     return Promise.resolve(new BindContext(ownServiceContext, dependentOfServiceContext));
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
-    let stackName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`ECS - Deploying Cluster and Service ${stackName}`);
+    let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Deploying Cluster and Service ${stackName}`);
 
     let clusterName = getShortenedClusterName(ownServiceContext);
     return getUserDataScript(clusterName, dependenciesDeployContexts)
@@ -334,41 +374,41 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
                 });
         })
         .then(compiledTemplate => {
-            return deployersCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, "ECS");
+            return deployPhaseCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, SERVICE_NAME);
         })
         .then(deployedStack => {
-            winston.info(`ECS - Finished Deploying Cluster and Serivce ${stackName}`);
+            winston.info(`${SERVICE_NAME} - Finished Deploying Cluster and Serivce ${stackName}`);
             let deployContext = new DeployContext(ownServiceContext);
             return deployContext;
         });
 }
 
 exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerServiceContext, producerDeployContext) {
-    return Promise.reject(new Error("The ECS service doesn't consume events from other services"));
+    return Promise.reject(new Error(`The ${SERVICE_NAME} service doesn't consume events from other services`));
 }
 
 exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext) {
-    return Promise.reject(new Error("The ECS service doesn't produce events for other services"));
+    return Promise.reject(new Error(`The ${SERVICE_NAME} service doesn't produce events for other services`));
 }
 
 exports.unPreDeploy = function (ownServiceContext) {
-    let sgName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`ECS - Executing UnPreDeploy on ${sgName}`);
+    let sgName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Executing UnPreDeploy on ${sgName}`);
 
-    return deployersCommon.deleteSecurityGroupForService(sgName)
+    return deletePhasesCommon.deleteSecurityGroupForService(sgName)
         .then(success => {
-            winston.info(`ECS - Finished UnPreDeploy on ${sgName}`);
+            winston.info(`${SERVICE_NAME} - Finished UnPreDeploy on ${sgName}`);
             return new UnPreDeployContext(ownServiceContext);
         });
 }
 
 exports.unBind = function (ownServiceContext) {
-    winston.info(`ECS - UnBind is not required for this service`);
+    winston.info(`${SERVICE_NAME} - UnBind is not required for this service`);
     return Promise.resolve(new UnBindContext(ownServiceContext));
 }
 
 exports.unDeploy = function (ownServiceContext) {
-    return deployersCommon.unDeployCloudFormationStack(ownServiceContext, 'ECS');
+    return deletePhasesCommon.unDeployCloudFormationStack(ownServiceContext, SERVICE_NAME);
 }
 
 exports.producedEventsSupportedServices = [];

--- a/lib/services/efs/index.js
+++ b/lib/services/efs/index.js
@@ -22,10 +22,13 @@ const BindContext = require('../../datatypes/bind-context');
 const DeployContext = require('../../datatypes/deploy-context');
 const accountConfig = require('../../common/account-config')().getAccountConfig();
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
-const deployersCommon = require('../../common/deployers-common');
+const deployPhaseCommon = require('../../common/deploy-phase-common');
+const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
+const deletePhasesCommon = require('../../common/delete-phases-common');
 const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../datatypes/un-bind-context');
 
+const SERVICE_NAME = "EFS";
 const EFS_PORT = 2049;
 const EFS_SG_PROTOCOL = "tcp";
 const EFS_PERFORMANCE_MODE_MAP = {
@@ -51,7 +54,7 @@ function getDeployContext(serviceContext, fileSystemId, region, fileSystemName) 
     let mountDir = `/mnt/share/${fileSystemName}`
     return getMountScript(fileSystemId, region, mountDir)
         .then(mountScript => {
-            let mountDirEnv = deployersCommon.getInjectedEnvVarName(serviceContext, 'MOUNT_DIR');
+            let mountDirEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'MOUNT_DIR');
             deployContext.environmentVariables[mountDirEnv] = mountDir
             deployContext.scripts.push(mountScript);
             return deployContext;
@@ -64,7 +67,7 @@ function getFileSystemIdFromStack(stack) {
         return fileSystemId;
     }
     else {
-        throw new Error("Couldn't find EFS file system ID in CloudFormation stack outputs");
+        throw new Error(`Couldn't find ${SERVICE_NAME} file system ID in CloudFormation stack outputs`);
     }
 }
 
@@ -115,19 +118,19 @@ exports.check = function (serviceContext) {
     let perfModeParam = params['performance_mode']
     if (perfModeParam) {
         if (perfModeParam !== 'general_purpose' && perfModeParam !== 'max_io') {
-            errors.push("EFS - 'performance_mode' parameter must be either 'general_purpose' or 'max_io'");
+            errors.push(`${SERVICE_NAME} - 'performance_mode' parameter must be either 'general_purpose' or 'max_io'`);
         }
     }
     return errors;
 }
 
 exports.preDeploy = function (serviceContext) {
-    let sgName = deployersCommon.getResourceName(serviceContext);
-    winston.info(`EFS - Executing PreDeploy on ${sgName}`);
+    let sgName = deployPhaseCommon.getResourceName(serviceContext);
+    winston.info(`${SERVICE_NAME} - Executing PreDeploy on ${sgName}`);
 
-    return deployersCommon.createSecurityGroupForService(sgName)
+    return preDeployPhaseCommon.createSecurityGroupForService(sgName)
         .then(securityGroup => {
-            winston.info(`EFS - Finished PreDeploy on ${sgName}`);
+            winston.info(`${SERVICE_NAME} - Finished PreDeploy on ${sgName}`);
             let preDeployContext = new PreDeployContext(serviceContext);
             preDeployContext.securityGroups.push(securityGroup);
             return preDeployContext;
@@ -135,8 +138,8 @@ exports.preDeploy = function (serviceContext) {
 }
 
 exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    let stackName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`EFS - Executing Bind on ${stackName}`);
+    let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Executing Bind on ${stackName}`);
     let ownSg = ownPreDeployContext.securityGroups[0];
     let sourceSg = dependentOfPreDeployContext.securityGroups[0];
 
@@ -144,58 +147,58 @@ exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServ
         EFS_SG_PROTOCOL, EFS_PORT,
         EFS_PORT, accountConfig['vpc'])
         .then(efsSecurityGroup => {
-            winston.info(`EFS - Finished Bind on ${stackName}`);
+            winston.info(`${SERVICE_NAME} - Finished Bind on ${stackName}`);
             return new BindContext(ownServiceContext, dependentOfServiceContext);
         });
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
-    let stackName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`EFS - Executing Deploy on ${stackName}`);
+    let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Executing Deploy on ${stackName}`);
 
     return getCompiledEfsTemplate(stackName, ownServiceContext, ownPreDeployContext)
         .then(compiledTemplate => {
-            return deployersCommon.deployCloudFormationStack(stackName, compiledTemplate, [], false, "EFS");
+            return deployPhaseCommon.deployCloudFormationStack(stackName, compiledTemplate, [], false, SERVICE_NAME);
         })
         .then(deployedStack => {
-            winston.info(`EFS - Finished deploy for '${stackName}'`)
+            winston.info(`${SERVICE_NAME} - Finished deploy for '${stackName}'`)
             let fileSystemId = getFileSystemIdFromStack(deployedStack);
             return getDeployContext(ownServiceContext, fileSystemId, accountConfig['region'], stackName);
         });
 }
 
 exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerServiceContext, producerDeployContext) {
-    return Promise.reject(new Error("The EFS service doesn't consume events from other services"));
+    return Promise.reject(new Error(`The ${SERVICE_NAME} service doesn't consume events from other services`));
 }
 
 exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext) {
-    return Promise.reject(new Error("The EFS service doesn't produce events for other services"));
+    return Promise.reject(new Error(`The ${SERVICE_NAME} service doesn't produce events for other services`));
 }
 
 exports.unPreDeploy = function (ownServiceContext) {
-    let sgName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`EFS - Executing UnPreDeploy on ${sgName}`);
+    let sgName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Executing UnPreDeploy on ${sgName}`);
 
-    return deployersCommon.deleteSecurityGroupForService(sgName)
+    return deletePhasesCommon.deleteSecurityGroupForService(sgName)
         .then(success => {
-            winston.info(`EFS - Finished UnPreDeploy on ${sgName}`);
+            winston.info(`${SERVICE_NAME} - Finished UnPreDeploy on ${sgName}`);
             return new UnPreDeployContext(ownServiceContext);
         });
 }
 
 exports.unBind = function (ownServiceContext) {
-    let sgName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`EFS - Executing UnBind on ${sgName}`);
+    let sgName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Executing UnBind on ${sgName}`);
 
-    return deployersCommon.unBindAllOnSg(sgName)
+    return deletePhasesCommon.unBindAllOnSg(sgName)
         .then(success => {
-            winston.info(`EFS - Finished UnBind on ${sgName}`);
+            winston.info(`${SERVICE_NAME} - Finished UnBind on ${sgName}`);
             return new UnBindContext(ownServiceContext);
         });
 }
 
 exports.unDeploy = function (ownServiceContext) {
-    return deployersCommon.unDeployCloudFormationStack(ownServiceContext, 'DynamoDB');
+    return deletePhasesCommon.unDeployCloudFormationStack(ownServiceContext, SERVICE_NAME);
 }
 
 exports.producedEventsSupportedServices = [];

--- a/lib/services/lambda/index.js
+++ b/lib/services/lambda/index.js
@@ -25,14 +25,17 @@ const UnBindContext = require('../../datatypes/un-bind-context');
 const util = require('../../common/util');
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
 const lambdaCalls = require('../../aws/lambda-calls');
-const deployersCommon = require('../../common/deployers-common');
+const deployPhaseCommon = require('../../common/deploy-phase-common');
+const deletePhasesCommon = require('../../common/delete-phases-common');
 const uuid = require('uuid');
 const _ = require('lodash');
 
+const SERVICE_NAME = "Lambda";
+
 function getEnvVariablesToInject(serviceContext, dependenciesDeployContexts) {
     let serviceParams = serviceContext.params;
-    let envVarsToInject = deployersCommon.getEnvVarsFromDependencyDeployContexts(dependenciesDeployContexts);
-    envVarsToInject = _.assign(envVarsToInject, deployersCommon.getEnvVarsFromServiceContext(serviceContext));
+    let envVarsToInject = deployPhaseCommon.getEnvVarsFromDependencyDeployContexts(dependenciesDeployContexts);
+    envVarsToInject = _.assign(envVarsToInject, deployPhaseCommon.getEnvVarsFromServiceContext(serviceContext));
 
     if (serviceParams.environment_variables) {
         for (let envVarName in serviceParams.environment_variables) {
@@ -84,19 +87,19 @@ function getDeployContext(serviceContext, cfStack) {
 
 function uploadDeployableArtifactToS3(serviceContext) {
     let s3FileName = `lambda-deployable-${uuid()}.zip`;
-    winston.info(`Lambda - Uploading deployable artifact to S3: ${s3FileName}`);
-    return deployersCommon.uploadDeployableArtifactToHandelBucket(serviceContext, s3FileName)
+    winston.info(`${SERVICE_NAME} - Uploading deployable artifact to S3: ${s3FileName}`);
+    return deployPhaseCommon.uploadDeployableArtifactToHandelBucket(serviceContext, s3FileName)
         .then(s3ArtifactInfo => {
-            winston.info(`Lambda - Uploaded deployable artifact to S3: ${s3FileName}`);
+            winston.info(`${SERVICE_NAME} - Uploaded deployable artifact to S3: ${s3FileName}`);
             return s3ArtifactInfo;
         });
 }
 
 function getPolicyStatementsForLambdaRole(serviceContext, dependenciesDeployContexts) {
     let ownPolicyStatements = JSON.parse(util.readFileSync(`${__dirname}/lambda-role-statements.json`));
-    ownPolicyStatements = ownPolicyStatements.concat(deployersCommon.getAppSecretsAccessPolicyStatements(serviceContext));
+    ownPolicyStatements = ownPolicyStatements.concat(deployPhaseCommon.getAppSecretsAccessPolicyStatements(serviceContext));
 
-    return deployersCommon.getAllPolicyStatementsForServiceRole(ownPolicyStatements, dependenciesDeployContexts);
+    return deployPhaseCommon.getAllPolicyStatementsForServiceRole(ownPolicyStatements, dependenciesDeployContexts);
 }
 
 
@@ -111,41 +114,41 @@ exports.check = function (serviceContext) {
 
     let serviceParams = serviceContext.params;
     if (!serviceParams.path_to_code) {
-        errors.push("Lambda - The 'path_to_code' parameter is required");
+        errors.push(`${SERVICE_NAME} - The 'path_to_code' parameter is required`);
     }
     if (!serviceParams.handler) {
-        errors.push("Lambda - The 'handler' parameter is required");
+        errors.push(`${SERVICE_NAME} - The 'handler' parameter is required`);
     }
     if (!serviceParams.runtime) {
-        errors.push("Lambda - The 'runtime' parameter is required");
+        errors.push(`${SERVICE_NAME} - The 'runtime' parameter is required`);
     }
 
     return errors;
 }
 
 exports.preDeploy = function (serviceContext) {
-    winston.info(`Lambda - PreDeploy is not required for this service, skipping it`);
+    winston.info(`${SERVICE_NAME} - PreDeploy is not required for this service, skipping it`);
     return Promise.resolve(new PreDeployContext(serviceContext));
 }
 
 exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    winston.info(`Lambda - Bind is not required for this service, skipping it`);
+    winston.info(`${SERVICE_NAME} - Bind is not required for this service, skipping it`);
     return Promise.resolve(new BindContext(ownServiceContext, dependentOfServiceContext));
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
-    let stackName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`Lambda - Executing Deploy on ${stackName}`);
+    let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Executing Deploy on '${stackName}'`);
 
     return uploadDeployableArtifactToS3(ownServiceContext)
         .then(s3ArtifactInfo => {
             return getCompiledLambdaTemplate(stackName, ownServiceContext, dependenciesDeployContexts, s3ArtifactInfo);
         })
         .then(compiledLambdaTemplate => {
-            return deployersCommon.deployCloudFormationStack(stackName, compiledLambdaTemplate, [], true, "Lambda");
+            return deployPhaseCommon.deployCloudFormationStack(stackName, compiledLambdaTemplate, [], true, SERVICE_NAME);
         })
         .then(deployedStack => {
-            winston.info(`Lambda - Finished deploying Lambda function ${stackName}`);
+            winston.info(`${SERVICE_NAME} - Finished deploying '${stackName}'`);
             return getDeployContext(ownServiceContext, deployedStack);
         });
 }
@@ -153,7 +156,7 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
 exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerServiceContext, producerDeployContext) {
     //TODO - DynamoDB streams will differ from this model
     return new Promise((resolve, reject) => {
-        winston.info(`Lambda - Consuming events from service '${producerServiceContext.serviceName}' for service '${ownServiceContext.serviceName}'`);
+        winston.info(`${SERVICE_NAME} - Consuming events from service '${producerServiceContext.serviceName}' for service '${ownServiceContext.serviceName}'`);
         let functionName = ownDeployContext.eventOutputs.lambdaName;
         let producerServiceType = producerServiceContext.serviceType;
         let principal;
@@ -167,33 +170,33 @@ exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerS
             sourceArn = producerDeployContext.eventOutputs.eventRuleArn;
         }
         else {
-            return reject(new Error(`Lambda - Unsupported event producer type given: ${producerServiceType}`));
+            return reject(new Error(`${SERVICE_NAME} - Unsupported event producer type given: ${producerServiceType}`));
         }
 
         return lambdaCalls.addLambdaPermissionIfNotExists(functionName, principal, sourceArn)
             .then(permissionStatement => {
-                winston.info(`Lambda - Allowed consuming events from ${producerServiceContext.serviceName} for ${ownServiceContext.serviceName}`);
+                winston.info(`${SERVICE_NAME} - Allowed consuming events from ${producerServiceContext.serviceName} for ${ownServiceContext.serviceName}`);
                 return resolve(new ConsumeEventsContext(ownServiceContext, producerServiceContext));
             });
     });
 }
 
 exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext) {
-    return Promise.reject(new Error("The Lambda service doesn't produce events for other services"));
+    return Promise.reject(new Error(`The ${SERVICE_NAME} service doesn't produce events for other services`));
 }
 
 exports.unPreDeploy = function (ownServiceContext) {
-    winston.info(`Lambda - UnPreDeploy is not required for this service`);
+    winston.info(`${SERVICE_NAME} - UnPreDeploy is not required for this service`);
     return Promise.resolve(new UnPreDeployContext(ownServiceContext));
 }
 
 exports.unBind = function (ownServiceContext) {
-    winston.info(`Lambda - UnBind is not required for this service`);
+    winston.info(`${SERVICE_NAME} - UnBind is not required for this service`);
     return Promise.resolve(new UnBindContext(ownServiceContext));
 }
 
 exports.unDeploy = function (ownServiceContext) {
-    return deployersCommon.unDeployCloudFormationStack(ownServiceContext, 'Lambda');
+    return deletePhasesCommon.unDeployCloudFormationStack(ownServiceContext, SERVICE_NAME);
 }
 
 exports.producedEventsSupportedServices = [];

--- a/lib/services/memcached/index.js
+++ b/lib/services/memcached/index.js
@@ -21,12 +21,15 @@ const BindContext = require('../../datatypes/bind-context');
 const DeployContext = require('../../datatypes/deploy-context');
 const accountConfig = require('../../common/account-config')().getAccountConfig();
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
-const deployersCommon = require('../../common/deployers-common');
+const deployPhaseCommon = require('../../common/deploy-phase-common');
+const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
+const deletePhasesCommon = require('../../common/delete-phases-common');
 const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../datatypes/un-bind-context');
 const handlebarsUtils = require('../../common/handlebars-utils');
 const uuid = require('uuid');
 
+const SERVICE_NAME = "Memcached";
 const MEMCACHED_PORT = 11211;
 const MEMCACHED_SG_PROTOCOL = "tcp";
 
@@ -34,10 +37,10 @@ function getDeployContext(serviceContext, cfStack) {
     let deployContext = new DeployContext(serviceContext);
 
     // Set port and address environment variables
-    let portEnv = deployersCommon.getInjectedEnvVarName(serviceContext, 'PORT');
+    let portEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'PORT');
     let port = cloudFormationCalls.getOutput('CachePort', cfStack);
     deployContext.environmentVariables[portEnv] = port;
-    let addressEnv = deployersCommon.getInjectedEnvVarName(serviceContext, 'ADDRESS');
+    let addressEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'ADDRESS');
     let address = cloudFormationCalls.getOutput('CacheAddress', cfStack);
     deployContext.environmentVariables[addressEnv] = address;
     return deployContext;
@@ -107,22 +110,22 @@ exports.check = function (serviceContext) {
     let serviceParams = serviceContext.params;
 
     if (!serviceParams.instance_type) {
-        errors.push(`Memcached - The 'instance_type' parameter is required`);
+        errors.push(`${SERVICE_NAME} - The 'instance_type' parameter is required`);
     }
     if (!serviceParams.memcached_version) {
-        errors.push(`Memcached - The 'memcached_version' parameter is required`);
+        errors.push(`${SERVICE_NAME} - The 'memcached_version' parameter is required`);
     }
 
     return errors;
 }
 
 exports.preDeploy = function (serviceContext) {
-    let sgName = deployersCommon.getResourceName(serviceContext);
-    winston.info(`Memcached - Executing PreDeploy on '${sgName}'`);
+    let sgName = deployPhaseCommon.getResourceName(serviceContext);
+    winston.info(`${SERVICE_NAME} - Executing PreDeploy on '${sgName}'`);
 
-    return deployersCommon.createSecurityGroupForService(sgName)
+    return preDeployPhaseCommon.createSecurityGroupForService(sgName)
         .then(securityGroup => {
-            winston.info(`Memcached - Finished PreDeploy on '${sgName}'`);
+            winston.info(`${SERVICE_NAME} - Finished PreDeploy on '${sgName}'`);
             let preDeployContext = new PreDeployContext(serviceContext);
             preDeployContext.securityGroups.push(securityGroup);
             return preDeployContext;
@@ -130,64 +133,64 @@ exports.preDeploy = function (serviceContext) {
 }
 
 exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    let stackName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`Memcached - Executing Bind on '${stackName}'`);
+    let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Executing Bind on '${stackName}'`);
     let ownSg = ownPreDeployContext.securityGroups[0];
     let sourceSg = dependentOfPreDeployContext.securityGroups[0];
 
     return ec2Calls.addIngressRuleToSgIfNotExists(sourceSg, ownSg, MEMCACHED_SG_PROTOCOL, MEMCACHED_PORT, MEMCACHED_PORT, accountConfig.vpc)
         .then(() => {
-            winston.info(`Memcached - Finished Bind on '${stackName}'`);
+            winston.info(`${SERVICE_NAME} - Finished Bind on '${stackName}'`);
             return new BindContext(ownServiceContext, dependentOfServiceContext);
         });
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
-    let stackName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`Memcached - Executing Deploy on '${stackName}'`);
+    let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Executing Deploy on '${stackName}'`);
 
     return getCompiledMemcachedTemplate(stackName, ownServiceContext, ownPreDeployContext)
         .then(compiledTemplate => {
-            return deployersCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, "Memcached");
+            return deployPhaseCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, SERVICE_NAME);
         })
         .then(deployedStack => {
-            winston.info(`Memcached - Finished Deploy on '${stackName}'`);
+            winston.info(`${SERVICE_NAME} - Finished Deploy on '${stackName}'`);
             return getDeployContext(ownServiceContext, deployedStack)
         });
 }
 
 exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerServiceContext, producerDeployContext) {
-    return Promise.reject(new Error("The Memcached service doesn't consume events from other services"));
+    return Promise.reject(new Error(`The ${SERVICE_NAME} service doesn't consume events from other services`));
 }
 
 exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext) {
-    return Promise.reject(new Error("The Memcached service doesn't produce events for other services"));
+    return Promise.reject(new Error(`The ${SERVICE_NAME} service doesn't produce events for other services`));
 }
 
 exports.unPreDeploy = function (ownServiceContext) {
-    let sgName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`Memcached - Executing UnPreDeploy on '${sgName}'`);
+    let sgName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Executing UnPreDeploy on '${sgName}'`);
 
-    return deployersCommon.deleteSecurityGroupForService(sgName)
+    return deletePhasesCommon.deleteSecurityGroupForService(sgName)
         .then(success => {
-            winston.info(`Memcached - Finished UnPreDeploy on '${sgName}'`);
+            winston.info(`${SERVICE_NAME} - Finished UnPreDeploy on '${sgName}'`);
             return new UnPreDeployContext(ownServiceContext);
         });
 }
 
 exports.unBind = function (ownServiceContext) {
-    let sgName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`Memcached - Executing UnBind on ${sgName}`);
+    let sgName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Executing UnBind on ${sgName}`);
 
-    return deployersCommon.unBindAllOnSg(sgName)
+    return deletePhasesCommon.unBindAllOnSg(sgName)
         .then(success => {
-            winston.info(`Memcached - Finished UnBind on ${sgName}`);
+            winston.info(`${SERVICE_NAME} - Finished UnBind on ${sgName}`);
             return new UnBindContext(ownServiceContext);
         });
 }
 
 exports.unDeploy = function (ownServiceContext) {
-    return deployersCommon.unDeployCloudFormationStack(ownServiceContext, 'Memcached');
+    return deletePhasesCommon.unDeployCloudFormationStack(ownServiceContext, SERVICE_NAME);
 }
 
 exports.producedEventsSupportedServices = [];

--- a/lib/services/mysql/index.js
+++ b/lib/services/mysql/index.js
@@ -16,18 +16,20 @@
  */
 const winston = require('winston');
 const ec2Calls = require('../../aws/ec2-calls');
-const ssmCalls = require('../../aws/ssm-calls');
 const handlebarsUtils = require('../../common/handlebars-utils');
 const PreDeployContext = require('../../datatypes/pre-deploy-context');
 const BindContext = require('../../datatypes/bind-context');
 const accountConfig = require('../../common/account-config')().getAccountConfig();
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
-const deployersCommon = require('../../common/deployers-common');
+const deployPhaseCommon = require('../../common/deploy-phase-common');
+const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
+const deletePhasesCommon = require('../../common/delete-phases-common');
 const rdsCommon = require('../../common/rds-common');
 const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../datatypes/un-bind-context');
 const uuid = require('uuid');
 
+const SERVICE_NAME = "MySQL";
 const MYSQL_PORT = 3306;
 const MYSQL_PROTOCOL = 'tcp';
 
@@ -99,19 +101,19 @@ exports.check = function (serviceContext) {
     let serviceParams = serviceContext.params;
 
     if (!serviceParams.database_name) {
-        errors.push(`MySQL - The 'database_name' parameter is required`);
+        errors.push(`${SERVICE_NAME} - The 'database_name' parameter is required`);
     }
 
     return errors;
 }
 
 exports.preDeploy = function (serviceContext) {
-    let sgName = deployersCommon.getResourceName(serviceContext);
-    winston.info(`MySQL - Executing PreDeploy on ${sgName}`);
+    let sgName = deployPhaseCommon.getResourceName(serviceContext);
+    winston.info(`${SERVICE_NAME} - Executing PreDeploy on ${sgName}`);
 
-    return deployersCommon.createSecurityGroupForService(sgName, MYSQL_PORT)
+    return preDeployPhaseCommon.createSecurityGroupForService(sgName, MYSQL_PORT)
         .then(securityGroup => {
-            winston.info(`MySQL - Finished PreDeploy on ${sgName}`);
+            winston.info(`${SERVICE_NAME} - Finished PreDeploy on ${sgName}`);
             let preDeployContext = new PreDeployContext(serviceContext);
             preDeployContext.securityGroups.push(securityGroup);
             return preDeployContext;
@@ -119,8 +121,8 @@ exports.preDeploy = function (serviceContext) {
 }
 
 exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    let stackName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`MySQL - Executing Bind on ${stackName}`);
+    let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Executing Bind on ${stackName}`);
     let ownSg = ownPreDeployContext.securityGroups[0];
     let sourceSg = dependentOfPreDeployContext.securityGroups[0];
 
@@ -128,14 +130,14 @@ exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServ
         MYSQL_PROTOCOL, MYSQL_PORT,
         MYSQL_PORT, accountConfig['vpc'])
         .then(mysqlSecurityGroup => {
-            winston.info(`MySQL - Finished Bind on ${stackName}`);
+            winston.info(`${SERVICE_NAME} - Finished Bind on ${stackName}`);
             return new BindContext(ownServiceContext, dependentOfServiceContext);
         });
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
-    let stackName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`MySQL - Executing Deploy on ${stackName}`);
+    let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Executing Deploy on ${stackName}`);
 
     return getCompiledMysqlTemplate(stackName, ownServiceContext, ownPreDeployContext)
         .then(compiledTemplate => {
@@ -146,56 +148,56 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
                         let cfParameters = {
                             DBPassword: dbPassword
                         }
-                        winston.info(`MySQL - Creating RDS instances '${stackName}'`);
+                        winston.info(`${SERVICE_NAME} - Creating RDS instances '${stackName}'`);
                         return cloudFormationCalls.createStack(stackName, compiledTemplate, cloudFormationCalls.getCfStyleStackParameters(cfParameters))
                             .then(deployedStack => {
                                 return rdsCommon.addDbCredentialToParameterStore(ownServiceContext, dbPassword, deployedStack);
                             });
                     }
                     else {
-                        winston.info(`MySQL - Updates are not supported for this service.`);
+                        winston.info(`${SERVICE_NAME} - Updates are not supported for this service.`);
                         return stack;
                     }
                 });
         })
         .then(deployedStack => {
-            winston.info(`MySQL - Finished deploying RDS instance '${stackName}'`)
+            winston.info(`${SERVICE_NAME} - Finished deploying RDS instance '${stackName}'`)
             return rdsCommon.getDeployContext(ownServiceContext, deployedStack);
         });
 }
 
 exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerServiceContext, producerDeployContext) {
-    return Promise.reject(new Error("The MySQL service doesn't consume events from other services"));
+    return Promise.reject(new Error(`The ${SERVICE_NAME} service doesn't consume events from other services`));
 }
 
 exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext) {
-    return Promise.reject(new Error("The MySQL service doesn't produce events for other services"));
+    return Promise.reject(new Error(`The ${SERVICE_NAME} service doesn't produce events for other services`));
 }
 
 exports.unPreDeploy = function (ownServiceContext) {
-    let sgName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`MySQL - Executing UnPreDeploy on ${sgName}`);
+    let sgName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Executing UnPreDeploy on ${sgName}`);
 
-    return deployersCommon.deleteSecurityGroupForService(sgName)
+    return deletePhasesCommon.deleteSecurityGroupForService(sgName)
         .then(success => {
-            winston.info(`MySQL - Finished UnPreDeploy on ${sgName}`);
+            winston.info(`${SERVICE_NAME} - Finished UnPreDeploy on ${sgName}`);
             return new UnPreDeployContext(ownServiceContext);
         });
 }
 
 exports.unBind = function (ownServiceContext) {
-    let sgName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`MySQL - Executing UnBind on ${sgName}`);
+    let sgName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Executing UnBind on ${sgName}`);
 
-    return deployersCommon.unBindAllOnSg(sgName)
+    return deletePhasesCommon.unBindAllOnSg(sgName)
         .then(success => {
-            winston.info(`MySQL - Finished UnBind on ${sgName}`);
+            winston.info(`${SERVICE_NAME} - Finished UnBind on ${sgName}`);
             return new UnBindContext(ownServiceContext);
         });
 }
 
 exports.unDeploy = function (ownServiceContext) {
-    return deployersCommon.unDeployCloudFormationStack(ownServiceContext, 'MySQL')
+    return deletePhasesCommon.unDeployCloudFormationStack(ownServiceContext, SERVICE_NAME)
         .then(unDeployContext => {
             return rdsCommon.deleteParametersFromParameterStore(ownServiceContext, unDeployContext)
         });

--- a/lib/services/postgresql/index.js
+++ b/lib/services/postgresql/index.js
@@ -21,12 +21,15 @@ const PreDeployContext = require('../../datatypes/pre-deploy-context');
 const BindContext = require('../../datatypes/bind-context');
 const accountConfig = require('../../common/account-config')().getAccountConfig();
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
-const deployersCommon = require('../../common/deployers-common');
+const deployPhaseCommon = require('../../common/deploy-phase-common');
+const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
+const deletePhasesCommon = require('../../common/delete-phases-common');
 const rdsCommon = require('../../common/rds-common');
 const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../datatypes/un-bind-context');
 const uuid = require('uuid');
 
+const SERVICE_NAME = "PostgreSQL";
 const POSTGRES_PORT = 5432;
 const POSTGRES_PROTOCOL = 'tcp';
 
@@ -101,19 +104,19 @@ exports.check = function (serviceContext) {
     let serviceParams = serviceContext.params;
 
     if (!serviceParams.database_name) {
-        errors.push(`PostgreSQL - The 'database_name' parameter is required`);
+        errors.push(`${SERVICE_NAME} - The 'database_name' parameter is required`);
     }
 
     return errors;
 }
 
 exports.preDeploy = function (serviceContext) {
-    let sgName = deployersCommon.getResourceName(serviceContext);
-    winston.info(`PostgreSQL - Executing PreDeploy on ${sgName}`);
+    let sgName = deployPhaseCommon.getResourceName(serviceContext);
+    winston.info(`${SERVICE_NAME} - Executing PreDeploy on ${sgName}`);
 
-    return deployersCommon.createSecurityGroupForService(sgName, POSTGRES_PORT)
+    return preDeployPhaseCommon.createSecurityGroupForService(sgName, POSTGRES_PORT)
         .then(securityGroup => {
-            winston.info(`PostgreSQL - Finished PreDeploy on ${sgName}`);
+            winston.info(`${SERVICE_NAME} - Finished PreDeploy on ${sgName}`);
             let preDeployContext = new PreDeployContext(serviceContext);
             preDeployContext.securityGroups.push(securityGroup);
             return preDeployContext;
@@ -121,8 +124,8 @@ exports.preDeploy = function (serviceContext) {
 }
 
 exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    let stackName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`PostgreSQL - Executing Bind on ${stackName}`);
+    let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Executing Bind on ${stackName}`);
     let ownSg = ownPreDeployContext.securityGroups[0];
     let sourceSg = dependentOfPreDeployContext.securityGroups[0];
 
@@ -136,8 +139,8 @@ exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServ
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
-    let stackName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`PostgreSQL - Executing Deploy on ${stackName}`);
+    let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Executing Deploy on ${stackName}`);
 
     return getCompiledPostgresTemplate(stackName, ownServiceContext, ownPreDeployContext)
         .then(compiledTemplate => {
@@ -148,56 +151,56 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
                         let cfParameters = {
                             DBPassword: dbPassword
                         }
-                        winston.info(`PostgreSQL - Creating RDS instances '${stackName}'`);
+                        winston.info(`${SERVICE_NAME} - Creating RDS instances '${stackName}'`);
                         return cloudFormationCalls.createStack(stackName, compiledTemplate, cloudFormationCalls.getCfStyleStackParameters(cfParameters))
                             .then(deployedStack => {
                                 return rdsCommon.addDbCredentialToParameterStore(ownServiceContext, dbPassword, deployedStack);
                             });
                     }
                     else {
-                        winston.info(`PostgreSQL - Updates are not supported for this service.`);
+                        winston.info(`${SERVICE_NAME} - Updates are not supported for this service.`);
                         return stack;
                     }
                 });
         })
         .then(deployedStack => {
-            winston.info(`PostgreSQL - Finished deploying RDS instance '${stackName}'`)
+            winston.info(`${SERVICE_NAME} - Finished deploying RDS instance '${stackName}'`)
             return rdsCommon.getDeployContext(ownServiceContext, deployedStack);
         });
 }
 
 exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerServiceContext, producerDeployContext) {
-    return Promise.reject(new Error("The PostgreSQL service doesn't consume events from other services"));
+    return Promise.reject(new Error(`The ${SERVICE_NAME} service doesn't consume events from other services`));
 }
 
 exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext) {
-    return Promise.reject(new Error("The PostgreSQL service doesn't produce events for other services"));
+    return Promise.reject(new Error(`The ${SERVICE_NAME} service doesn't produce events for other services`));
 }
 
 exports.unPreDeploy = function (ownServiceContext) {
-    let sgName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`PostgreSQL - Executing UnPreDeploy on ${sgName}`);
+    let sgName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Executing UnPreDeploy on ${sgName}`);
 
-    return deployersCommon.deleteSecurityGroupForService(sgName)
+    return deletePhasesCommon.deleteSecurityGroupForService(sgName)
         .then(success => {
-            winston.info(`PostgreSQL - Finished UnPreDeploy on ${sgName}`);
+            winston.info(`${SERVICE_NAME} - Finished UnPreDeploy on ${sgName}`);
             return new UnPreDeployContext(ownServiceContext);
         });
 }
 
 exports.unBind = function (ownServiceContext) {
-    let sgName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`PostgreSQL - Executing UnBind on ${sgName}`);
+    let sgName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Executing UnBind on ${sgName}`);
 
-    return deployersCommon.unBindAllOnSg(sgName)
+    return deletePhasesCommon.unBindAllOnSg(sgName)
         .then(success => {
-            winston.info(`PostgreSQL - Finished UnBind on ${sgName}`);
+            winston.info(`${SERVICE_NAME} - Finished UnBind on ${sgName}`);
             return new UnBindContext(ownServiceContext);
         });
 }
 
 exports.unDeploy = function (ownServiceContext) {
-    return deployersCommon.unDeployCloudFormationStack(ownServiceContext, 'PostgreSQL')
+    return deletePhasesCommon.unDeployCloudFormationStack(ownServiceContext, SERVICE_NAME)
         .then(unDeployContext => {
             return rdsCommon.deleteParametersFromParameterStore(ownServiceContext, unDeployContext);
         });

--- a/lib/services/redis/index.js
+++ b/lib/services/redis/index.js
@@ -21,12 +21,15 @@ const BindContext = require('../../datatypes/bind-context');
 const DeployContext = require('../../datatypes/deploy-context');
 const accountConfig = require('../../common/account-config')().getAccountConfig();
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
-const deployersCommon = require('../../common/deployers-common');
+const deployPhaseCommon = require('../../common/deploy-phase-common');
+const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
+const deletePhasesCommon = require('../../common/delete-phases-common');
 const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../datatypes/un-bind-context');
 const handlebarsUtils = require('../../common/handlebars-utils');
 const uuid = require('uuid');
 
+const SERVICE_NAME = "Redis";
 const REDIS_PORT = 6379;
 const REDIS_SG_PROTOCOL = "tcp";
 
@@ -34,10 +37,10 @@ function getDeployContext(serviceContext, cfStack) {
     let deployContext = new DeployContext(serviceContext);
 
     // Set port and address environment variables
-    let portEnv = deployersCommon.getInjectedEnvVarName(serviceContext, 'PORT');
+    let portEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'PORT');
     let port = cloudFormationCalls.getOutput('CachePort', cfStack);
     deployContext.environmentVariables[portEnv] = port;
-    let addressEnv = deployersCommon.getInjectedEnvVarName(serviceContext, 'ADDRESS');
+    let addressEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'ADDRESS');
     let address = cloudFormationCalls.getOutput('CacheAddress', cfStack);
     deployContext.environmentVariables[addressEnv] = address;
     return deployContext;
@@ -145,26 +148,26 @@ exports.check = function (serviceContext) {
     let serviceParams = serviceContext.params;
 
     if (!serviceParams.instance_type) {
-        errors.push(`Redis - The 'instance_type' parameter is required`);
+        errors.push(`${SERVICE_NAME} - The 'instance_type' parameter is required`);
     }
     if (!serviceParams.redis_version) {
-        errors.push(`Redis - The 'redis_version' parameter is required`);
+        errors.push(`${SERVICE_NAME} - The 'redis_version' parameter is required`);
     }
 
     if (serviceParams.read_replicas) {
         if (serviceParams.read_replicas < 0 || serviceParams.read_replicas > 5) {
-            errors.push(`Redis - The 'read_replicas' parameter may only have a value of 0-5`);
+            errors.push(`${SERVICE_NAME} - The 'read_replicas' parameter may only have a value of 0-5`);
         }
         if (serviceParams.read_replicas > 0 && (serviceParams.instance_type.includes('t2') || serviceParams.instance_type.includes("t1"))) {
-            errors.push(`Redis - You may not use the 't1' and 't2' instance types when using any read replicas`);
+            errors.push(`${SERVICE_NAME} - You may not use the 't1' and 't2' instance types when using any read replicas`);
         }
     }
     // if(serviceParams.num_shards) {
     //     if(serviceParams.num_shards < 1 || serviceParams.num_shards > 15) {
-    //         errors.push(`Redis - The 'num_shards' parameter may only have a value of 1-15`);
+    //         errors.push(`${SERVICE_NAME} - The 'num_shards' parameter may only have a value of 1-15`);
     //     }
     //     if(serviceParams.num_shards > 1 && (serviceParams.redis_version.includes("2.6") || serviceParams.redis_version.includes('2.8'))) { //Cluster mode enabled
-    //         errors.push(`Redis - You may not use cluster mode (num_shards > 1) unless you are using version 3.2 or higher`);
+    //         errors.push(`${SERVICE_NAME} - You may not use cluster mode (num_shards > 1) unless you are using version 3.2 or higher`);
     //     }
     // }
 
@@ -172,12 +175,12 @@ exports.check = function (serviceContext) {
 }
 
 exports.preDeploy = function (serviceContext) {
-    let sgName = deployersCommon.getResourceName(serviceContext);
-    winston.info(`Redis - Executing PreDeploy on '${sgName}'`);
+    let sgName = deployPhaseCommon.getResourceName(serviceContext);
+    winston.info(`${SERVICE_NAME} - Executing PreDeploy on '${sgName}'`);
 
-    return deployersCommon.createSecurityGroupForService(sgName)
+    return preDeployPhaseCommon.createSecurityGroupForService(sgName)
         .then(securityGroup => {
-            winston.info(`Redis - Finished PreDeploy on '${sgName}'`);
+            winston.info(`${SERVICE_NAME} - Finished PreDeploy on '${sgName}'`);
             let preDeployContext = new PreDeployContext(serviceContext);
             preDeployContext.securityGroups.push(securityGroup);
             return preDeployContext;
@@ -185,64 +188,64 @@ exports.preDeploy = function (serviceContext) {
 }
 
 exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    let stackName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`Redis - Executing Bind on '${stackName}'`);
+    let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Executing Bind on '${stackName}'`);
     let ownSg = ownPreDeployContext.securityGroups[0];
     let sourceSg = dependentOfPreDeployContext.securityGroups[0];
 
     return ec2Calls.addIngressRuleToSgIfNotExists(sourceSg, ownSg, REDIS_SG_PROTOCOL, REDIS_PORT, REDIS_PORT, accountConfig.vpc)
         .then(() => {
-            winston.info(`Redis - Finished Bind on '${stackName}'`);
+            winston.info(`${SERVICE_NAME} - Finished Bind on '${stackName}'`);
             return new BindContext(ownServiceContext, dependentOfServiceContext);
         });
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
-    let stackName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`Redis - Executing Deploy on '${stackName}'`);
+    let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Executing Deploy on '${stackName}'`);
 
     return getCompiledRedisTemplate(stackName, ownServiceContext, ownPreDeployContext)
         .then(compiledTemplate => {
-            return deployersCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, "Redis");
+            return deployPhaseCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, SERVICE_NAME);
         })
         .then(deployedStack => {
-            winston.info(`Redis - Finished Deploy on '${stackName}'`);
+            winston.info(`${SERVICE_NAME} - Finished Deploy on '${stackName}'`);
             return getDeployContext(ownServiceContext, deployedStack)
         });
 }
 
 exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerServiceContext, producerDeployContext) {
-    return Promise.reject(new Error("The Redis service doesn't consume events from other services"));
+    return Promise.reject(new Error(`The ${SERVICE_NAME} service doesn't consume events from other services`));
 }
 
 exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext) {
-    return Promise.reject(new Error("The Redis service doesn't produce events for other services"));
+    return Promise.reject(new Error(`The ${SERVICE_NAME} service doesn't produce events for other services`));
 }
 
 exports.unPreDeploy = function (ownServiceContext) {
-    let sgName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`Redis - Executing UnPreDeploy on '${sgName}'`);
+    let sgName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Executing UnPreDeploy on '${sgName}'`);
 
-    return deployersCommon.deleteSecurityGroupForService(sgName)
+    return deletePhasesCommon.deleteSecurityGroupForService(sgName)
         .then(success => {
-            winston.info(`Redis - Finished UnPreDeploy on '${sgName}'`);
+            winston.info(`${SERVICE_NAME} - Finished UnPreDeploy on '${sgName}'`);
             return new UnPreDeployContext(ownServiceContext);
         });
 }
 
 exports.unBind = function (ownServiceContext) {
-    let sgName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`Redis - Executing UnBind on ${sgName}`);
+    let sgName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Executing UnBind on ${sgName}`);
 
-    return deployersCommon.unBindAllOnSg(sgName)
+    return deletePhasesCommon.unBindAllOnSg(sgName)
         .then(success => {
-            winston.info(`Redis - Finished UnBind on ${sgName}`);
+            winston.info(`${SERVICE_NAME} - Finished UnBind on ${sgName}`);
             return new UnBindContext(ownServiceContext);
         });
 }
 
 exports.unDeploy = function (ownServiceContext) {
-    return deployersCommon.unDeployCloudFormationStack(ownServiceContext, 'Redis');
+    return deletePhasesCommon.unDeployCloudFormationStack(ownServiceContext, SERVICE_NAME);
 }
 
 exports.producedEventsSupportedServices = [];

--- a/lib/services/s3/index.js
+++ b/lib/services/s3/index.js
@@ -20,11 +20,13 @@ const BindContext = require('../../datatypes/bind-context');
 const DeployContext = require('../../datatypes/deploy-context');
 const accountConfig = require('../../common/account-config')().getAccountConfig();
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
-const deployersCommon = require('../../common/deployers-common');
+const deployPhaseCommon = require('../../common/deploy-phase-common');
+const deletePhasesCommon = require('../../common/delete-phases-common');
 const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../datatypes/un-bind-context');
 const handlebarsUtils = require('../../common/handlebars-utils');
 
+const SERVICE_NAME = "S3";
 const VERSIONING_PARAM_MAPPING = {
     enabled: 'Enabled',
     disabled: 'Suspended'
@@ -35,11 +37,11 @@ function getDeployContext(serviceContext, cfStack) {
     let deployContext = new DeployContext(serviceContext);
 
     //Env variables to inject into consuming services
-    let bucketNameEnv = deployersCommon.getInjectedEnvVarName(serviceContext, 'BUCKET_NAME');
+    let bucketNameEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'BUCKET_NAME');
     deployContext.environmentVariables[bucketNameEnv] = bucketName;
-    let bucketUrlEnv = deployersCommon.getInjectedEnvVarName(serviceContext, "BUCKET_URL");
+    let bucketUrlEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, "BUCKET_URL");
     deployContext.environmentVariables[bucketUrlEnv] = `https://${bucketName}.s3.amazonaws.com/`
-    let regionEndpointEnv = deployersCommon.getInjectedEnvVarName(serviceContext, "REGION_ENDPOINT");
+    let regionEndpointEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, "REGION_ENDPOINT");
     deployContext.environmentVariables[regionEndpointEnv] = `s3-${accountConfig.region}.amazonaws.com`;
 
     //Need two policies for accessing S3. The first allows you to list the contents of the bucket,
@@ -102,56 +104,56 @@ exports.check = function (serviceContext) {
 
     let params = serviceContext.params;
     if (params.versioning && (params.versioning !== 'enabled' && params.versioning !== 'disabled')) {
-        errors.push("S3 - 'versioning' parameter must be either 'enabled' or 'disabled'");
+        errors.push(`${SERVICE_NAME} - 'versioning' parameter must be either 'enabled' or 'disabled'`);
     }
 
     return errors;
 }
 
 exports.preDeploy = function (serviceContext) {
-    winston.info(`S3 - PreDeploy is not required for this service, skipping it`);
+    winston.info(`${SERVICE_NAME} - PreDeploy is not required for this service, skipping it`);
     return Promise.resolve(new PreDeployContext(serviceContext));
 }
 
 exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    winston.info(`S3 - Bind is not required for this service, skipping it`);
+    winston.info(`${SERVICE_NAME} - Bind is not required for this service, skipping it`);
     return Promise.resolve(new BindContext(ownServiceContext, dependentOfServiceContext));
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
-    let stackName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`S3 - Deploying S3 bucket ${stackName}`);
+    let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Deploying S3 bucket ${stackName}`);
 
     return getCompiledS3Template(stackName, ownServiceContext)
         .then(compiledTemplate => {
-            return deployersCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, "S3");
+            return deployPhaseCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, SERVICE_NAME);
         })
         .then(createdOrUpdatedStack => {
-            winston.info(`S3 - Finished deploying S3 bucket ${stackName}`);
+            winston.info(`${SERVICE_NAME} - Finished deploying S3 bucket ${stackName}`);
             return getDeployContext(ownServiceContext, createdOrUpdatedStack);
         });
 }
 
 exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerServiceContext, producerDeployContext) {
-    return Promise.reject(new Error("The S3 service doesn't consume events from other services"));
+    return Promise.reject(new Error(`The ${SERVICE_NAME} service doesn't consume events from other services`));
 }
 
 exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext) {
-    return Promise.reject(new Error("The S3 service doesn't currently produce events for other services"));
+    return Promise.reject(new Error(`The ${SERVICE_NAME} service doesn't currently produce events for other services`));
 }
 
 exports.unPreDeploy = function (ownServiceContext) {
-    winston.info(`S3 - UnPreDeploy is not required for this service`);
+    winston.info(`${SERVICE_NAME} - UnPreDeploy is not required for this service`);
     return Promise.resolve(new UnPreDeployContext(ownServiceContext));
 }
 
 exports.unBind = function (ownServiceContext) {
-    winston.info(`S3 - UnBind is not required for this service`);
+    winston.info(`${SERVICE_NAME} - UnBind is not required for this service`);
     return Promise.resolve(new UnBindContext(ownServiceContext));
 }
 
 exports.unDeploy = function (ownServiceContext) {
-    return deployersCommon.unDeployCloudFormationStack(ownServiceContext, 'S3');
+    return deletePhasesCommon.unDeployCloudFormationStack(ownServiceContext, SERVICE_NAME);
 }
 
 exports.producedEventsSupportedServices = []; //TODO - No events supported yet, but we will support some like Lambda

--- a/lib/services/s3staticsite/index.js
+++ b/lib/services/s3staticsite/index.js
@@ -20,12 +20,14 @@ const PreDeployContext = require('../../datatypes/pre-deploy-context');
 const BindContext = require('../../datatypes/bind-context');
 const DeployContext = require('../../datatypes/deploy-context');
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
-const deployersCommon = require('../../common/deployers-common')
+const deployPhaseCommon = require('../../common/deploy-phase-common');
+const deletePhasesCommon = require('../../common/delete-phases-common');
 const accountConfig = require('../../common/account-config')().getAccountConfig();;
 const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../datatypes/un-bind-context');
 const handlebarsUtils = require('../../common/handlebars-utils');
 
+const SERVICE_NAME = "S3 Static Site";
 const VERSIONING_PARAM_MAPPING = {
     enabled: 'Enabled',
     disabled: 'Suspended'
@@ -65,7 +67,7 @@ function createLoggingBucketIfNotExists() {
 
     return handlebarsUtils.compileTemplate(`${__dirname}/s3-static-site-logging-bucket.yml`, handlebarsParams)
         .then(compiledTemplate => {
-            return deployersCommon.deployCloudFormationStack(stackName, compiledTemplate, [], false, "Logging Bucket for S3 Static Sites");
+            return deployPhaseCommon.deployCloudFormationStack(stackName, compiledTemplate, [], false, "Logging Bucket for S3 Static Sites");
         })
         .then(deployedStack => {
             return cloudFormationCalls.getOutput("BucketName", deployedStack);
@@ -83,69 +85,69 @@ exports.check = function (serviceContext) {
     let serviceParams = serviceContext.params;
 
     if (!serviceParams.path_to_code) {
-        errors.push(`S3 Static Site - The 'path_to_code' parameter is required`);
+        errors.push(`${SERVICE_NAME} - The 'path_to_code' parameter is required`);
     }
 
     return errors;
 }
 
 exports.preDeploy = function (serviceContext) {
-    winston.info(`S3 Static Site - PreDeploy is not required for this service, skipping it`);
+    winston.info(`${SERVICE_NAME} - PreDeploy is not required for this service, skipping it`);
     return Promise.resolve(new PreDeployContext(serviceContext));
 }
 
 exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    winston.info(`S3 Static Site - Bind is not required for this service, skipping it`);
+    winston.info(`${SERVICE_NAME} - Bind is not required for this service, skipping it`);
     return Promise.resolve(new BindContext(ownServiceContext, dependentOfServiceContext));
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
-    let stackName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`S3 Static Site - Deploying S3 static website ${stackName}`);
+    let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Deploying S3 static website '${stackName}'`);
 
     return createLoggingBucketIfNotExists()
         .then(loggingBucketName => {
             return getCompiledS3Template(ownServiceContext, stackName, loggingBucketName)
         })
         .then(compiledTemplate => {
-            return deployersCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, "S3 Static Site");
+            return deployPhaseCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, SERVICE_NAME);
         })
         .then(createdOrUpdatedStack => {
             let bucketName = cloudFormationCalls.getOutput("BucketName", createdOrUpdatedStack);
             //Upload files from path_to_website to S3
-            winston.info(`Uploading code files to static site '${stackName}'`);
+            winston.info(`${SERVICE_NAME} - Uploading code files to static site '${stackName}'`);
             return s3Calls.uploadDirectory(bucketName, "", ownServiceContext.params.path_to_code)
                 .then(() => {
-                    winston.info(`Finished uploading code files to static site '${stackName}'`);
+                    winston.info(`${SERVICE_NAME} - Finished uploading code files to static site '${stackName}'`);
                     return createdOrUpdatedStack;
                 });
         })
         .then(createdOrUpdatedStack => {
-            winston.info(`S3 Static Site - Finished deploying S3 static site '${stackName}'`);
+            winston.info(`${SERVICE_NAME} - Finished deploying S3 static site '${stackName}'`);
             return new DeployContext(ownServiceContext);
         });
 }
 
 exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerServiceContext, producerDeployContext) {
-    return Promise.reject(new Error("The S3 Static Site service doesn't consume events from other services"));
+    return Promise.reject(new Error(`The ${SERVICE_NAME} service doesn't consume events from other services`));
 }
 
 exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext) {
-    return Promise.reject(new Error("The S3 Static Site service doesn't produce events for other services"));
+    return Promise.reject(new Error(`The ${SERVICE_NAME} service doesn't produce events for other services`));
 }
 
 exports.unPreDeploy = function (ownServiceContext) {
-    winston.info(`S3 Static Site - UnPreDeploy is not required for this service`);
+    winston.info(`${SERVICE_NAME} - UnPreDeploy is not required for this service`);
     return Promise.resolve(new UnPreDeployContext(ownServiceContext));
 }
 
 exports.unBind = function (ownServiceContext) {
-    winston.info(`S3 Static Site - UnBind is not required for this service`);
+    winston.info(`${SERVICE_NAME} - UnBind is not required for this service`);
     return Promise.resolve(new UnBindContext(ownServiceContext));
 }
 
 exports.unDeploy = function (ownServiceContext) {
-    return deployersCommon.unDeployCloudFormationStack(ownServiceContext, 'S3 Static Site');
+    return deletePhasesCommon.unDeployCloudFormationStack(ownServiceContext, SERVICE_NAME);
 }
 
 exports.producedEventsSupportedServices = [];

--- a/lib/services/sns/index.js
+++ b/lib/services/sns/index.js
@@ -22,12 +22,14 @@ const ProduceEventsContext = require('../../datatypes/produce-events-context');
 const DeployContext = require('../../datatypes/deploy-context');
 const snsCalls = require('../../aws/sns-calls');
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
-const deployersCommon = require('../../common/deployers-common');
+const deployPhaseCommon = require('../../common/deploy-phase-common');
+const deletePhasesCommon = require('../../common/delete-phases-common');
 const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../datatypes/un-bind-context');
 
-function getCompiledSnsTemplate(stackName, serviceContext) {
-    let serviceParams = serviceContext.params;
+const SERVICE_NAME = "SNS";
+
+function getCompiledSnsTemplate(stackName) {
     let handlebarsParams = {
         topicName: stackName
     };
@@ -44,9 +46,9 @@ function getDeployContext(serviceContext, cfStack) {
     deployContext.eventOutputs.principal = "sns.amazonaws.com";
 
     //Env variables to inject into consuming services
-    let topicArnEnv = deployersCommon.getInjectedEnvVarName(serviceContext, 'TOPIC_ARN');
+    let topicArnEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'TOPIC_ARN');
     deployContext.environmentVariables[topicArnEnv] = topicArn;
-    let topicNameEnv = deployersCommon.getInjectedEnvVarName(serviceContext, "TOPIC_NAME");
+    let topicNameEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, "TOPIC_NAME");
     deployContext.environmentVariables[topicNameEnv] = topicName;
 
     //Policy to talk to this queue
@@ -90,36 +92,36 @@ exports.check = function (serviceContext) {
 }
 
 exports.preDeploy = function (serviceContext) {
-    winston.info(`SNS - PreDeploy is not required for this service, skipping it`);
+    winston.info(`${SERVICE_NAME} - PreDeploy is not required for this service, skipping it`);
     return Promise.resolve(new PreDeployContext(serviceContext));
 }
 
 exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    winston.info(`SNS - Bind is not required for this service, skipping it`);
+    winston.info(`${SERVICE_NAME} - Bind is not required for this service, skipping it`);
     return Promise.resolve(new BindContext(ownServiceContext, dependentOfServiceContext));
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
-    let stackName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`SNS - Executing Deploy on ${stackName}`);
+    let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Executing Deploy on ${stackName}`);
 
-    return getCompiledSnsTemplate(stackName, ownServiceContext)
+    return getCompiledSnsTemplate(stackName)
         .then(compiledSnsTemplate => {
-            return deployersCommon.deployCloudFormationStack(stackName, compiledSnsTemplate, [], true, "SNS");
+            return deployPhaseCommon.deployCloudFormationStack(stackName, compiledSnsTemplate, [], true, SERVICE_NAME);
         })
         .then(deployedStack => {
-            winston.info(`SNS - Finished deploying SNS topic ${stackName}`);
+            winston.info(`${SERVICE_NAME} - Finished deploying SNS topic ${stackName}`);
             return getDeployContext(ownServiceContext, deployedStack);
         });
 }
 
 exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerServiceContext, producerDeployContext) {
-    return Promise.reject(new Error("The SNS service doesn't consume events from other services"));
+    return Promise.reject(new Error(`The ${SERVICE_NAME} service doesn't consume events from other services`));
 }
 
 exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext) {
     return new Promise((resolve, reject) => {
-        winston.info(`SNS - Producing events from ${ownServiceContext.serviceName} for consumer ${consumerServiceContext.serviceName}`);
+        winston.info(`${SERVICE_NAME} - Producing events from ${ownServiceContext.serviceName} for consumer ${consumerServiceContext.serviceName}`);
         //Add subscription to sns service
         let topicArn = ownDeployContext.eventOutputs.topicArn;
         let consumerServiceType = consumerServiceContext.serviceType;
@@ -134,29 +136,29 @@ exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerS
             endpoint = consumerDeployContext.eventOutputs.queueArn;
         }
         else {
-            return reject(new Error(`SNS - Unsupported event consumer type given: ${consumerServiceType}`));
+            return reject(new Error(`${SERVICE_NAME} - Unsupported event consumer type given: ${consumerServiceType}`));
         }
 
         return snsCalls.subscribeToTopic(topicArn, protocol, endpoint)
             .then(subscriptionArn => {
-                winston.info(`SNS - Configured production of events from ${ownServiceContext.serviceName} for consumer ${consumerServiceContext.serviceName}`);
+                winston.info(`${SERVICE_NAME} - Configured production of events from ${ownServiceContext.serviceName} for consumer ${consumerServiceContext.serviceName}`);
                 return resolve(new ProduceEventsContext(ownServiceContext, consumerServiceContext));
             });
     });
 }
 
 exports.unPreDeploy = function (ownServiceContext) {
-    winston.info(`SNS - UnPreDeploy is not required for this service`);
+    winston.info(`${SERVICE_NAME} - UnPreDeploy is not required for this service`);
     return Promise.resolve(new UnPreDeployContext(ownServiceContext));
 }
 
 exports.unBind = function (ownServiceContext) {
-    winston.info(`SNS - UnBind is not required for this service`);
+    winston.info(`${SERVICE_NAME} - UnBind is not required for this service`);
     return Promise.resolve(new UnBindContext(ownServiceContext));
 }
 
 exports.unDeploy = function (ownServiceContext) {
-    return deployersCommon.unDeployCloudFormationStack(ownServiceContext, 'SNS');
+    return deletePhasesCommon.unDeployCloudFormationStack(ownServiceContext, SERVICE_NAME);
 }
 
 exports.producedEventsSupportedServices = [

--- a/lib/services/sqs/index.js
+++ b/lib/services/sqs/index.js
@@ -23,8 +23,11 @@ const ConsumeEventsContext = require('../../datatypes/consume-events-context');
 const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../datatypes/un-bind-context');
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
-const deployersCommon = require('../../common/deployers-common');
+const deployPhaseCommon = require('../../common/deploy-phase-common');
+const deletePhasesCommon = require('../../common/delete-phases-common');
 const sqsCalls = require('../../aws/sqs-calls');
+
+const SERVICE_NAME = "SQS";
 
 function getCompiledSqsTemplate(stackName, serviceContext) {
     let serviceParams = serviceContext.params;
@@ -70,11 +73,11 @@ function getDeployContext(serviceContext, cfStack) {
     let deployContext = new DeployContext(serviceContext);
 
     //Env variables to inject into consuming services
-    let queueNameEnv = deployersCommon.getInjectedEnvVarName(serviceContext, 'QUEUE_NAME');
+    let queueNameEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'QUEUE_NAME');
     deployContext.environmentVariables[queueNameEnv] = queueName;
-    let queueArnEnv = deployersCommon.getInjectedEnvVarName(serviceContext, "QUEUE_ARN");
+    let queueArnEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, "QUEUE_ARN");
     deployContext.environmentVariables[queueArnEnv] = queueArn;
-    let queueUrlEnv = deployersCommon.getInjectedEnvVarName(serviceContext, "QUEUE_URL");
+    let queueUrlEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, "QUEUE_URL");
     deployContext.environmentVariables[queueUrlEnv] = queueUrl;
 
     //Add event outputs for event consumption
@@ -132,32 +135,32 @@ exports.check = function (serviceContext) {
 }
 
 exports.preDeploy = function (serviceContext) {
-    winston.info(`SQS - PreDeploy is not required for this service, skipping it`);
+    winston.info(`${SERVICE_NAME} - PreDeploy is not required for this service, skipping it`);
     return Promise.resolve(new PreDeployContext(serviceContext));
 }
 
 exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    winston.info(`SQS - Bind is not required for this service, skipping it`);
+    winston.info(`${SERVICE_NAME} - Bind is not required for this service, skipping it`);
     return Promise.resolve(new BindContext(ownServiceContext, dependentOfServiceContext));
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
-    let stackName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`SQS - Executing Deploy on ${stackName}`);
+    let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Executing Deploy on ${stackName}`);
 
     return getCompiledSqsTemplate(stackName, ownServiceContext)
         .then(sqsTemplate => {
-            return deployersCommon.deployCloudFormationStack(stackName, sqsTemplate, [], true, "SQS");
+            return deployPhaseCommon.deployCloudFormationStack(stackName, sqsTemplate, [], true, SERVICE_NAME);
         })
         .then(deployedStack => {
-            winston.info(`SQS - Finished deploying SQS queue ${stackName}`);
+            winston.info(`${SERVICE_NAME} - Finished deploying SQS queue ${stackName}`);
             return getDeployContext(ownServiceContext, deployedStack);
         });
 }
 
 exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerServiceContext, producerDeployContext) {
     return new Promise((resolve, reject) => {
-        winston.info(`SQS - Consuming events from service '${producerServiceContext.serviceName}' for service '${ownServiceContext.serviceName}'`);
+        winston.info(`${SERVICE_NAME} - Consuming events from service '${producerServiceContext.serviceName}' for service '${ownServiceContext.serviceName}'`);
         let queueUrl = ownDeployContext.eventOutputs.queueUrl;
         let queueArn = ownDeployContext.eventOutputs.queueArn;
         let producerServiceType = producerServiceContext.serviceType;
@@ -166,7 +169,7 @@ exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerS
             producerArn = producerDeployContext.eventOutputs.topicArn;
         }
         else {
-            return reject(new Error(`SQS - Unsupported event producer type given: ${producerServiceType}`));
+            return reject(new Error(`${SERVICE_NAME} - Unsupported event producer type given: ${producerServiceType}`));
         }
 
         let policyStatement = getPolicyStatementForSqsEventConsumption(queueArn, producerArn);
@@ -174,28 +177,28 @@ exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerS
         //Add SQS permission
         return sqsCalls.addSqsPermissionIfNotExists(queueUrl, queueArn, producerArn, policyStatement)
             .then(permissionStatement => {
-                winston.info(`SQS - Allowed consuming events from '${producerServiceContext.serviceName}' for '${ownServiceContext.serviceName}'`);
+                winston.info(`${SERVICE_NAME} - Allowed consuming events from '${producerServiceContext.serviceName}' for '${ownServiceContext.serviceName}'`);
                 return resolve(new ConsumeEventsContext(ownServiceContext, producerServiceContext));
             });
     });
 }
 
 exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext) {
-    return Promise.reject(new Error("The SQS service doesn't produce events for other services"));
+    return Promise.reject(new Error(`The ${SERVICE_NAME} service doesn't produce events for other services`));
 }
 
 exports.unPreDeploy = function (ownServiceContext) {
-    winston.info(`SQS - UnPreDeploy is not required for this service`);
+    winston.info(`${SERVICE_NAME} - UnPreDeploy is not required for this service`);
     return Promise.resolve(new UnPreDeployContext(ownServiceContext));
 }
 
 exports.unBind = function (ownServiceContext) {
-    winston.info(`SQS - UnBind is not required for this service`);
+    winston.info(`${SERVICE_NAME} - UnBind is not required for this service`);
     return Promise.resolve(new UnBindContext(ownServiceContext));
 }
 
 exports.unDeploy = function (ownServiceContext) {
-    return deployersCommon.unDeployCloudFormationStack(ownServiceContext, 'SQS');
+    return deletePhasesCommon.unDeployCloudFormationStack(ownServiceContext, SERVICE_NAME);
 }
 
 exports.producedEventsSupportedServices = [];

--- a/test/common/delete-phases-common-test.js
+++ b/test/common/delete-phases-common-test.js
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const ServiceContext = require('../../lib/datatypes/service-context');
+const UnDeployContext = require('../../lib/datatypes/un-deploy-context');
+const deletePhasesCommon = require('../../lib/common/delete-phases-common');
+const cloudformationCalls = require('../../lib/aws/cloudformation-calls');
+const ec2Calls = require('../../lib/aws/ec2-calls');
+const sinon = require('sinon');
+const expect = require('chai').expect;
+
+describe('Delete phases common module', function () {
+    let sandbox;
+
+    beforeEach(function () {
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    describe('unBindAllOnSg', function () {
+        it('should remove all ingress from the given security group', function () {
+            let removeIngressStub = sandbox.stub(ec2Calls, 'removeAllIngressFromSg').returns(Promise.resolve({}));
+
+            return deletePhasesCommon.unBindAllOnSg('FakeStack')
+                .then(success => {
+                    expect(success).to.be.true;
+                    expect(removeIngressStub.calledOnce).to.be.true;
+                });
+        });
+    });
+
+    describe('deleteSecurityGroupForService', function () {
+        it('should delete the stack if it exists', function () {
+            let getStackStub = sandbox.stub(cloudformationCalls, 'getStack').returns(Promise.resolve({}));
+            let deleteStackStub = sandbox.stub(cloudformationCalls, 'deleteStack').returns(Promise.resolve(true));
+
+            return deletePhasesCommon.deleteSecurityGroupForService("FakeStack")
+                .then(success => {
+                    expect(success).to.be.true;
+                    expect(getStackStub.calledOnce).to.be.true;
+                    expect(deleteStackStub.calledOnce).to.be.true;
+                });
+        });
+
+        it('should return true if the stack is already deleted', function () {
+            let getStackStub = sandbox.stub(cloudformationCalls, 'getStack').returns(Promise.resolve(null));
+            let deleteStackStub = sandbox.stub(cloudformationCalls, 'deleteStack').returns(Promise.resolve(true));
+
+            return deletePhasesCommon.deleteSecurityGroupForService("FakeStack")
+                .then(success => {
+                    expect(success).to.be.true;
+                    expect(getStackStub.calledOnce).to.be.true;
+                    expect(deleteStackStub.notCalled).to.be.true;
+                });
+        })
+    });
+
+    describe('unDeployCloudFormationStack', function () {
+        it('should delete the stack if it exists', function () {
+            let getStackStub = sandbox.stub(cloudformationCalls, 'getStack').returns(Promise.resolve({}));
+            let deleteStackStub = sandbox.stub(cloudformationCalls, 'deleteStack').returns(Promise.resolve(true));
+
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "dynamodb", "1", {});
+            return deletePhasesCommon.unDeployCloudFormationStack(serviceContext, "DynamoDB")
+                .then(unDeployContext => {
+                    expect(unDeployContext).to.be.instanceof(UnDeployContext);
+                    expect(getStackStub.calledOnce).to.be.true;
+                    expect(deleteStackStub.calledOnce).to.be.true;
+                });
+        });
+
+        it('should suceed even if the stack has been deleted', function () {
+            let getStackStub = sandbox.stub(cloudformationCalls, 'getStack').returns(Promise.resolve(null));
+            let deleteStackStub = sandbox.stub(cloudformationCalls, 'deleteStack').returns(Promise.resolve(true));
+
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "dynamodb", "1", {});
+            return deletePhasesCommon.unDeployCloudFormationStack(serviceContext, "DynamoDB")
+                .then(unDeployContext => {
+                    expect(unDeployContext).to.be.instanceof(UnDeployContext);
+                    expect(getStackStub.calledOnce).to.be.true;
+                    expect(deleteStackStub.notCalled).to.be.true;
+                });
+        });
+    });
+
+});

--- a/test/common/deploy-phase-common-test.js
+++ b/test/common/deploy-phase-common-test.js
@@ -17,7 +17,7 @@
 const ServiceContext = require('../../lib/datatypes/service-context');
 const DeployContext = require('../../lib/datatypes/deploy-context');
 const UnDeployContext = require('../../lib/datatypes/un-deploy-context');
-const deployersCommon = require('../../lib/common/deployers-common');
+const deployPhaseCommon = require('../../lib/common/deploy-phase-common');
 const iamCalls = require('../../lib/aws/iam-calls');
 const s3Calls = require('../../lib/aws/s3-calls');
 const cloudformationCalls = require('../../lib/aws/cloudformation-calls');
@@ -27,7 +27,7 @@ const fs = require('fs');
 const sinon = require('sinon');
 const expect = require('chai').expect;
 
-describe('deployers-common', function () {
+describe('Deploy phase common module', function () {
     let sandbox;
 
     beforeEach(function () {
@@ -41,7 +41,7 @@ describe('deployers-common', function () {
     describe('getInjectedEnvVarName', function () {
         it('should return the environment variable name from the given ServiceContext and suffix', function () {
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
-            let envVarName = deployersCommon.getInjectedEnvVarName(serviceContext, "SOME_INFO");
+            let envVarName = deployPhaseCommon.getInjectedEnvVarName(serviceContext, "SOME_INFO");
             expect(envVarName).to.equal("FAKETYPE_FAKEAPP_FAKEENV_FAKESERVICE_SOME_INFO");
         });
     });
@@ -53,7 +53,7 @@ describe('deployers-common', function () {
             let serviceName = "FakeService";
             let deployVersion = "1";
             let serviceContext = new ServiceContext(appName, envName, serviceName, "apigateway", deployVersion, {});
-            let returnEnvVars = deployersCommon.getEnvVarsFromServiceContext(serviceContext);
+            let returnEnvVars = deployPhaseCommon.getEnvVarsFromServiceContext(serviceContext);
             expect(returnEnvVars['HANDEL_APP_NAME']).to.equal(appName);
             expect(returnEnvVars['HANDEL_ENVIRONMENT_NAME']).to.equal(envName);
             expect(returnEnvVars['HANDEL_SERVICE_NAME']).to.equal(serviceName);
@@ -78,7 +78,7 @@ describe('deployers-common', function () {
             deployContext2.environmentVariables[envVarName2] = envVarValue2;
             deployContexts.push(deployContext2);
 
-            let returnVars = deployersCommon.getEnvVarsFromDependencyDeployContexts(deployContexts);
+            let returnVars = deployPhaseCommon.getEnvVarsFromDependencyDeployContexts(deployContexts);
 
             expect(returnVars[envVarName1]).to.equal(envVarValue1);
             expect(returnVars[envVarName2]).to.equal(envVarValue2);
@@ -94,7 +94,7 @@ describe('deployers-common', function () {
             let attachPolicyStub = sandbox.stub(iamCalls, 'attachPolicyToRole').returns(Promise.resolve({}));
             let getRoleStub = sandbox.stub(iamCalls, 'getRole').returns(Promise.resolve(null));
 
-            return deployersCommon.createCustomRole("ecs.amazonaws.com", "MyRole", [{}])
+            return deployPhaseCommon.createCustomRole("ecs.amazonaws.com", "MyRole", [{}])
                 .then(role => {
                     expect(getRoleStub.calledTwice).to.be.true;
                     expect(createRoleStub.calledOnce).to.be.true;
@@ -107,7 +107,7 @@ describe('deployers-common', function () {
             let createRoleStub = sandbox.stub(iamCalls, 'createRoleIfNotExists').returns(Promise.resolve({}));
             let getRoleStub = sandbox.stub(iamCalls, 'getRole').returns(Promise.resolve({}));
 
-            return deployersCommon.createCustomRole("ecs.amazonaws.com", "MyRole", [])
+            return deployPhaseCommon.createCustomRole("ecs.amazonaws.com", "MyRole", [])
                 .then(role => {
                     expect(getRoleStub.calledOnce).to.be.true;
                     expect(createRoleStub.notCalled).to.be.true;
@@ -155,98 +155,16 @@ describe('deployers-common', function () {
             });
             dependenciesDeployContexts.push(dependencyDeployContext);
 
-            let policyStatements = deployersCommon.getAllPolicyStatementsForServiceRole(ownServicePolicyStatements, dependenciesDeployContexts);
+            let policyStatements = deployPhaseCommon.getAllPolicyStatementsForServiceRole(ownServicePolicyStatements, dependenciesDeployContexts);
             expect(policyStatements.length).to.equal(2);
         });
-    });
-
-    describe('createSecurityGroupForService', function () {
-        it('should create the security group when it doesnt exist', function () {
-            let sgName = "FakeSg";
-
-            let getStackStub = sandbox.stub(cloudformationCalls, 'getStack').returns(Promise.resolve(null));
-            let createStackStub = sandbox.stub(cloudformationCalls, 'createStack').returns(Promise.resolve({
-                Outputs: [{
-                    OutputKey: "GroupId",
-                    OutputValue: "SomeId"
-                }]
-            }))
-            let getSecurityGroupByIdStub = sandbox.stub(ec2Calls, 'getSecurityGroupById').returns(Promise.resolve({}));
-
-            return deployersCommon.createSecurityGroupForService(sgName, 22)
-                .then(securityGroup => {
-                    expect(securityGroup).to.deep.equal({});
-                    expect(getStackStub.calledOnce).to.be.true;
-                    expect(createStackStub.calledOnce).to.be.true;
-                    expect(getSecurityGroupByIdStub.calledOnce).to.be.true;
-                });
-        });
-
-        it('should update the security group when it exists', function () {
-            let sgName = "FakeSg";
-
-            let getStackStub = sandbox.stub(cloudformationCalls, 'getStack').returns(Promise.resolve({}));
-            let updateStackStub = sandbox.stub(cloudformationCalls, 'updateStack').returns(Promise.resolve({
-                Outputs: [{
-                    OutputKey: "GroupId",
-                    OutputValue: "SomeId"
-                }]
-            }))
-            let getSecurityGroupByIdStub = sandbox.stub(ec2Calls, 'getSecurityGroupById').returns(Promise.resolve({}));
-
-            return deployersCommon.createSecurityGroupForService(sgName, 22)
-                .then(securityGroup => {
-                    expect(securityGroup).to.deep.equal({});
-                    expect(getStackStub.calledOnce).to.be.true;
-                    expect(updateStackStub.calledOnce).to.be.true;
-                    expect(getSecurityGroupByIdStub.calledOnce).to.be.true;
-                });
-        });
-    });
-
-    describe('unBindAllOnSg', function () {
-        it('should remove all ingress from the given security group', function () {
-            let removeIngressStub = sandbox.stub(ec2Calls, 'removeAllIngressFromSg').returns(Promise.resolve({}));
-
-            return deployersCommon.unBindAllOnSg('FakeStack')
-                .then(success => {
-                    expect(success).to.be.true;
-                    expect(removeIngressStub.calledOnce).to.be.true;
-                });
-        });
-    });
-
-    describe('deleteSecurityGroupForService', function () {
-        it('should delete the stack if it exists', function () {
-            let getStackStub = sandbox.stub(cloudformationCalls, 'getStack').returns(Promise.resolve({}));
-            let deleteStackStub = sandbox.stub(cloudformationCalls, 'deleteStack').returns(Promise.resolve(true));
-
-            return deployersCommon.deleteSecurityGroupForService("FakeStack")
-                .then(success => {
-                    expect(success).to.be.true;
-                    expect(getStackStub.calledOnce).to.be.true;
-                    expect(deleteStackStub.calledOnce).to.be.true;
-                });
-        });
-
-        it('should return true if the stack is already deleted', function () {
-            let getStackStub = sandbox.stub(cloudformationCalls, 'getStack').returns(Promise.resolve(null));
-            let deleteStackStub = sandbox.stub(cloudformationCalls, 'deleteStack').returns(Promise.resolve(true));
-
-            return deployersCommon.deleteSecurityGroupForService("FakeStack")
-                .then(success => {
-                    expect(success).to.be.true;
-                    expect(getStackStub.calledOnce).to.be.true;
-                    expect(deleteStackStub.notCalled).to.be.true;
-                });
-        })
     });
 
     describe('deployCloudFormationStack', function() {
         it('should create the stack if it doesnt exist yet', function() {
             let getStackStub = sandbox.stub(cloudformationCalls, 'getStack').returns(Promise.resolve(null));
             let createStackStub = sandbox.stub(cloudformationCalls, 'createStack').returns(Promise.resolve({}));
-            return deployersCommon.deployCloudFormationStack("FakeStack", "", [], true, "FakeService")
+            return deployPhaseCommon.deployCloudFormationStack("FakeStack", "", [], true, "FakeService")
                 .then(deployedStack => {
                     expect(deployedStack).to.deep.equal({});
                     expect(getStackStub.callCount).to.equal(1);
@@ -257,7 +175,7 @@ describe('deployers-common', function () {
         it('should update the stack if it exists and updates are supported', function() {
             let getStackStub = sandbox.stub(cloudformationCalls, 'getStack').returns(Promise.resolve({}));
             let updateStackStub = sandbox.stub(cloudformationCalls, 'updateStack').returns(Promise.resolve({}));
-            return deployersCommon.deployCloudFormationStack("FakeStack", "", [], true, "FakeService")
+            return deployPhaseCommon.deployCloudFormationStack("FakeStack", "", [], true, "FakeService")
                 .then(deployedStack => {
                     expect(deployedStack).to.deep.equal({});
                     expect(getStackStub.callCount).to.equal(1);
@@ -268,67 +186,12 @@ describe('deployers-common', function () {
         it('should just return the stack if it exists and updates are not supported', function() {
             let getStackStub = sandbox.stub(cloudformationCalls, 'getStack').returns(Promise.resolve({}));
             let updateStackStub = sandbox.stub(cloudformationCalls, 'updateStack').returns(Promise.resolve(null));
-            return deployersCommon.deployCloudFormationStack("FakeStack", "", [], false, "FakeService")
+            return deployPhaseCommon.deployCloudFormationStack("FakeStack", "", [], false, "FakeService")
                 .then(deployedStack => {
                     expect(deployedStack).to.deep.equal({});
                     expect(getStackStub.callCount).to.equal(1);
                     expect(updateStackStub.callCount).to.equal(0);
                 });
-        });
-    });
-
-    describe('unDeployCloudFormationStack', function () {
-        it('should delete the stack if it exists', function () {
-            let getStackStub = sandbox.stub(cloudformationCalls, 'getStack').returns(Promise.resolve({}));
-            let deleteStackStub = sandbox.stub(cloudformationCalls, 'deleteStack').returns(Promise.resolve(true));
-
-            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "dynamodb", "1", {});
-            return deployersCommon.unDeployCloudFormationStack(serviceContext, "DynamoDB")
-                .then(unDeployContext => {
-                    expect(unDeployContext).to.be.instanceof(UnDeployContext);
-                    expect(getStackStub.calledOnce).to.be.true;
-                    expect(deleteStackStub.calledOnce).to.be.true;
-                });
-        });
-
-        it('should suceed even if the stack has been deleted', function () {
-            let getStackStub = sandbox.stub(cloudformationCalls, 'getStack').returns(Promise.resolve(null));
-            let deleteStackStub = sandbox.stub(cloudformationCalls, 'deleteStack').returns(Promise.resolve(true));
-
-            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "dynamodb", "1", {});
-            return deployersCommon.unDeployCloudFormationStack(serviceContext, "DynamoDB")
-                .then(unDeployContext => {
-                    expect(unDeployContext).to.be.instanceof(UnDeployContext);
-                    expect(getStackStub.calledOnce).to.be.true;
-                    expect(deleteStackStub.notCalled).to.be.true;
-                });
-        });
-    })
-
-    describe('getRoutingInformationForService', function () {
-        it('should return null if no routing info defined in the given ServiceContext', function () {
-            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
-
-            let routingInfo = deployersCommon.getRoutingInformationForService(serviceContext);
-            expect(routingInfo).to.be.null;
-        })
-
-        it('should return routing information when defined in the given ServiceContext', function () {
-            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {
-                routing: {
-                    type: 'https',
-                    timeout: 59,
-                    health_check_path: '/healthcheck/heartbeat',
-                    https_certificate: 'SomeCert'
-                }
-            });
-
-            let routingInfo = deployersCommon.getRoutingInformationForService(serviceContext);
-            expect(routingInfo).to.not.be.null;
-            expect(routingInfo.type).to.equal('https');
-            expect(routingInfo.timeout).to.equal(59);
-            expect(routingInfo.healthCheckPath).to.equal('/healthcheck/heartbeat');
-            expect(routingInfo.httpsCertificate).to.contain('SomeCert');
         });
     });
 
@@ -343,7 +206,7 @@ describe('deployers-common', function () {
             let uploadFileStub = sandbox.stub(s3Calls, 'uploadFile').returns({});
             let cleanupOldVersionsStub = sandbox.stub(s3Calls, 'cleanupOldVersionsOfFiles').returns(Promise.resolve(null));
 
-            return deployersCommon.uploadFileToHandelBucket(serviceContext, diskFilePath, s3FileName)
+            return deployPhaseCommon.uploadFileToHandelBucket(serviceContext, diskFilePath, s3FileName)
                 .then(s3ObjectInfo => {
                     expect(createBucketStub.calledOnce).to.be.true;
                     expect(uploadFileStub.calledOnce).to.be.true;
@@ -360,9 +223,9 @@ describe('deployers-common', function () {
             });
             let s3FileName = "FakeS3Filename";
 
-            let uploadFileToHandelBucketStub = sandbox.stub(deployersCommon, 'uploadFileToHandelBucket').returns(Promise.resolve({}));
+            let uploadFileToHandelBucketStub = sandbox.stub(deployPhaseCommon, 'uploadFileToHandelBucket').returns(Promise.resolve({}));
 
-            return deployersCommon.uploadDeployableArtifactToHandelBucket(serviceContext, s3FileName)
+            return deployPhaseCommon.uploadDeployableArtifactToHandelBucket(serviceContext, s3FileName)
                 .then(s3ObjectInfo => {
                     expect(uploadFileToHandelBucketStub.calledOnce).to.be.true;
                     expect(s3ObjectInfo).to.deep.equal({});
@@ -376,10 +239,10 @@ describe('deployers-common', function () {
             let s3FileName = "FakeS3Filename";
 
             let zipDirectoryToFileStub = sandbox.stub(util, 'zipDirectoryToFile').returns(Promise.resolve({}));
-            let uploadFileToHandelBucketStub = sandbox.stub(deployersCommon, 'uploadFileToHandelBucket').returns(Promise.resolve({}));
+            let uploadFileToHandelBucketStub = sandbox.stub(deployPhaseCommon, 'uploadFileToHandelBucket').returns(Promise.resolve({}));
             let unlinkSyncStub = sandbox.stub(fs, 'unlinkSync').returns(null);
 
-            return deployersCommon.uploadDeployableArtifactToHandelBucket(serviceContext, s3FileName)
+            return deployPhaseCommon.uploadDeployableArtifactToHandelBucket(serviceContext, s3FileName)
                 .then(s3ObjectInfo => {
                     expect(zipDirectoryToFileStub.calledOnce).to.be.true;
                     expect(uploadFileToHandelBucketStub.calledOnce).to.be.true;
@@ -395,7 +258,7 @@ describe('deployers-common', function () {
             let envName = "FakeEnv";
             let serviceName = "FakeService";
             let serviceContext = new ServiceContext(appName, envName, serviceName, "lambda", "1", {});
-            let policyStatements = deployersCommon.getAppSecretsAccessPolicyStatements(serviceContext);
+            let policyStatements = deployPhaseCommon.getAppSecretsAccessPolicyStatements(serviceContext);
             expect(policyStatements.length).to.equal(2);
             expect(policyStatements[1].Resource[0]).to.contain(`parameter/${appName}.${envName}*`)
         });
@@ -418,7 +281,7 @@ describe('deployers-common', function () {
                 }]
             });
 
-            let eventConsumerConfig = deployersCommon.getEventConsumerConfigParams(producerServiceContext, consumerServiceContext);
+            let eventConsumerConfig = deployPhaseCommon.getEventConsumerConfigParams(producerServiceContext, consumerServiceContext);
             expect(eventConsumerConfig).to.not.be.null;
             expect(eventConsumerConfig.event_input).to.equal(eventInputVal);
         });
@@ -428,7 +291,7 @@ describe('deployers-common', function () {
                 event_consumers: []
             });
 
-            let eventConsumerConfig = deployersCommon.getEventConsumerConfigParams(producerServiceContext, consumerServiceContext);
+            let eventConsumerConfig = deployPhaseCommon.getEventConsumerConfigParams(producerServiceContext, consumerServiceContext);
             expect(eventConsumerConfig).to.be.null;
         });
     });

--- a/test/common/pre-deploy-phase-common-test.js
+++ b/test/common/pre-deploy-phase-common-test.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const preDeployPhaseCommon = require('../../lib/common/pre-deploy-phase-common');
+const cloudformationCalls = require('../../lib/aws/cloudformation-calls');
+const ec2Calls = require('../../lib/aws/ec2-calls');
+const sinon = require('sinon');
+const expect = require('chai').expect;
+
+describe('PreDeploy Phase Common module', function () {
+    let sandbox;
+
+    beforeEach(function () {
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    describe('createSecurityGroupForService', function () {
+        it('should create the security group when it doesnt exist', function () {
+            let sgName = "FakeSg";
+
+            let getStackStub = sandbox.stub(cloudformationCalls, 'getStack').returns(Promise.resolve(null));
+            let createStackStub = sandbox.stub(cloudformationCalls, 'createStack').returns(Promise.resolve({
+                Outputs: [{
+                    OutputKey: "GroupId",
+                    OutputValue: "SomeId"
+                }]
+            }))
+            let getSecurityGroupByIdStub = sandbox.stub(ec2Calls, 'getSecurityGroupById').returns(Promise.resolve({}));
+
+            return preDeployPhaseCommon.createSecurityGroupForService(sgName, 22)
+                .then(securityGroup => {
+                    expect(securityGroup).to.deep.equal({});
+                    expect(getStackStub.calledOnce).to.be.true;
+                    expect(createStackStub.calledOnce).to.be.true;
+                    expect(getSecurityGroupByIdStub.calledOnce).to.be.true;
+                });
+        });
+
+        it('should update the security group when it exists', function () {
+            let sgName = "FakeSg";
+
+            let getStackStub = sandbox.stub(cloudformationCalls, 'getStack').returns(Promise.resolve({}));
+            let updateStackStub = sandbox.stub(cloudformationCalls, 'updateStack').returns(Promise.resolve({
+                Outputs: [{
+                    OutputKey: "GroupId",
+                    OutputValue: "SomeId"
+                }]
+            }))
+            let getSecurityGroupByIdStub = sandbox.stub(ec2Calls, 'getSecurityGroupById').returns(Promise.resolve({}));
+
+            return preDeployPhaseCommon.createSecurityGroupForService(sgName, 22)
+                .then(securityGroup => {
+                    expect(securityGroup).to.deep.equal({});
+                    expect(getStackStub.calledOnce).to.be.true;
+                    expect(updateStackStub.calledOnce).to.be.true;
+                    expect(getSecurityGroupByIdStub.calledOnce).to.be.true;
+                });
+        });
+    });
+});

--- a/test/services/apigateway/apigateway-test.js
+++ b/test/services/apigateway/apigateway-test.js
@@ -22,7 +22,8 @@ const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
 const BindContext = require('../../../lib/datatypes/bind-context');
 const sinon = require('sinon');
 const expect = require('chai').expect;
-const deployersCommon = require('../../../lib/common/deployers-common');
+const deployPhaseCommon = require('../../../lib/common/deploy-phase-common');
+const deletePhasesCommon = require('../../../lib/common/delete-phases-common');
 const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../../lib/datatypes/un-bind-context');
 const UnDeployContext = require('../../../lib/datatypes/un-deploy-context');
@@ -128,11 +129,11 @@ describe('apigateway deployer', function () {
             //Stub out dependent services
             let bucketName = "FakeBucket";
             let bucketKey = "FakeBucketKey";
-            let uploadDeployableArtifactToHandelBucketStub = sandbox.stub(deployersCommon, 'uploadDeployableArtifactToHandelBucket').returns(Promise.resolve({
+            let uploadDeployableArtifactToHandelBucketStub = sandbox.stub(deployPhaseCommon, 'uploadDeployableArtifactToHandelBucket').returns(Promise.resolve({
                 Bucket: bucketName,
                 Key: bucketKey
             }));
-            let deployStackStub = sandbox.stub(deployersCommon, 'deployCloudFormationStack').returns(Promise.resolve({
+            let deployStackStub = sandbox.stub(deployPhaseCommon, 'deployCloudFormationStack').returns(Promise.resolve({
                 Outputs: [{
                     OutputKey: 'RestApiId',
                     OutputValue: 'someApiId'
@@ -195,7 +196,7 @@ describe('apigateway deployer', function () {
     describe('unDeploy', function () {
         it('should undeploy the stack', function () {
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "apigateway", "1", {});
-            let unDeployStackStub = sandbox.stub(deployersCommon, 'unDeployCloudFormationStack').returns(Promise.resolve(new UnDeployContext(serviceContext)));
+            let unDeployStackStub = sandbox.stub(deletePhasesCommon, 'unDeployCloudFormationStack').returns(Promise.resolve(new UnDeployContext(serviceContext)));
 
             return apigateway.unDeploy(serviceContext)
                 .then(unDeployContext => {

--- a/test/services/beanstalk/beanstalk-test.js
+++ b/test/services/beanstalk/beanstalk-test.js
@@ -20,7 +20,9 @@ const ServiceContext = require('../../../lib/datatypes/service-context');
 const DeployContext = require('../../../lib/datatypes/deploy-context');
 const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
 const BindContext = require('../../../lib/datatypes/bind-context');
-const deployersCommon = require('../../../lib/common/deployers-common');
+const deployPhaseCommon = require('../../../lib/common/deploy-phase-common');
+const preDeployPhaseCommon = require('../../../lib/common/pre-deploy-phase-common');
+const deletePhasesCommon = require('../../../lib/common/delete-phases-common');
 const deployableArtifact = require('../../../lib/services/beanstalk/deployable-artifact');
 const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../../lib/datatypes/un-bind-context');
@@ -51,7 +53,7 @@ describe('beanstalk deployer', function () {
     describe('preDeploy', function () {
         it('should create a security group and add self and SSH bastion ingress', function () {
             let groupId = "FakeSgGroupId";
-            let createSecurityGroupStub = sandbox.stub(deployersCommon, 'createSecurityGroupForService').returns(Promise.resolve({
+            let createSecurityGroupStub = sandbox.stub(preDeployPhaseCommon, 'createSecurityGroupForService').returns(Promise.resolve({
                 GroupId: groupId
             }));
 
@@ -100,14 +102,14 @@ describe('beanstalk deployer', function () {
         }
 
         it('should deploy the service', function () {
-            let createCustomRoleStub = sandbox.stub(deployersCommon, 'createCustomRole').returns(Promise.resolve({
+            let createCustomRoleStub = sandbox.stub(deployPhaseCommon, 'createCustomRole').returns(Promise.resolve({
                 RoleName: "FakeServiceRole"
             }));
             let prepareAndUploadDeployableArtifactStub = sandbox.stub(deployableArtifact, 'prepareAndUploadDeployableArtifact').returns(Promise.resolve({
                 Bucket: "FakeBucket",
                 Key: "FakeKey"
             }));
-            let deployStackStub = sandbox.stub(deployersCommon, 'deployCloudFormationStack').returns(Promise.resolve({}));
+            let deployStackStub = sandbox.stub(deployPhaseCommon, 'deployCloudFormationStack').returns(Promise.resolve({}));
 
             let ownServiceContext = getServiceContext();
             let sgGroupId = "FakeSgId";
@@ -149,7 +151,7 @@ describe('beanstalk deployer', function () {
 
     describe('unPreDeploy', function () {
         it('should delete the security group', function () {
-            let deleteSecurityGroupStub = sandbox.stub(deployersCommon, 'deleteSecurityGroupForService').returns(Promise.resolve(true));
+            let deleteSecurityGroupStub = sandbox.stub(deletePhasesCommon, 'deleteSecurityGroupForService').returns(Promise.resolve(true));
 
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "beanstalk", "1", {});
             return beanstalk.unPreDeploy(serviceContext)
@@ -173,7 +175,7 @@ describe('beanstalk deployer', function () {
     describe('unDeploy', function () {
         it('should undeploy the stack', function () {
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "beanstalk", "1", {});
-            let unDeployStackStub = sandbox.stub(deployersCommon, 'unDeployCloudFormationStack').returns(Promise.resolve(new UnDeployContext(serviceContext)));
+            let unDeployStackStub = sandbox.stub(deletePhasesCommon, 'unDeployCloudFormationStack').returns(Promise.resolve(new UnDeployContext(serviceContext)));
 
             return beanstalk.unDeploy(serviceContext)
                 .then(unDeployContext => {

--- a/test/services/beanstalk/deployable-artifact-test.js
+++ b/test/services/beanstalk/deployable-artifact-test.js
@@ -16,7 +16,7 @@
  */
 const accountConfig = require('../../../lib/common/account-config')(`${__dirname}/../../test-account-config.yml`).getAccountConfig();
 const deployableArtifact = require('../../../lib/services/beanstalk/deployable-artifact');
-const deployersCommon = require('../../../lib/common/deployers-common');
+const deployPhaseCommon = require('../../../lib/common/deploy-phase-common');
 const ebextensions = require('../../../lib/services/beanstalk/ebextensions');
 const ServiceContext = require('../../../lib/datatypes/service-context');
 const util = require('../../../lib/common/util');
@@ -48,7 +48,7 @@ describe('deployable artifact module', function () {
             let lstatStub = sandbox.stub(fs, 'lstatSync').returns({ isDirectory: function () { return true; } })
             let addEbextensionsStub = sandbox.stub(ebextensions, 'addEbextensionsToDir').returns(true);
             let zipDirStub = sandbox.stub(util, 'zipDirectoryToFile').returns(Promise.resolve(true));
-            let uploadFileStub = sandbox.stub(deployersCommon, 'uploadFileToHandelBucket').returns(Promise.resolve({
+            let uploadFileStub = sandbox.stub(deployPhaseCommon, 'uploadFileToHandelBucket').returns(Promise.resolve({
                 Bucket: bucket,
                 Key: key
             }));
@@ -100,7 +100,7 @@ describe('deployable artifact module', function () {
             let copyDirectoryStub = sandbox.stub(util, 'copyDirectory').returns(Promise.resolve(true));
             let addEbextensionsStub = sandbox.stub(ebextensions, 'addEbextensionsToDir').returns(true);
             let zipDirStub = sandbox.stub(util, 'zipDirectoryToFile').returns(Promise.resolve(true));
-            let uploadFileStub = sandbox.stub(deployersCommon, 'uploadFileToHandelBucket').returns(Promise.resolve({
+            let uploadFileStub = sandbox.stub(deployPhaseCommon, 'uploadFileToHandelBucket').returns(Promise.resolve({
                 Bucket: bucket,
                 Key: key
             }));
@@ -154,7 +154,7 @@ describe('deployable artifact module', function () {
             let copyDirectoryStub = sandbox.stub(util, 'copyDirectory').returns(Promise.resolve(true));
             let addEbextensionsStub = sandbox.stub(ebextensions, 'addEbextensionsToDir').returns(true);
             let zipDirStub = sandbox.stub(util, 'zipDirectoryToFile').returns(Promise.resolve(true));
-            let uploadFileStub = sandbox.stub(deployersCommon, 'uploadFileToHandelBucket').returns(Promise.resolve({
+            let uploadFileStub = sandbox.stub(deployPhaseCommon, 'uploadFileToHandelBucket').returns(Promise.resolve({
                 Bucket: bucket,
                 Key: key
             }));
@@ -191,7 +191,7 @@ describe('deployable artifact module', function () {
             let copyDirectoryStub = sandbox.stub(util, 'copyDirectory').returns(Promise.resolve(true));
             let addEbextensionsStub = sandbox.stub(ebextensions, 'addEbextensionsToDir').returns(true);
             let zipDirStub = sandbox.stub(util, 'zipDirectoryToFile').returns(Promise.resolve(true));
-            let uploadFileStub = sandbox.stub(deployersCommon, 'uploadFileToHandelBucket').returns(Promise.resolve({
+            let uploadFileStub = sandbox.stub(deployPhaseCommon, 'uploadFileToHandelBucket').returns(Promise.resolve({
                 Bucket: bucket,
                 Key: key
             }));

--- a/test/services/dynamodb/dynamodb-test.js
+++ b/test/services/dynamodb/dynamodb-test.js
@@ -20,7 +20,8 @@ const ServiceContext = require('../../../lib/datatypes/service-context');
 const DeployContext = require('../../../lib/datatypes/deploy-context');
 const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
 const BindContext = require('../../../lib/datatypes/bind-context');
-const deployersCommon = require('../../../lib/common/deployers-common');
+const deployPhaseCommon = require('../../../lib/common/deploy-phase-common');
+const deletePhasesCommon = require('../../../lib/common/delete-phases-common');
 const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../../lib/datatypes/un-bind-context');
 const UnDeployContext = require('../../../lib/datatypes/un-deploy-context');
@@ -116,7 +117,7 @@ describe('dynamodb deployer', function () {
         let tableArn = `arn:aws:dynamodb:us-west-2:123456789012:table/${tableName}`
 
         it('should deploy the table', function () {
-            let deployStackStub = sandbox.stub(deployersCommon, 'deployCloudFormationStack').returns(Promise.resolve({
+            let deployStackStub = sandbox.stub(deployPhaseCommon, 'deployCloudFormationStack').returns(Promise.resolve({
                 Outputs: [{
                     OutputKey: 'TableName',
                     OutputValue: tableName
@@ -182,7 +183,7 @@ describe('dynamodb deployer', function () {
     describe('unDeploy', function () {
         it('should undeploy the stack', function () {
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "dynamodb", "1", {});
-            let unDeployStackStub = sandbox.stub(deployersCommon, 'unDeployCloudFormationStack').returns(Promise.resolve(new UnDeployContext(serviceContext)));
+            let unDeployStackStub = sandbox.stub(deletePhasesCommon, 'unDeployCloudFormationStack').returns(Promise.resolve(new UnDeployContext(serviceContext)));
 
             return dynamodb.unDeploy(serviceContext)
                 .then(unDeployContext => {

--- a/test/services/efs/efs-test.js
+++ b/test/services/efs/efs-test.js
@@ -21,7 +21,9 @@ const ServiceContext = require('../../../lib/datatypes/service-context');
 const DeployContext = require('../../../lib/datatypes/deploy-context');
 const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
 const BindContext = require('../../../lib/datatypes/bind-context');
-const deployersCommon = require('../../../lib/common/deployers-common');
+const deployPhaseCommon = require('../../../lib/common/deploy-phase-common');
+const preDeployPhaseCommon = require('../../../lib/common/pre-deploy-phase-common');
+const deletePhasesCommon = require('../../../lib/common/delete-phases-common');
 const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../../lib/datatypes/un-bind-context');
 const UnDeployContext = require('../../../lib/datatypes/un-deploy-context');
@@ -64,7 +66,7 @@ describe('efs deployer', function () {
     describe('preDeploy', function () {
         it('should create a security group', function () {
             let groupId = "FakeSgGroupId";
-            let createSecurityGroupStub = sandbox.stub(deployersCommon, 'createSecurityGroupForService').returns(Promise.resolve({
+            let createSecurityGroupStub = sandbox.stub(preDeployPhaseCommon, 'createSecurityGroupForService').returns(Promise.resolve({
                 GroupId: groupId
             }));
 
@@ -119,7 +121,7 @@ describe('efs deployer', function () {
         let fileSystemId = "FakeFileSystemId";
 
         it('should deploy the file system', function () {
-            let deployStackStub = sandbox.stub(deployersCommon, 'deployCloudFormationStack').returns(Promise.resolve({
+            let deployStackStub = sandbox.stub(deployPhaseCommon, 'deployCloudFormationStack').returns(Promise.resolve({
                 Outputs: [{
                     OutputKey: "EFSFileSystemId",
                     OutputValue: fileSystemId
@@ -161,7 +163,7 @@ describe('efs deployer', function () {
 
     describe('unPreDeploy', function () {
         it('should delete the security group', function () {
-            let deleteSecurityGroupStub = sandbox.stub(deployersCommon, 'deleteSecurityGroupForService').returns(Promise.resolve(true));
+            let deleteSecurityGroupStub = sandbox.stub(deletePhasesCommon, 'deleteSecurityGroupForService').returns(Promise.resolve(true));
 
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "efs", "1", {});
             return efs.unPreDeploy(serviceContext)
@@ -174,7 +176,7 @@ describe('efs deployer', function () {
 
     describe('unBind', function () {
         it('should unbind the security group', function () {
-            let unBindAllStub = sandbox.stub(deployersCommon, 'unBindAllOnSg').returns(Promise.resolve(true));
+            let unBindAllStub = sandbox.stub(deletePhasesCommon, 'unBindAllOnSg').returns(Promise.resolve(true));
 
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "efs", "1", {});
             return efs.unBind(serviceContext)
@@ -188,7 +190,7 @@ describe('efs deployer', function () {
     describe('unDeploy', function () {
         it('should undeploy the stack', function () {
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "efs", "1", {});
-            let unDeployStackStub = sandbox.stub(deployersCommon, 'unDeployCloudFormationStack').returns(Promise.resolve(new UnDeployContext(serviceContext)));
+            let unDeployStackStub = sandbox.stub(deletePhasesCommon, 'unDeployCloudFormationStack').returns(Promise.resolve(new UnDeployContext(serviceContext)));
 
             return efs.unDeploy(serviceContext)
                 .then(unDeployContext => {

--- a/test/services/memcached/memcached-test.js
+++ b/test/services/memcached/memcached-test.js
@@ -21,7 +21,9 @@ const ServiceContext = require('../../../lib/datatypes/service-context');
 const DeployContext = require('../../../lib/datatypes/deploy-context');
 const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
 const BindContext = require('../../../lib/datatypes/bind-context');
-const deployersCommon = require('../../../lib/common/deployers-common');
+const deployPhaseCommon = require('../../../lib/common/deploy-phase-common');
+const preDeployPhaseCommon = require('../../../lib/common/pre-deploy-phase-common');
+const deletePhasesCommon = require('../../../lib/common/delete-phases-common');
 const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../../lib/datatypes/un-bind-context');
 const UnDeployContext = require('../../../lib/datatypes/un-deploy-context');
@@ -77,7 +79,7 @@ describe('memcached deployer', function () {
     describe('preDeploy', function () {
         it('should create a security group', function () {
             let groupId = "FakeSgGroupId";
-            let createSecurityGroupStub = sandbox.stub(deployersCommon, 'createSecurityGroupForService').returns(Promise.resolve({
+            let createSecurityGroupStub = sandbox.stub(preDeployPhaseCommon, 'createSecurityGroupForService').returns(Promise.resolve({
                 GroupId: groupId
             }));
 
@@ -138,7 +140,7 @@ describe('memcached deployer', function () {
         let envPrefix = `MEMCACHED_${appName}_${envName}_FAKESERVICE`.toUpperCase();
 
         it('should deploy the cluster', function () {
-            let deployStackStub = sandbox.stub(deployersCommon, 'deployCloudFormationStack').returns(Promise.resolve({
+            let deployStackStub = sandbox.stub(deployPhaseCommon, 'deployCloudFormationStack').returns(Promise.resolve({
                 Outputs: [
                     {
                         OutputKey: "CacheAddress",
@@ -187,7 +189,7 @@ describe('memcached deployer', function () {
 
     describe('unPreDeploy', function () {
         it('should delete the security group', function () {
-            let deleteSecurityGroupStub = sandbox.stub(deployersCommon, 'deleteSecurityGroupForService').returns(Promise.resolve(true));
+            let deleteSecurityGroupStub = sandbox.stub(deletePhasesCommon, 'deleteSecurityGroupForService').returns(Promise.resolve(true));
 
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "memcached", "1", {});
             return memcached.unPreDeploy(serviceContext)
@@ -200,7 +202,7 @@ describe('memcached deployer', function () {
 
     describe('unBind', function () {
         it('should unbind the security group', function () {
-            let unBindAllStub = sandbox.stub(deployersCommon, 'unBindAllOnSg').returns(Promise.resolve(true));
+            let unBindAllStub = sandbox.stub(deletePhasesCommon, 'unBindAllOnSg').returns(Promise.resolve(true));
 
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "memcached", "1", {});
             return memcached.unBind(serviceContext)
@@ -214,7 +216,7 @@ describe('memcached deployer', function () {
     describe('unDeploy', function () {
         it('should undeploy the stack', function () {
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "memcached", "1", {});
-            let unDeployStackStub = sandbox.stub(deployersCommon, 'unDeployCloudFormationStack').returns(Promise.resolve(new UnDeployContext(serviceContext)));
+            let unDeployStackStub = sandbox.stub(deletePhasesCommon, 'unDeployCloudFormationStack').returns(Promise.resolve(new UnDeployContext(serviceContext)));
 
             return memcached.unDeploy(serviceContext)
                 .then(unDeployContext => {

--- a/test/services/mysql/mysql-test.js
+++ b/test/services/mysql/mysql-test.js
@@ -23,7 +23,9 @@ const ServiceContext = require('../../../lib/datatypes/service-context');
 const DeployContext = require('../../../lib/datatypes/deploy-context');
 const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
 const BindContext = require('../../../lib/datatypes/bind-context');
-const deployersCommon = require('../../../lib/common/deployers-common');
+const deployPhaseCommon = require('../../../lib/common/deploy-phase-common');
+const preDeployPhaseCommon = require('../../../lib/common/pre-deploy-phase-common');
+const deletePhasesCommon = require('../../../lib/common/delete-phases-common');
 const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../../lib/datatypes/un-bind-context');
 const UnDeployContext = require('../../../lib/datatypes/un-deploy-context');
@@ -65,7 +67,7 @@ describe('mysql deployer', function () {
     describe('preDeploy', function () {
         it('should create a security group', function () {
             let groupId = "FakeSgGroupId";
-            let createSecurityGroupStub = sandbox.stub(deployersCommon, 'createSecurityGroupForService').returns(Promise.resolve({
+            let createSecurityGroupStub = sandbox.stub(preDeployPhaseCommon, 'createSecurityGroupForService').returns(Promise.resolve({
                 GroupId: groupId
             }));
 
@@ -225,7 +227,7 @@ describe('mysql deployer', function () {
 
     describe('unPreDeploy', function () {
         it('should delete the security group', function () {
-            let deleteSecurityGroupStub = sandbox.stub(deployersCommon, 'deleteSecurityGroupForService').returns(Promise.resolve(true));
+            let deleteSecurityGroupStub = sandbox.stub(deletePhasesCommon, 'deleteSecurityGroupForService').returns(Promise.resolve(true));
 
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "mysql", "1", {});
             return mysql.unPreDeploy(serviceContext)
@@ -238,7 +240,7 @@ describe('mysql deployer', function () {
 
     describe('unBind', function () {
         it('should unbind the security group', function () {
-            let unBindAllStub = sandbox.stub(deployersCommon, 'unBindAllOnSg').returns(Promise.resolve(true));
+            let unBindAllStub = sandbox.stub(deletePhasesCommon, 'unBindAllOnSg').returns(Promise.resolve(true));
 
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "mysql", "1", {});
             return mysql.unBind(serviceContext)
@@ -252,7 +254,7 @@ describe('mysql deployer', function () {
     describe('unDeploy', function () {
         it('should undeploy the stack', function () {
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "mysql", "1", {});
-            let unDeployStackStub = sandbox.stub(deployersCommon, 'unDeployCloudFormationStack').returns(Promise.resolve(new UnDeployContext(serviceContext)));
+            let unDeployStackStub = sandbox.stub(deletePhasesCommon, 'unDeployCloudFormationStack').returns(Promise.resolve(new UnDeployContext(serviceContext)));
             let deleteParametersStub = sandbox.stub(ssmCalls, 'deleteParameters').returns(Promise.resolve({}));
 
             return mysql.unDeploy(serviceContext)

--- a/test/services/postgresql/postgresql-test.js
+++ b/test/services/postgresql/postgresql-test.js
@@ -22,7 +22,9 @@ const ServiceContext = require('../../../lib/datatypes/service-context');
 const DeployContext = require('../../../lib/datatypes/deploy-context');
 const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
 const BindContext = require('../../../lib/datatypes/bind-context');
-const deployersCommon = require('../../../lib/common/deployers-common');
+const deployPhaseCommon = require('../../../lib/common/deploy-phase-common');
+const preDeployPhaseCommon = require('../../../lib/common/pre-deploy-phase-common');
+const deletePhasesCommon = require('../../../lib/common/delete-phases-common');
 const rdsCommon = require('../../../lib/common/rds-common');
 const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../../lib/datatypes/un-bind-context');
@@ -65,7 +67,7 @@ describe('postgresql deployer', function () {
     describe('preDeploy', function () {
         it('should create a security group', function () {
             let groupId = "FakeSgGroupId";
-            let createSecurityGroupStub = sandbox.stub(deployersCommon, 'createSecurityGroupForService').returns(Promise.resolve({
+            let createSecurityGroupStub = sandbox.stub(preDeployPhaseCommon, 'createSecurityGroupForService').returns(Promise.resolve({
                 GroupId: groupId
             }));
 
@@ -208,7 +210,7 @@ describe('postgresql deployer', function () {
 
     describe('unPreDeploy', function () {
         it('should delete the security group', function () {
-            let deleteSecurityGroupStub = sandbox.stub(deployersCommon, 'deleteSecurityGroupForService').returns(Promise.resolve(true));
+            let deleteSecurityGroupStub = sandbox.stub(deletePhasesCommon, 'deleteSecurityGroupForService').returns(Promise.resolve(true));
 
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "postgresql", "1", {});
             return postgresql.unPreDeploy(serviceContext)
@@ -221,7 +223,7 @@ describe('postgresql deployer', function () {
 
     describe('unBind', function () {
         it('should unbind the security group', function () {
-            let unBindAllStub = sandbox.stub(deployersCommon, 'unBindAllOnSg').returns(Promise.resolve(true));
+            let unBindAllStub = sandbox.stub(deletePhasesCommon, 'unBindAllOnSg').returns(Promise.resolve(true));
 
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "postgresql", "1", {});
             return postgresql.unBind(serviceContext)
@@ -236,7 +238,7 @@ describe('postgresql deployer', function () {
         it('should undeploy the stack', function () {
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "postgresql", "1", {});
             let unDeployContext = new UnDeployContext(serviceContext);
-            let unDeployStackStub = sandbox.stub(deployersCommon, 'unDeployCloudFormationStack').returns(Promise.resolve(unDeployContext));
+            let unDeployStackStub = sandbox.stub(deletePhasesCommon, 'unDeployCloudFormationStack').returns(Promise.resolve(unDeployContext));
             let deleteParametersStub = sandbox.stub(rdsCommon, 'deleteParametersFromParameterStore').returns(Promise.resolve(unDeployContext));
 
             return postgresql.unDeploy(serviceContext)

--- a/test/services/redis/redis-test.js
+++ b/test/services/redis/redis-test.js
@@ -21,7 +21,9 @@ const ServiceContext = require('../../../lib/datatypes/service-context');
 const DeployContext = require('../../../lib/datatypes/deploy-context');
 const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
 const BindContext = require('../../../lib/datatypes/bind-context');
-const deployersCommon = require('../../../lib/common/deployers-common');
+const deployPhaseCommon = require('../../../lib/common/deploy-phase-common');
+const preDeployPhaseCommon = require('../../../lib/common/pre-deploy-phase-common');
+const deletePhasesCommon = require('../../../lib/common/delete-phases-common');
 const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../../lib/datatypes/un-bind-context');
 const UnDeployContext = require('../../../lib/datatypes/un-deploy-context');
@@ -104,7 +106,7 @@ describe('redis deployer', function () {
     describe('preDeploy', function () {
         it('should create a security group', function () {
             let groupId = "FakeSgGroupId";
-            let createSecurityGroupStub = sandbox.stub(deployersCommon, 'createSecurityGroupForService').returns(Promise.resolve({
+            let createSecurityGroupStub = sandbox.stub(preDeployPhaseCommon, 'createSecurityGroupForService').returns(Promise.resolve({
                 GroupId: groupId
             }));
 
@@ -165,7 +167,7 @@ describe('redis deployer', function () {
         let envPrefix = `REDIS_${appName}_${envName}_FAKESERVICE`.toUpperCase();
 
         it('should deploy the cluster', function () {
-            let deployStackStub = sandbox.stub(deployersCommon, 'deployCloudFormationStack').returns(Promise.resolve({
+            let deployStackStub = sandbox.stub(deployPhaseCommon, 'deployCloudFormationStack').returns(Promise.resolve({
                 Outputs: [
                     {
                         OutputKey: "CacheAddress",
@@ -214,7 +216,7 @@ describe('redis deployer', function () {
 
     describe('unPreDeploy', function () {
         it('should delete the security group', function () {
-            let deleteSecurityGroupStub = sandbox.stub(deployersCommon, 'deleteSecurityGroupForService').returns(Promise.resolve(true));
+            let deleteSecurityGroupStub = sandbox.stub(deletePhasesCommon, 'deleteSecurityGroupForService').returns(Promise.resolve(true));
 
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "redis", "1", {});
             return redis.unPreDeploy(serviceContext)
@@ -227,7 +229,7 @@ describe('redis deployer', function () {
 
     describe('unBind', function () {
         it('should unbind the security group', function () {
-            let unBindAllStub = sandbox.stub(deployersCommon, 'unBindAllOnSg').returns(Promise.resolve(true));
+            let unBindAllStub = sandbox.stub(deletePhasesCommon, 'unBindAllOnSg').returns(Promise.resolve(true));
 
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "redis", "1", {});
             return redis.unBind(serviceContext)
@@ -241,7 +243,7 @@ describe('redis deployer', function () {
     describe('unDeploy', function () {
         it('should undeploy the stack', function () {
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "redis", "1", {});
-            let unDeployStackStub = sandbox.stub(deployersCommon, 'unDeployCloudFormationStack').returns(Promise.resolve(new UnDeployContext(serviceContext)));
+            let unDeployStackStub = sandbox.stub(deletePhasesCommon, 'unDeployCloudFormationStack').returns(Promise.resolve(new UnDeployContext(serviceContext)));
 
             return redis.unDeploy(serviceContext)
                 .then(unDeployContext => {

--- a/test/services/s3/s3-test.js
+++ b/test/services/s3/s3-test.js
@@ -20,7 +20,8 @@ const ServiceContext = require('../../../lib/datatypes/service-context');
 const DeployContext = require('../../../lib/datatypes/deploy-context');
 const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
 const BindContext = require('../../../lib/datatypes/bind-context');
-const deployersCommon = require('../../../lib/common/deployers-common');
+const deployPhaseCommon = require('../../../lib/common/deploy-phase-common');
+const deletePhasesCommon = require('../../../lib/common/delete-phases-common');
 const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../../lib/datatypes/un-bind-context');
 const UnDeployContext = require('../../../lib/datatypes/un-deploy-context');
@@ -94,7 +95,7 @@ describe('s3 deployer', function () {
         let preDeployContext = new PreDeployContext(serviceContext);
 
         it('should deploy the bucket', function () {
-            let deployStackStub = sandbox.stub(deployersCommon, 'deployCloudFormationStack').returns(Promise.resolve({
+            let deployStackStub = sandbox.stub(deployPhaseCommon, 'deployCloudFormationStack').returns(Promise.resolve({
                 Outputs: [{
                     OutputKey: 'BucketName',
                     OutputValue: bucketName
@@ -160,7 +161,7 @@ describe('s3 deployer', function () {
     describe('unDeploy', function () {
         it('should undeploy the stack', function () {
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "s3", "1", {});
-            let unDeployStackStub = sandbox.stub(deployersCommon, 'unDeployCloudFormationStack').returns(Promise.resolve(new UnDeployContext(serviceContext)));
+            let unDeployStackStub = sandbox.stub(deletePhasesCommon, 'unDeployCloudFormationStack').returns(Promise.resolve(new UnDeployContext(serviceContext)));
 
             return s3.unDeploy(serviceContext)
                 .then(unDeployContext => {

--- a/test/services/s3staticsite/s3staticsite-test.js
+++ b/test/services/s3staticsite/s3staticsite-test.js
@@ -21,7 +21,8 @@ const DeployContext = require('../../../lib/datatypes/deploy-context');
 const s3Calls = require('../../../lib/aws/s3-calls');
 const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
 const BindContext = require('../../../lib/datatypes/bind-context');
-const deployersCommon = require('../../../lib/common/deployers-common');
+const deployPhaseCommon = require('../../../lib/common/deploy-phase-common');
+const deletePhasesCommon = require('../../../lib/common/delete-phases-common');
 const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../../lib/datatypes/un-bind-context');
 const UnDeployContext = require('../../../lib/datatypes/un-deploy-context');
@@ -83,7 +84,7 @@ describe('s3staticsite deployer', function () {
         let ownPreDeployContext = new PreDeployContext(ownServiceContext);
 
         it('should deploy the static site bucket', function () {
-            let deployStackStub = sandbox.stub(deployersCommon, 'deployCloudFormationStack');
+            let deployStackStub = sandbox.stub(deployPhaseCommon, 'deployCloudFormationStack');
             deployStackStub.onCall(0).returns(Promise.resolve({
                 Outputs: [{
                     OutputKey: 'BucketName',
@@ -154,7 +155,7 @@ describe('s3staticsite deployer', function () {
     describe('unDeploy', function () {
         it('should undeploy the stack', function () {
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "s3staticsite", "1", {});
-            let unDeployStackStub = sandbox.stub(deployersCommon, 'unDeployCloudFormationStack').returns(Promise.resolve(new UnDeployContext(serviceContext)));
+            let unDeployStackStub = sandbox.stub(deletePhasesCommon, 'unDeployCloudFormationStack').returns(Promise.resolve(new UnDeployContext(serviceContext)));
 
             return s3StaticSite.unDeploy(serviceContext)
                 .then(unDeployContext => {

--- a/test/services/sns/sns-test.js
+++ b/test/services/sns/sns-test.js
@@ -22,7 +22,8 @@ const DeployContext = require('../../../lib/datatypes/deploy-context');
 const ProduceEventsContext = require('../../../lib/datatypes/produce-events-context');
 const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
 const BindContext = require('../../../lib/datatypes/bind-context');
-const deployersCommon = require('../../../lib/common/deployers-common');
+const deployPhaseCommon = require('../../../lib/common/deploy-phase-common');
+const deletePhasesCommon = require('../../../lib/common/delete-phases-common');
 const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../../lib/datatypes/un-bind-context');
 const UnDeployContext = require('../../../lib/datatypes/un-deploy-context');
@@ -84,7 +85,7 @@ describe('sns deployer', function () {
         let ownPreDeployContext = new PreDeployContext(ownServiceContext);
 
         it('should deploy the topic', function () {
-            let deployStackStub = sandbox.stub(deployersCommon, 'deployCloudFormationStack').returns(Promise.resolve({
+            let deployStackStub = sandbox.stub(deployPhaseCommon, 'deployCloudFormationStack').returns(Promise.resolve({
                 Outputs: [
                     {
                         OutputKey: 'TopicName',
@@ -197,7 +198,7 @@ describe('sns deployer', function () {
     describe('unDeploy', function () {
         it('should undeploy the stack', function () {
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "sns", "1", {});
-            let unDeployStackStub = sandbox.stub(deployersCommon, 'unDeployCloudFormationStack').returns(Promise.resolve(new UnDeployContext(serviceContext)));
+            let unDeployStackStub = sandbox.stub(deletePhasesCommon, 'unDeployCloudFormationStack').returns(Promise.resolve(new UnDeployContext(serviceContext)));
 
             return sns.unDeploy(serviceContext)
                 .then(unDeployContext => {

--- a/test/services/sqs/sqs-test.js
+++ b/test/services/sqs/sqs-test.js
@@ -22,7 +22,8 @@ const DeployContext = require('../../../lib/datatypes/deploy-context');
 const ConsumeEventsContext = require('../../../lib/datatypes/consume-events-context');
 const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
 const BindContext = require('../../../lib/datatypes/bind-context');
-const deployersCommon = require('../../../lib/common/deployers-common');
+const deployPhaseCommon = require('../../../lib/common/deploy-phase-common');
+const deletePhasesCommon = require('../../../lib/common/delete-phases-common');
 const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../../lib/datatypes/un-bind-context');
 const UnDeployContext = require('../../../lib/datatypes/un-deploy-context');
@@ -91,7 +92,7 @@ describe('sqs deployer', function () {
         let ownPreDeployContext = new PreDeployContext(ownServiceContext);
 
         it('should deploy the queue', function () {
-            let deployStackStub = sandbox.stub(deployersCommon, 'deployCloudFormationStack').returns(Promise.resolve({
+            let deployStackStub = sandbox.stub(deployPhaseCommon, 'deployCloudFormationStack').returns(Promise.resolve({
                 Outputs: [
                     {
                         OutputKey: 'QueueName',
@@ -188,7 +189,7 @@ describe('sqs deployer', function () {
     describe('unDeploy', function () {
         it('should undeploy the stack', function () {
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "sqs", "1", {});
-            let unDeployStackStub = sandbox.stub(deployersCommon, 'unDeployCloudFormationStack').returns(Promise.resolve(new UnDeployContext(serviceContext)));
+            let unDeployStackStub = sandbox.stub(deletePhasesCommon, 'unDeployCloudFormationStack').returns(Promise.resolve(new UnDeployContext(serviceContext)));
 
             return sqs.unDeploy(serviceContext)
                 .then(unDeployContext => {


### PR DESCRIPTION
This change splits apart deployers-common into smaller modules. It
also does some other small refactors like putting service names
in logs from a single variable.