### PR TITLE
DRY up the PreDeploy and Bind phases in service deployers.

### DIFF
--- a/lib/common/bind-phase-common.js
+++ b/lib/common/bind-phase-common.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const winston = require('winston');
+const BindContext = require('../datatypes/bind-context');
+const deployPhaseCommon = require('./deploy-phase-common');
+const accountConfig = require('./account-config')().getAccountConfig();
+const ec2Calls = require('../aws/ec2-calls');
+
+exports.bindDependentSecurityGroupToSelf = function (ownServiceContext,
+    ownPreDeployContext,
+    dependentOfServiceContext,
+    dependentOfPreDeployContext,
+    protocol,
+    port,
+    serviceName) {
+        
+    let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${serviceName} - Executing Bind on ${stackName}`);
+    let ownSg = ownPreDeployContext.securityGroups[0];
+    let sourceSg = dependentOfPreDeployContext.securityGroups[0];
+
+    return ec2Calls.addIngressRuleToSgIfNotExists(sourceSg, ownSg,
+        protocol, port,
+        port, accountConfig['vpc'])
+        .then(efsSecurityGroup => {
+            winston.info(`${serviceName} - Finished Bind on ${stackName}`);
+            return new BindContext(ownServiceContext, dependentOfServiceContext);
+        });
+}
+
+exports.bindNotRequired = function (ownServiceContext, dependentOfServiceContext, serviceName) {
+    winston.info(`${serviceName} - Bind is not required for this service, skipping it`);
+    return Promise.resolve(new BindContext(ownServiceContext, dependentOfServiceContext));
+}

--- a/lib/common/delete-phases-common.js
+++ b/lib/common/delete-phases-common.js
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 const accountConfig = require('../common/account-config')().getAccountConfig();
 const ec2Calls = require('../aws/ec2-calls');
 const cloudformationCalls = require('../aws/cloudformation-calls');

--- a/lib/common/pre-deploy-phase-common.js
+++ b/lib/common/pre-deploy-phase-common.js
@@ -1,9 +1,28 @@
-const handlebarsUtils = require('../common/handlebars-utils');
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const handlebarsUtils = require('./handlebars-utils');
 const cloudformationCalls = require('../aws/cloudformation-calls');
-const accountConfig = require('../common/account-config')().getAccountConfig();
+const accountConfig = require('./account-config')().getAccountConfig();
+const deployPhaseCommon = require('./deploy-phase-common');
+const PreDeployContext = require('../datatypes/pre-deploy-context');
 const ec2Calls = require('../aws/ec2-calls');
+const winston = require('winston');
 
-exports.createSecurityGroupForService = function (stackName, sshBastionIngressPort) {
+function createSecurityGroupForService(stackName, sshBastionIngressPort) {
     let sgName = `${stackName}-sg`;
     let handlebarsParams = {
         groupName: sgName,
@@ -31,3 +50,22 @@ exports.createSecurityGroupForService = function (stackName, sshBastionIngressPo
             return ec2Calls.getSecurityGroupById(groupId, accountConfig.vpc);
         });
 }
+
+exports.preDeployCreateSecurityGroup = function (serviceContext, sshBastionIngressPort, serviceName) {
+    let sgName = deployPhaseCommon.getResourceName(serviceContext);
+    winston.info(`${serviceName} - Executing PreDeploy on ${sgName}`);
+
+    return createSecurityGroupForService(sgName, sshBastionIngressPort)
+        .then(securityGroup => {
+            winston.info(`${serviceName} - Finished PreDeploy on ${sgName}`);
+            let preDeployContext = new PreDeployContext(serviceContext);
+            preDeployContext.securityGroups.push(securityGroup);
+            return preDeployContext;
+        });
+}
+
+exports.preDeployNotRequired = function (serviceContext, serviceName) {
+    winston.info(`${serviceName} - PreDeploy is not required for this service, skipping it`);
+    return Promise.resolve(new PreDeployContext(serviceContext));
+}
+

--- a/lib/common/rds-common.js
+++ b/lib/common/rds-common.js
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 const cloudFormationCalls = require('../aws/cloudformation-calls');
 const deployPhaseCommon = require('../common/deploy-phase-common');
 const DeployContext = require('../datatypes/deploy-context');

--- a/lib/services/apiaccess/index.js
+++ b/lib/services/apiaccess/index.js
@@ -15,11 +15,11 @@
  *
  */
 const winston = require('winston');
-const PreDeployContext = require('../../datatypes/pre-deploy-context');
-const BindContext = require('../../datatypes/bind-context');
 const DeployContext = require('../../datatypes/deploy-context');
 const fs = require('fs');
 const deployPhaseCommon = require('../../common/deploy-phase-common');
+const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
+const bindPhaseCommon = require('../../common/bind-phase-common');
 const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../datatypes/un-bind-context');
 const UnDeployContext = require('../../datatypes/un-deploy-context');
@@ -71,14 +71,12 @@ exports.check = function (serviceContext) {
 
 
 exports.preDeploy = function (serviceContext) {
-    winston.info(`${SERVICE_NAME} - PreDeploy is not required for this service, skipping it`);
-    return Promise.resolve(new PreDeployContext(serviceContext));
+    return preDeployPhaseCommon.preDeployNotRequired(serviceContext, SERVICE_NAME);
 }
 
 
 exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    winston.info(`${SERVICE_NAME} - Bind is not required for this service, skipping it`);
-    return Promise.resolve(new BindContext(ownServiceContext, dependentOfServiceContext));
+    return bindPhaseCommon.bindNotRequired(ownServiceContext, dependentOfServiceContext, SERVICE_NAME);
 }
 
 

--- a/lib/services/apigateway/index.js
+++ b/lib/services/apigateway/index.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  *
  */
-const BindContext = require('../../datatypes/bind-context');
-const PreDeployContext = require('../../datatypes/pre-deploy-context');
 const DeployContext = require('../../datatypes/deploy-context');
 const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../datatypes/un-bind-context');
@@ -24,6 +22,8 @@ const util = require('../../common/util');
 const handlebarsUtils = require('../../common/handlebars-utils');
 const deployPhaseCommon = require('../../common/deploy-phase-common');
 const deletePhasesCommon = require('../../common/delete-phases-common');
+const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
+const bindPhaseCommon = require('../../common/bind-phase-common');
 const uuid = require('uuid');
 const accountConfig = require('../../common/account-config')().getAccountConfig();
 const winston = require('winston');
@@ -130,14 +130,12 @@ exports.check = function (serviceContext) {
 }
 
 exports.preDeploy = function (serviceContext) {
-    winston.info(`${SERVICE_NAME} - PreDeploy not currently required for this service, skipping it`);
-    //TODO - Once VPC support is enabled, create a security group for the Lambda
-    return Promise.resolve(new PreDeployContext(serviceContext));
+    //TODO - Once VPC support is enabled, we'll probably need to create a security group for the Lambda
+    return preDeployPhaseCommon.preDeployNotRequired(serviceContext, SERVICE_NAME);
 }
 
 exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    winston.info(`${SERVICE_NAME} - Bind not currently required for this service, skipping it`);
-    return Promise.resolve(new BindContext(ownServiceContext, dependentOfServiceContext));
+    return bindPhaseCommon.bindNotRequired(ownServiceContext, dependentOfServiceContext, SERVICE_NAME);
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {

--- a/lib/services/beanstalk/index.js
+++ b/lib/services/beanstalk/index.js
@@ -16,12 +16,11 @@
  */
 const winston = require('winston');
 const handlebarsUtils = require('../../common/handlebars-utils');
-const PreDeployContext = require('../../datatypes/pre-deploy-context');
-const BindContext = require('../../datatypes/bind-context');
 const DeployContext = require('../../datatypes/deploy-context');
 const accountConfig = require('../../common/account-config')().getAccountConfig();
 const deployPhaseCommon = require('../../common/deploy-phase-common');
 const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
+const bindPhaseCommon = require('../../common/bind-phase-common');
 const deletePhasesCommon = require('../../common/delete-phases-common');
 const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../datatypes/un-bind-context');
@@ -195,21 +194,11 @@ exports.check = function (serviceContext) {
 }
 
 exports.preDeploy = function (serviceContext) {
-    let sgName = deployPhaseCommon.getResourceName(serviceContext);
-    winston.info(`${SERVICE_NAME} - Executing PreDeploy on ${sgName}`);
-
-    return preDeployPhaseCommon.createSecurityGroupForService(sgName, 22)
-        .then(securityGroup => {
-            winston.info(`${SERVICE_NAME} - Finished PreDeploy on ${sgName}`);
-            let preDeployContext = new PreDeployContext(serviceContext);
-            preDeployContext.securityGroups.push(securityGroup);
-            return preDeployContext;
-        });
+    return preDeployPhaseCommon.preDeployCreateSecurityGroup(serviceContext, 22, SERVICE_NAME);
 }
 
 exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    winston.info(`${SERVICE_NAME} - Bind is not required for this service, skipping it`);
-    return Promise.resolve(new BindContext(ownServiceContext, dependentOfServiceContext));
+    return bindPhaseCommon.bindNotRequired(ownServiceContext, dependentOfServiceContext, SERVICE_NAME);
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {

--- a/lib/services/cloudwatchevent/index.js
+++ b/lib/services/cloudwatchevent/index.js
@@ -15,8 +15,6 @@
  *
  */
 const winston = require('winston');
-const PreDeployContext = require('../../datatypes/pre-deploy-context');
-const BindContext = require('../../datatypes/bind-context');
 const DeployContext = require('../../datatypes/deploy-context');
 const UnDeployContext = require('../../datatypes/un-deploy-context');
 const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
@@ -25,6 +23,8 @@ const ProduceEventsContext = require('../../datatypes/produce-events-context');
 const cloudWatchEventsCalls = require('../../aws/cloudwatch-events-calls');
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
 const deployPhaseCommon = require('../../common/deploy-phase-common');
+const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
+const bindPhaseCommon = require('../../common/bind-phase-common');
 const deletePhasesCommon = require('../../common/delete-phases-common');
 const handlebarsUtils = require('../../common/handlebars-utils');
 const yaml = require('js-yaml');
@@ -86,13 +86,11 @@ exports.check = function (serviceContext) {
 }
 
 exports.preDeploy = function (serviceContext) {
-    winston.info(`${SERVICE_NAME} - PreDeploy is not required for this service, skipping it`);
-    return Promise.resolve(new PreDeployContext(serviceContext));
+    return preDeployPhaseCommon.preDeployNotRequired(SERVICE_NAME);
 }
 
 exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    winston.info(`${SERVICE_NAME} - Bind is not required for this service, skipping it`);
-    return Promise.resolve(new BindContext(ownServiceContext, dependentOfServiceContext));
+    return bindPhaseCommon.bindNotRequired(ownServiceContext, dependentOfServiceContext, SERVICE_NAME);
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {

--- a/lib/services/dynamodb/index.js
+++ b/lib/services/dynamodb/index.js
@@ -18,10 +18,10 @@ const winston = require('winston');
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
 const deployPhaseCommon = require('../../common/deploy-phase-common');
 const deletePhasesCommon = require('../../common/delete-phases-common');
+const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
+const bindPhaseCommon = require('../../common/bind-phase-common');
 const handlebarsUtils = require('../../common/handlebars-utils');
 const accountConfig = require('../../common/account-config')().getAccountConfig();
-const PreDeployContext = require('../../datatypes/pre-deploy-context');
-const BindContext = require('../../datatypes/bind-context');
 const DeployContext = require('../../datatypes/deploy-context');
 const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../datatypes/un-bind-context');
@@ -129,13 +129,11 @@ exports.check = function (serviceContext) {
 }
 
 exports.preDeploy = function (serviceContext) {
-    winston.info(`${SERVICE_NAME} - PreDeploy not required for this service, skipping it`);
-    return Promise.resolve(new PreDeployContext(serviceContext));
+    return preDeployPhaseCommon.preDeployNotRequired(serviceContext, SERVICE_NAME);
 }
 
 exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    winston.info(`${SERVICE_NAME} - Bind not required for this service, skipping it`);
-    return Promise.resolve(new BindContext(ownServiceContext, dependentOfServiceContext));
+    return bindPhaseCommon.bindNotRequired(ownServiceContext, dependentOfServiceContext, SERVICE_NAME);
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {

--- a/lib/services/ecs/index.js
+++ b/lib/services/ecs/index.js
@@ -15,14 +15,13 @@
  *
  */
 const winston = require('winston');
-const PreDeployContext = require('../../datatypes/pre-deploy-context');
-const BindContext = require('../../datatypes/bind-context');
 const DeployContext = require('../../datatypes/deploy-context');
 const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../datatypes/un-bind-context');
 const accountConfig = require('../../common/account-config')().getAccountConfig();
 const deployPhaseCommon = require('../../common/deploy-phase-common');
 const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
+const bindPhaseCommon = require('../../common/bind-phase-common');
 const deletePhasesCommon = require('../../common/delete-phases-common');
 const handlebarsUtils = require('../../common/handlebars-utils');
 const _ = require('lodash');
@@ -344,21 +343,11 @@ exports.check = function (serviceContext) {
 }
 
 exports.preDeploy = function (serviceContext) {
-    let sgName = deployPhaseCommon.getResourceName(serviceContext);
-    winston.info(`${SERVICE_NAME} - Executing PreDeploy on ${sgName}`);
-
-    return preDeployPhaseCommon.createSecurityGroupForService(sgName, 22)
-        .then(securityGroup => {
-            winston.info(`${SERVICE_NAME} - Finished PreDeploy on ${sgName}`);
-            let preDeployContext = new PreDeployContext(serviceContext);
-            preDeployContext.securityGroups.push(securityGroup);
-            return preDeployContext;
-        });
+    return preDeployPhaseCommon.preDeployCreateSecurityGroup(serviceContext, 22, SERVICE_NAME);
 }
 
 exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    winston.info(`${SERVICE_NAME} - Bind not required for this service, skipping it`);
-    return Promise.resolve(new BindContext(ownServiceContext, dependentOfServiceContext));
+    return bindPhaseCommon.bindNotRequired(ownServiceContext, dependentOfServiceContext, SERVICE_NAME);
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {

--- a/lib/services/efs/index.js
+++ b/lib/services/efs/index.js
@@ -15,15 +15,13 @@
  *
  */
 const winston = require('winston');
-const ec2Calls = require('../../aws/ec2-calls');
 const handlebarsUtils = require('../../common/handlebars-utils');
-const PreDeployContext = require('../../datatypes/pre-deploy-context');
-const BindContext = require('../../datatypes/bind-context');
 const DeployContext = require('../../datatypes/deploy-context');
 const accountConfig = require('../../common/account-config')().getAccountConfig();
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
 const deployPhaseCommon = require('../../common/deploy-phase-common');
 const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
+const bindPhaseCommon = require('../../common/bind-phase-common');
 const deletePhasesCommon = require('../../common/delete-phases-common');
 const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../datatypes/un-bind-context');
@@ -125,31 +123,11 @@ exports.check = function (serviceContext) {
 }
 
 exports.preDeploy = function (serviceContext) {
-    let sgName = deployPhaseCommon.getResourceName(serviceContext);
-    winston.info(`${SERVICE_NAME} - Executing PreDeploy on ${sgName}`);
-
-    return preDeployPhaseCommon.createSecurityGroupForService(sgName)
-        .then(securityGroup => {
-            winston.info(`${SERVICE_NAME} - Finished PreDeploy on ${sgName}`);
-            let preDeployContext = new PreDeployContext(serviceContext);
-            preDeployContext.securityGroups.push(securityGroup);
-            return preDeployContext;
-        });
+    return preDeployPhaseCommon.preDeployCreateSecurityGroup(serviceContext, null, SERVICE_NAME);
 }
 
 exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
-    winston.info(`${SERVICE_NAME} - Executing Bind on ${stackName}`);
-    let ownSg = ownPreDeployContext.securityGroups[0];
-    let sourceSg = dependentOfPreDeployContext.securityGroups[0];
-
-    return ec2Calls.addIngressRuleToSgIfNotExists(sourceSg, ownSg,
-        EFS_SG_PROTOCOL, EFS_PORT,
-        EFS_PORT, accountConfig['vpc'])
-        .then(efsSecurityGroup => {
-            winston.info(`${SERVICE_NAME} - Finished Bind on ${stackName}`);
-            return new BindContext(ownServiceContext, dependentOfServiceContext);
-        });
+    return bindPhaseCommon.bindDependentSecurityGroupToSelf(ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext, EFS_SG_PROTOCOL, EFS_PORT, SERVICE_NAME);
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {

--- a/lib/services/lambda/index.js
+++ b/lib/services/lambda/index.js
@@ -16,8 +16,6 @@
  */
 const winston = require('winston');
 const handlebarsUtils = require('../../common/handlebars-utils');
-const PreDeployContext = require('../../datatypes/pre-deploy-context');
-const BindContext = require('../../datatypes/bind-context');
 const DeployContext = require('../../datatypes/deploy-context');
 const ConsumeEventsContext = require('../../datatypes/consume-events-context');
 const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
@@ -27,6 +25,8 @@ const cloudFormationCalls = require('../../aws/cloudformation-calls');
 const lambdaCalls = require('../../aws/lambda-calls');
 const deployPhaseCommon = require('../../common/deploy-phase-common');
 const deletePhasesCommon = require('../../common/delete-phases-common');
+const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
+const bindPhaseCommon = require('../../common/bind-phase-common');
 const uuid = require('uuid');
 const _ = require('lodash');
 
@@ -127,13 +127,11 @@ exports.check = function (serviceContext) {
 }
 
 exports.preDeploy = function (serviceContext) {
-    winston.info(`${SERVICE_NAME} - PreDeploy is not required for this service, skipping it`);
-    return Promise.resolve(new PreDeployContext(serviceContext));
+    return preDeployPhaseCommon.preDeployNotRequired(serviceContext, SERVICE_NAME);
 }
 
 exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    winston.info(`${SERVICE_NAME} - Bind is not required for this service, skipping it`);
-    return Promise.resolve(new BindContext(ownServiceContext, dependentOfServiceContext));
+    return bindPhaseCommon.bindNotRequired(ownServiceContext, dependentOfServiceContext, SERVICE_NAME);
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {

--- a/lib/services/memcached/index.js
+++ b/lib/services/memcached/index.js
@@ -15,14 +15,12 @@
  *
  */
 const winston = require('winston');
-const ec2Calls = require('../../aws/ec2-calls');
-const PreDeployContext = require('../../datatypes/pre-deploy-context');
-const BindContext = require('../../datatypes/bind-context');
 const DeployContext = require('../../datatypes/deploy-context');
 const accountConfig = require('../../common/account-config')().getAccountConfig();
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
 const deployPhaseCommon = require('../../common/deploy-phase-common');
 const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
+const bindPhaseCommon = require('../../common/bind-phase-common');
 const deletePhasesCommon = require('../../common/delete-phases-common');
 const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../datatypes/un-bind-context');
@@ -120,29 +118,11 @@ exports.check = function (serviceContext) {
 }
 
 exports.preDeploy = function (serviceContext) {
-    let sgName = deployPhaseCommon.getResourceName(serviceContext);
-    winston.info(`${SERVICE_NAME} - Executing PreDeploy on '${sgName}'`);
-
-    return preDeployPhaseCommon.createSecurityGroupForService(sgName)
-        .then(securityGroup => {
-            winston.info(`${SERVICE_NAME} - Finished PreDeploy on '${sgName}'`);
-            let preDeployContext = new PreDeployContext(serviceContext);
-            preDeployContext.securityGroups.push(securityGroup);
-            return preDeployContext;
-        });
+    return preDeployPhaseCommon.preDeployCreateSecurityGroup(serviceContext, null, SERVICE_NAME);
 }
 
 exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
-    winston.info(`${SERVICE_NAME} - Executing Bind on '${stackName}'`);
-    let ownSg = ownPreDeployContext.securityGroups[0];
-    let sourceSg = dependentOfPreDeployContext.securityGroups[0];
-
-    return ec2Calls.addIngressRuleToSgIfNotExists(sourceSg, ownSg, MEMCACHED_SG_PROTOCOL, MEMCACHED_PORT, MEMCACHED_PORT, accountConfig.vpc)
-        .then(() => {
-            winston.info(`${SERVICE_NAME} - Finished Bind on '${stackName}'`);
-            return new BindContext(ownServiceContext, dependentOfServiceContext);
-        });
+    return bindPhaseCommon.bindDependentSecurityGroupToSelf(ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext, MEMCACHED_SG_PROTOCOL, MEMCACHED_PORT, SERVICE_NAME);
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {

--- a/lib/services/mysql/index.js
+++ b/lib/services/mysql/index.js
@@ -15,14 +15,12 @@
  *
  */
 const winston = require('winston');
-const ec2Calls = require('../../aws/ec2-calls');
 const handlebarsUtils = require('../../common/handlebars-utils');
-const PreDeployContext = require('../../datatypes/pre-deploy-context');
-const BindContext = require('../../datatypes/bind-context');
 const accountConfig = require('../../common/account-config')().getAccountConfig();
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
 const deployPhaseCommon = require('../../common/deploy-phase-common');
 const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
+const bindPhaseCommon = require('../../common/bind-phase-common');
 const deletePhasesCommon = require('../../common/delete-phases-common');
 const rdsCommon = require('../../common/rds-common');
 const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
@@ -108,31 +106,11 @@ exports.check = function (serviceContext) {
 }
 
 exports.preDeploy = function (serviceContext) {
-    let sgName = deployPhaseCommon.getResourceName(serviceContext);
-    winston.info(`${SERVICE_NAME} - Executing PreDeploy on ${sgName}`);
-
-    return preDeployPhaseCommon.createSecurityGroupForService(sgName, MYSQL_PORT)
-        .then(securityGroup => {
-            winston.info(`${SERVICE_NAME} - Finished PreDeploy on ${sgName}`);
-            let preDeployContext = new PreDeployContext(serviceContext);
-            preDeployContext.securityGroups.push(securityGroup);
-            return preDeployContext;
-        });
+    return preDeployPhaseCommon.preDeployCreateSecurityGroup(serviceContext, MYSQL_PORT, SERVICE_NAME);
 }
 
 exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
-    winston.info(`${SERVICE_NAME} - Executing Bind on ${stackName}`);
-    let ownSg = ownPreDeployContext.securityGroups[0];
-    let sourceSg = dependentOfPreDeployContext.securityGroups[0];
-
-    return ec2Calls.addIngressRuleToSgIfNotExists(sourceSg, ownSg,
-        MYSQL_PROTOCOL, MYSQL_PORT,
-        MYSQL_PORT, accountConfig['vpc'])
-        .then(mysqlSecurityGroup => {
-            winston.info(`${SERVICE_NAME} - Finished Bind on ${stackName}`);
-            return new BindContext(ownServiceContext, dependentOfServiceContext);
-        });
+    return bindPhaseCommon.bindDependentSecurityGroupToSelf(ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext, MYSQL_PROTOCOL, MYSQL_PORT, SERVICE_NAME);
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {

--- a/lib/services/postgresql/index.js
+++ b/lib/services/postgresql/index.js
@@ -15,14 +15,12 @@
  *
  */
 const winston = require('winston');
-const ec2Calls = require('../../aws/ec2-calls');
 const handlebarsUtils = require('../../common/handlebars-utils');
-const PreDeployContext = require('../../datatypes/pre-deploy-context');
-const BindContext = require('../../datatypes/bind-context');
 const accountConfig = require('../../common/account-config')().getAccountConfig();
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
 const deployPhaseCommon = require('../../common/deploy-phase-common');
 const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
+const bindPhaseCommon = require('../../common/bind-phase-common');
 const deletePhasesCommon = require('../../common/delete-phases-common');
 const rdsCommon = require('../../common/rds-common');
 const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
@@ -111,31 +109,11 @@ exports.check = function (serviceContext) {
 }
 
 exports.preDeploy = function (serviceContext) {
-    let sgName = deployPhaseCommon.getResourceName(serviceContext);
-    winston.info(`${SERVICE_NAME} - Executing PreDeploy on ${sgName}`);
-
-    return preDeployPhaseCommon.createSecurityGroupForService(sgName, POSTGRES_PORT)
-        .then(securityGroup => {
-            winston.info(`${SERVICE_NAME} - Finished PreDeploy on ${sgName}`);
-            let preDeployContext = new PreDeployContext(serviceContext);
-            preDeployContext.securityGroups.push(securityGroup);
-            return preDeployContext;
-        });
+    return preDeployPhaseCommon.preDeployCreateSecurityGroup(serviceContext, POSTGRES_PORT, SERVICE_NAME);
 }
 
 exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
-    winston.info(`${SERVICE_NAME} - Executing Bind on ${stackName}`);
-    let ownSg = ownPreDeployContext.securityGroups[0];
-    let sourceSg = dependentOfPreDeployContext.securityGroups[0];
-
-    return ec2Calls.addIngressRuleToSgIfNotExists(sourceSg, ownSg,
-        POSTGRES_PROTOCOL, POSTGRES_PORT,
-        POSTGRES_PORT, accountConfig['vpc'])
-        .then(postgresSecurityGroup => {
-            winston.info(`PostgreSQL - Finished Bind on ${stackName}`);
-            return new BindContext(ownServiceContext, dependentOfServiceContext);
-        });
+    return bindPhaseCommon.bindDependentSecurityGroupToSelf(ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext, POSTGRES_PROTOCOL, POSTGRES_PORT, SERVICE_NAME);
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {

--- a/lib/services/redis/index.js
+++ b/lib/services/redis/index.js
@@ -15,14 +15,12 @@
  *
  */
 const winston = require('winston');
-const ec2Calls = require('../../aws/ec2-calls');
-const PreDeployContext = require('../../datatypes/pre-deploy-context');
-const BindContext = require('../../datatypes/bind-context');
 const DeployContext = require('../../datatypes/deploy-context');
 const accountConfig = require('../../common/account-config')().getAccountConfig();
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
 const deployPhaseCommon = require('../../common/deploy-phase-common');
 const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
+const bindPhaseCommon = require('../../common/bind-phase-common');
 const deletePhasesCommon = require('../../common/delete-phases-common');
 const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../datatypes/un-bind-context');
@@ -175,29 +173,11 @@ exports.check = function (serviceContext) {
 }
 
 exports.preDeploy = function (serviceContext) {
-    let sgName = deployPhaseCommon.getResourceName(serviceContext);
-    winston.info(`${SERVICE_NAME} - Executing PreDeploy on '${sgName}'`);
-
-    return preDeployPhaseCommon.createSecurityGroupForService(sgName)
-        .then(securityGroup => {
-            winston.info(`${SERVICE_NAME} - Finished PreDeploy on '${sgName}'`);
-            let preDeployContext = new PreDeployContext(serviceContext);
-            preDeployContext.securityGroups.push(securityGroup);
-            return preDeployContext;
-        });
+    return preDeployPhaseCommon.preDeployCreateSecurityGroup(serviceContext, null, SERVICE_NAME);
 }
 
 exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
-    winston.info(`${SERVICE_NAME} - Executing Bind on '${stackName}'`);
-    let ownSg = ownPreDeployContext.securityGroups[0];
-    let sourceSg = dependentOfPreDeployContext.securityGroups[0];
-
-    return ec2Calls.addIngressRuleToSgIfNotExists(sourceSg, ownSg, REDIS_SG_PROTOCOL, REDIS_PORT, REDIS_PORT, accountConfig.vpc)
-        .then(() => {
-            winston.info(`${SERVICE_NAME} - Finished Bind on '${stackName}'`);
-            return new BindContext(ownServiceContext, dependentOfServiceContext);
-        });
+    return bindPhaseCommon.bindDependentSecurityGroupToSelf(ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext, REDIS_SG_PROTOCOL, REDIS_PORT, SERVICE_NAME);
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {

--- a/lib/services/s3/index.js
+++ b/lib/services/s3/index.js
@@ -15,13 +15,13 @@
  *
  */
 const winston = require('winston');
-const PreDeployContext = require('../../datatypes/pre-deploy-context');
-const BindContext = require('../../datatypes/bind-context');
 const DeployContext = require('../../datatypes/deploy-context');
 const accountConfig = require('../../common/account-config')().getAccountConfig();
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
 const deployPhaseCommon = require('../../common/deploy-phase-common');
 const deletePhasesCommon = require('../../common/delete-phases-common');
+const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
+const bindPhaseCommon = require('../../common/bind-phase-common');
 const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../datatypes/un-bind-context');
 const handlebarsUtils = require('../../common/handlebars-utils');
@@ -111,13 +111,11 @@ exports.check = function (serviceContext) {
 }
 
 exports.preDeploy = function (serviceContext) {
-    winston.info(`${SERVICE_NAME} - PreDeploy is not required for this service, skipping it`);
-    return Promise.resolve(new PreDeployContext(serviceContext));
+    return preDeployPhaseCommon.preDeployNotRequired(serviceContext, SERVICE_NAME);
 }
 
 exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    winston.info(`${SERVICE_NAME} - Bind is not required for this service, skipping it`);
-    return Promise.resolve(new BindContext(ownServiceContext, dependentOfServiceContext));
+    return bindPhaseCommon.bindNotRequired(ownServiceContext, dependentOfServiceContext, SERVICE_NAME);
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {

--- a/lib/services/s3staticsite/index.js
+++ b/lib/services/s3staticsite/index.js
@@ -16,12 +16,12 @@
  */
 const winston = require('winston');
 const s3Calls = require('../../aws/s3-calls');
-const PreDeployContext = require('../../datatypes/pre-deploy-context');
-const BindContext = require('../../datatypes/bind-context');
 const DeployContext = require('../../datatypes/deploy-context');
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
 const deployPhaseCommon = require('../../common/deploy-phase-common');
 const deletePhasesCommon = require('../../common/delete-phases-common');
+const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
+const bindPhaseCommon = require('../../common/bind-phase-common');
 const accountConfig = require('../../common/account-config')().getAccountConfig();;
 const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../datatypes/un-bind-context');
@@ -92,13 +92,11 @@ exports.check = function (serviceContext) {
 }
 
 exports.preDeploy = function (serviceContext) {
-    winston.info(`${SERVICE_NAME} - PreDeploy is not required for this service, skipping it`);
-    return Promise.resolve(new PreDeployContext(serviceContext));
+    return preDeployPhaseCommon.preDeployNotRequired(serviceContext, SERVICE_NAME);
 }
 
 exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    winston.info(`${SERVICE_NAME} - Bind is not required for this service, skipping it`);
-    return Promise.resolve(new BindContext(ownServiceContext, dependentOfServiceContext));
+    return bindPhaseCommon.bindNotRequired(ownServiceContext, dependentOfServiceContext, SERVICE_NAME);
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {

--- a/lib/services/sns/index.js
+++ b/lib/services/sns/index.js
@@ -16,14 +16,14 @@
  */
 const winston = require('winston');
 const handlebarsUtils = require('../../common/handlebars-utils');
-const PreDeployContext = require('../../datatypes/pre-deploy-context');
-const BindContext = require('../../datatypes/bind-context');
 const ProduceEventsContext = require('../../datatypes/produce-events-context');
 const DeployContext = require('../../datatypes/deploy-context');
 const snsCalls = require('../../aws/sns-calls');
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
 const deployPhaseCommon = require('../../common/deploy-phase-common');
 const deletePhasesCommon = require('../../common/delete-phases-common');
+const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
+const bindPhaseCommon = require('../../common/bind-phase-common');
 const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../datatypes/un-bind-context');
 
@@ -92,13 +92,11 @@ exports.check = function (serviceContext) {
 }
 
 exports.preDeploy = function (serviceContext) {
-    winston.info(`${SERVICE_NAME} - PreDeploy is not required for this service, skipping it`);
-    return Promise.resolve(new PreDeployContext(serviceContext));
+    return preDeployPhaseCommon.preDeployNotRequired(serviceContext, SERVICE_NAME);
 }
 
 exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    winston.info(`${SERVICE_NAME} - Bind is not required for this service, skipping it`);
-    return Promise.resolve(new BindContext(ownServiceContext, dependentOfServiceContext));
+    return bindPhaseCommon.bindNotRequired(ownServiceContext, dependentOfServiceContext, SERVICE_NAME);
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {

--- a/lib/services/sqs/index.js
+++ b/lib/services/sqs/index.js
@@ -16,8 +16,6 @@
  */
 const winston = require('winston');
 const handlebarsUtils = require('../../common/handlebars-utils');
-const PreDeployContext = require('../../datatypes/pre-deploy-context');
-const BindContext = require('../../datatypes/bind-context');
 const DeployContext = require('../../datatypes/deploy-context');
 const ConsumeEventsContext = require('../../datatypes/consume-events-context');
 const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
@@ -25,6 +23,8 @@ const UnBindContext = require('../../datatypes/un-bind-context');
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
 const deployPhaseCommon = require('../../common/deploy-phase-common');
 const deletePhasesCommon = require('../../common/delete-phases-common');
+const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
+const bindPhaseCommon = require('../../common/bind-phase-common');
 const sqsCalls = require('../../aws/sqs-calls');
 
 const SERVICE_NAME = "SQS";
@@ -135,14 +135,13 @@ exports.check = function (serviceContext) {
 }
 
 exports.preDeploy = function (serviceContext) {
-    winston.info(`${SERVICE_NAME} - PreDeploy is not required for this service, skipping it`);
-    return Promise.resolve(new PreDeployContext(serviceContext));
+    return preDeployPhaseCommon.preDeployNotRequired(serviceContext, SERVICE_NAME);
 }
 
 exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    winston.info(`${SERVICE_NAME} - Bind is not required for this service, skipping it`);
-    return Promise.resolve(new BindContext(ownServiceContext, dependentOfServiceContext));
+    return bindPhaseCommon.bindNotRequired(ownServiceContext, dependentOfServiceContext, SERVICE_NAME);
 }
+
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
     let stackName = deployPhaseCommon.getResourceName(ownServiceContext);

--- a/test/common/bind-phase-common-test.js
+++ b/test/common/bind-phase-common-test.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const ServiceContext = require('../../lib/datatypes/service-context');
+const PreDeployContext = require('../../lib/datatypes/pre-deploy-context');
+const BindContext = require('../../lib/datatypes/bind-context');
+const bindPhaseCommon = require('../../lib/common/bind-phase-common');
+const ec2Calls = require('../../lib/aws/ec2-calls');
+const sinon = require('sinon');
+const expect = require('chai').expect;
+
+describe('bind phases common module', function () {
+    let sandbox;
+
+    beforeEach(function () {
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    describe('bindDependentSecurityGroupToSelf', function() {
+        it('should add an ssh ingress on the security group', function() {
+            let appName = "FakeApp";
+            let envName = "FakeEnv";
+            let deployVersion = "1";
+            let ownServiceContext = new ServiceContext(appName, envName, "FakeService", "mysql", deployVersion, {});
+            let ownPreDeployContext = new PreDeployContext(ownServiceContext);
+            ownPreDeployContext.securityGroups.push({
+                GroupId: 'FakeId'
+            });
+
+            let dependentOfServiceContext = new ServiceContext(appName, envName, "FakeDependentOfService", "ecs", deployVersion, {});
+            let dependentOfPreDeployContext = new PreDeployContext(dependentOfServiceContext);
+            dependentOfPreDeployContext.securityGroups.push({
+                GroupId: 'OtherId'
+            });
+
+            let addIngressRuleToSgIfNotExistsStub = sandbox.stub(ec2Calls, 'addIngressRuleToSgIfNotExists').returns(Promise.resolve({}));
+
+            return bindPhaseCommon.bindDependentSecurityGroupToSelf(ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext, 'tcp', 22, "FakeService")
+                .then(bindContext => {
+                    expect(bindContext).to.be.instanceof(BindContext);
+                    expect(addIngressRuleToSgIfNotExistsStub.callCount).to.equal(1);
+                });
+        })
+    })
+
+    describe('bindNotRequired', function () {
+        it('should return an empty bind context', function () {
+            let appName = "FakeApp";
+            let envName = "FakeEnv";
+            let ownServiceContext = new ServiceContext(appName, envName, "FakeService", "efs", "1", {});
+            let dependentOfServiceContext = new ServiceContext(appName, envName, "FakeDependentService", "ecs", "1", {});
+            
+            return bindPhaseCommon.bindNotRequired(ownServiceContext, dependentOfServiceContext, "FakeService")
+                .then(bindContext => {
+                    expect(bindContext).to.be.instanceof(BindContext);
+                });
+        });
+    });
+
+});

--- a/test/services/apiaccess/apiaccess-test.js
+++ b/test/services/apiaccess/apiaccess-test.js
@@ -23,6 +23,8 @@ const BindContext = require('../../../lib/datatypes/bind-context');
 const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../../lib/datatypes/un-bind-context');
 const UnDeployContext = require('../../../lib/datatypes/un-deploy-context');
+const preDeployPhaseCommon = require('../../../lib/common/pre-deploy-phase-common');
+const bindPhaseCommon = require('../../../lib/common/bind-phase-common');
 const sinon = require('sinon');
 const expect = require('chai').expect;
 
@@ -59,8 +61,11 @@ describe('apiaccess deployer', function () {
     describe('preDeploy', function () {
         it('should return an empty predeploy context', function () {
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "apiaccess", "1", {});
+            let preDeployNotRequiredStub = sandbox.stub(preDeployPhaseCommon, 'preDeployNotRequired').returns(Promise.resolve(new PreDeployContext(serviceContext)));
+
             return apiaccess.preDeploy(serviceContext)
                 .then(preDeployContext => {
+                    expect(preDeployNotRequiredStub.callCount).to.equal(1);
                     expect(preDeployContext).to.be.instanceof(PreDeployContext);
                 });
         });
@@ -69,8 +74,11 @@ describe('apiaccess deployer', function () {
     describe('bind', function () {
         it('should return an empty bind context', function () {
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "apiaccess", "1", {});
+            let bindNotRequiredStub = sandbox.stub(bindPhaseCommon, 'bindNotRequired').returns(Promise.resolve(new BindContext(serviceContext, {})));
+
             return apiaccess.bind(serviceContext)
                 .then(bindContext => {
+                    expect(bindNotRequiredStub.callCount).to.equal(1);
                     expect(bindContext).to.be.instanceof(BindContext);
                 });
         });

--- a/test/services/apigateway/apigateway-test.js
+++ b/test/services/apigateway/apigateway-test.js
@@ -24,6 +24,8 @@ const sinon = require('sinon');
 const expect = require('chai').expect;
 const deployPhaseCommon = require('../../../lib/common/deploy-phase-common');
 const deletePhasesCommon = require('../../../lib/common/delete-phases-common');
+const preDeployPhaseCommon = require('../../../lib/common/pre-deploy-phase-common');
+const bindPhaseCommon = require('../../../lib/common/bind-phase-common');
 const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../../lib/datatypes/un-bind-context');
 const UnDeployContext = require('../../../lib/datatypes/un-deploy-context');
@@ -77,8 +79,11 @@ describe('apigateway deployer', function () {
     describe('preDeploy', function () {
         it('should return an empty preDeploy context', function () {
             let serviceContext = new ServiceContext("FakeName", "FakeEnv", "FakeService", "FakeType", "1", {});
+            let preDeployNotRequiredStub = sandbox.stub(preDeployPhaseCommon, 'preDeployNotRequired').returns(Promise.resolve(new PreDeployContext(serviceContext)));
+
             return apigateway.preDeploy(serviceContext)
                 .then(preDeployContext => {
+                    expect(preDeployNotRequiredStub.callCount).to.equal(1);
                     expect(preDeployContext).to.be.instanceof(PreDeployContext);
                 });
         });
@@ -86,8 +91,11 @@ describe('apigateway deployer', function () {
 
     describe('bind', function () {
         it('should return an empty bind context', function () {
+            let bindNotRequiredStub = sandbox.stub(bindPhaseCommon, 'bindNotRequired').returns(Promise.resolve(new BindContext({}, {})));
+
             return apigateway.bind(null, null, null, null)
                 .then(bindContext => {
+                    expect(bindNotRequiredStub.callCount).to.equal(1);
                     expect(bindContext).to.be.instanceof(BindContext);
                 });
         });

--- a/test/services/cloudwatchevent/cloudwatchevent-test.js
+++ b/test/services/cloudwatchevent/cloudwatchevent-test.js
@@ -16,11 +16,12 @@
  */
 const accountConfig = require('../../../lib/common/account-config')(`${__dirname}/../../test-account-config.yml`).getAccountConfig();
 const cloudWatchEvent = require('../../../lib/services/cloudwatchevent');
-const cloudFormationCalls = require('../../../lib/aws/cloudformation-calls');
 const cloudWatchEventsCalls = require('../../../lib/aws/cloudwatch-events-calls');
 const deployPhaseCommon = require('../../../lib/common/deploy-phase-common');
 const ServiceContext = require('../../../lib/datatypes/service-context');
 const deletePhasesCommon = require('../../../lib/common/delete-phases-common');
+const preDeployPhaseCommon = require('../../../lib/common/pre-deploy-phase-common');
+const bindPhaseCommon = require('../../../lib/common/bind-phase-common');
 const ProduceEventsContext = require('../../../lib/datatypes/produce-events-context');
 const DeployContext = require('../../../lib/datatypes/deploy-context');
 const UnDeployContext = require('../../../lib/datatypes/un-deploy-context');
@@ -66,8 +67,11 @@ describe('cloudwatchevent deployer', function () {
     describe('preDeploy', function () {
         it('should return an empty predeploy context', function () {
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
+            let preDeployNotRequiredStub = sandbox.stub(preDeployPhaseCommon, 'preDeployNotRequired').returns(Promise.resolve(new PreDeployContext(serviceContext)));
+
             return cloudWatchEvent.preDeploy(serviceContext)
                 .then(preDeployContext => {
+                    expect(preDeployNotRequiredStub.callCount).to.equal(1);
                     expect(preDeployContext).to.be.instanceof(PreDeployContext);
                 });
         });
@@ -76,8 +80,11 @@ describe('cloudwatchevent deployer', function () {
     describe('bind', function () {
         it('should return an empty bind context', function () {
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
+            let bindNotRequiredStub = sandbox.stub(bindPhaseCommon, 'bindNotRequired').returns(Promise.resolve(new BindContext({}, {})));
+            
             return cloudWatchEvent.bind(serviceContext)
                 .then(bindContext => {
+                    expect(bindNotRequiredStub.callCount).to.equal(1);
                     expect(bindContext).to.be.instanceof(BindContext);
                 });
         });

--- a/test/services/dynamodb/dynamodb-test.js
+++ b/test/services/dynamodb/dynamodb-test.js
@@ -22,6 +22,8 @@ const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
 const BindContext = require('../../../lib/datatypes/bind-context');
 const deployPhaseCommon = require('../../../lib/common/deploy-phase-common');
 const deletePhasesCommon = require('../../../lib/common/delete-phases-common');
+const preDeployPhaseCommon = require('../../../lib/common/pre-deploy-phase-common');
+const bindPhaseCommon = require('../../../lib/common/bind-phase-common');
 const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../../lib/datatypes/un-bind-context');
 const UnDeployContext = require('../../../lib/datatypes/un-deploy-context');
@@ -77,8 +79,11 @@ describe('dynamodb deployer', function () {
     describe('preDeploy', function () {
         it('should do nothing and just return an empty PreDeployContext', function () {
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
+            let preDeployNotRequiredStub = sandbox.stub(preDeployPhaseCommon, 'preDeployNotRequired').returns(Promise.resolve(new PreDeployContext(serviceContext)));
+
             return dynamodb.preDeploy(serviceContext)
                 .then(preDeployContext => {
+                    expect(preDeployNotRequiredStub.callCount).to.equal(1);
                     expect(preDeployContext).to.be.instanceof(PreDeployContext);
                 });
         });
@@ -86,12 +91,11 @@ describe('dynamodb deployer', function () {
 
     describe('bind', function () {
         it('should do nothing and just return an empty BindContext', function () {
-            let ownServiceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
-            let ownPreDeployContext = new PreDeployContext(ownServiceContext);
-            let dependentOfServiceContext = new ServiceContext("FakeApp", "FakeEnv", "OtherService", "OtherType", "1", {});
-            let dependentOfPreDeployContext = new PreDeployContext(ownServiceContext);
-            return dynamodb.bind(ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext)
+            let bindNotRequiredStub = sandbox.stub(bindPhaseCommon, 'bindNotRequired').returns(Promise.resolve(new BindContext({}, {})));
+
+            return dynamodb.bind({}, {}, {}, {})
                 .then(bindContext => {
+                    expect(bindNotRequiredStub.callCount).to.equal(1);
                     expect(bindContext).to.be.instanceof(BindContext);
                 });
         });

--- a/test/services/efs/efs-test.js
+++ b/test/services/efs/efs-test.js
@@ -16,13 +16,13 @@
  */
 const accountConfig = require('../../../lib/common/account-config')(`${__dirname}/../../test-account-config.yml`).getAccountConfig();
 const efs = require('../../../lib/services/efs');
-const ec2Calls = require('../../../lib/aws/ec2-calls');
 const ServiceContext = require('../../../lib/datatypes/service-context');
 const DeployContext = require('../../../lib/datatypes/deploy-context');
 const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
 const BindContext = require('../../../lib/datatypes/bind-context');
 const deployPhaseCommon = require('../../../lib/common/deploy-phase-common');
 const preDeployPhaseCommon = require('../../../lib/common/pre-deploy-phase-common');
+const bindPhaseCommon = require('../../../lib/common/bind-phase-common');
 const deletePhasesCommon = require('../../../lib/common/delete-phases-common');
 const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../../lib/datatypes/un-bind-context');
@@ -66,44 +66,31 @@ describe('efs deployer', function () {
     describe('preDeploy', function () {
         it('should create a security group', function () {
             let groupId = "FakeSgGroupId";
-            let createSecurityGroupStub = sandbox.stub(preDeployPhaseCommon, 'createSecurityGroupForService').returns(Promise.resolve({
-                GroupId: groupId
-            }));
-
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
+            let preDeployContext = new PreDeployContext(serviceContext);
+            preDeployContext.securityGroups.push({
+                GroupId: groupId
+            });
+            let createSgStub = sandbox.stub(preDeployPhaseCommon, 'preDeployCreateSecurityGroup').returns(Promise.resolve(preDeployContext));
+
             return efs.preDeploy(serviceContext)
                 .then(preDeployContext => {
                     expect(preDeployContext).to.be.instanceof(PreDeployContext);
                     expect(preDeployContext.securityGroups.length).to.equal(1);
                     expect(preDeployContext.securityGroups[0].GroupId).to.equal(groupId);
-                    expect(createSecurityGroupStub.calledOnce).to.be.true;
+                    expect(createSgStub.callCount).to.equal(1);
                 });
         });
     });
 
     describe('bind', function () {
         it('should add the source sg to its own sg as an ingress rule', function () {
-            let appName = "FakeApp";
-            let envName = "FakeEnv";
-            let deployVersion = "1";
-            let ownServiceContext = new ServiceContext(appName, envName, "FakeService", "efs", deployVersion, {});
-            let ownPreDeployContext = new PreDeployContext(ownServiceContext);
-            ownPreDeployContext.securityGroups.push({
-                GroupId: 'FakeId'
-            });
-
-            let dependentOfServiceContext = new ServiceContext(appName, envName, "FakeDependentOfService", "ecs", deployVersion, {});
-            let dependentOfPreDeployContext = new PreDeployContext(dependentOfServiceContext);
-            dependentOfPreDeployContext.securityGroups.push({
-                GroupId: 'OtherId'
-            });
-
-            let addIngressRuleToSgIfNotExistsStub = sandbox.stub(ec2Calls, 'addIngressRuleToSgIfNotExists').returns(Promise.resolve({}));
-
-            return efs.bind(ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext)
+            let bindSgStub = sandbox.stub(bindPhaseCommon, 'bindDependentSecurityGroupToSelf').returns(Promise.resolve(new BindContext({}, {})));
+            
+            return efs.bind({}, {}, {}, {})
                 .then(bindContext => {
                     expect(bindContext).to.be.instanceof(BindContext);
-                    expect(addIngressRuleToSgIfNotExistsStub.calledOnce).to.be.true;
+                    expect(bindSgStub.callCount).to.equal(1);
                 });
         });
     });

--- a/test/services/lambda/lambda-test.js
+++ b/test/services/lambda/lambda-test.js
@@ -27,6 +27,8 @@ const BindContext = require('../../../lib/datatypes/bind-context');
 const UnBindContext = require('../../../lib/datatypes/un-bind-context');
 const deployPhaseCommon = require('../../../lib/common/deploy-phase-common');
 const deletePhasesCommon = require('../../../lib/common/delete-phases-common');
+const preDeployPhaseCommon = require('../../../lib/common/pre-deploy-phase-common');
+const bindPhaseCommon = require('../../../lib/common/bind-phase-common');
 const sinon = require('sinon');
 const expect = require('chai').expect;
 
@@ -86,21 +88,24 @@ describe('lambda deployer', function () {
     describe('preDeploy', function () {
         it('should return an empty predeploy context since it doesnt do anything', function () {
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
+            let preDeployNotRequiredStub = sandbox.stub(preDeployPhaseCommon, 'preDeployNotRequired').returns(Promise.resolve(new PreDeployContext(serviceContext)));
+
             return lambda.preDeploy(serviceContext)
                 .then(preDeployContext => {
                     expect(preDeployContext).to.be.instanceof(PreDeployContext);
-                    expect(preDeployContext.appName).to.equal(serviceContext.appName);
+                    expect(preDeployNotRequiredStub.callCount).to.equal(1);
                 });
         });
     });
 
     describe('bind', function () {
         it('should return an empty bind context since it doesnt do anything', function () {
-            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
-            return lambda.bind(serviceContext)
+            let bindNotRequiredStub = sandbox.stub(bindPhaseCommon, 'bindNotRequired').returns(Promise.resolve(new BindContext({}, {})));
+
+            return lambda.bind({}, {}, {}, {})
                 .then(bindContext => {
                     expect(bindContext).to.be.instanceof(BindContext);
-                    expect(bindContext.dependencyServiceContext.appName).to.equal(serviceContext.appName);
+                    expect(bindNotRequiredStub.callCount).to.equal(1);
                 });
         });
     });

--- a/test/services/memcached/memcached-test.js
+++ b/test/services/memcached/memcached-test.js
@@ -16,13 +16,13 @@
  */
 const accountConfig = require('../../../lib/common/account-config')(`${__dirname}/../../test-account-config.yml`).getAccountConfig();
 const memcached = require('../../../lib/services/memcached');
-const ec2Calls = require('../../../lib/aws/ec2-calls');
 const ServiceContext = require('../../../lib/datatypes/service-context');
 const DeployContext = require('../../../lib/datatypes/deploy-context');
 const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
 const BindContext = require('../../../lib/datatypes/bind-context');
 const deployPhaseCommon = require('../../../lib/common/deploy-phase-common');
 const preDeployPhaseCommon = require('../../../lib/common/pre-deploy-phase-common');
+const bindPhaseCommon = require('../../../lib/common/bind-phase-common');
 const deletePhasesCommon = require('../../../lib/common/delete-phases-common');
 const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../../lib/datatypes/un-bind-context');
@@ -79,44 +79,31 @@ describe('memcached deployer', function () {
     describe('preDeploy', function () {
         it('should create a security group', function () {
             let groupId = "FakeSgGroupId";
-            let createSecurityGroupStub = sandbox.stub(preDeployPhaseCommon, 'createSecurityGroupForService').returns(Promise.resolve({
-                GroupId: groupId
-            }));
-
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "memcached", "1", {});
+            let preDeployContext = new PreDeployContext(serviceContext);
+            preDeployContext.securityGroups.push({
+                GroupId: groupId
+            });
+            let preDeployCreateSgStub = sandbox.stub(preDeployPhaseCommon, 'preDeployCreateSecurityGroup').returns(Promise.resolve(preDeployContext));
+
             return memcached.preDeploy(serviceContext)
                 .then(preDeployContext => {
                     expect(preDeployContext).to.be.instanceof(PreDeployContext);
                     expect(preDeployContext.securityGroups.length).to.equal(1);
                     expect(preDeployContext.securityGroups[0].GroupId).to.equal(groupId);
-                    expect(createSecurityGroupStub.calledOnce).to.be.true;
+                    expect(preDeployCreateSgStub.callCount).to.equal(1);
                 });
         });
     });
 
     describe('bind', function () {
         it('should add the source sg to its own sg as an ingress rule', function () {
-            let appName = "FakeApp";
-            let envName = "FakeEnv";
-            let deployVersion = "1";
-            let ownServiceContext = new ServiceContext(appName, envName, "FakeService", "memcached", deployVersion, {});
-            let ownPreDeployContext = new PreDeployContext(ownServiceContext);
-            ownPreDeployContext.securityGroups.push({
-                GroupId: 'FakeId'
-            });
+            let bindSgStub = sandbox.stub(bindPhaseCommon, 'bindDependentSecurityGroupToSelf').returns(Promise.resolve(new BindContext({}, {})));
 
-            let dependentOfServiceContext = new ServiceContext(appName, envName, "FakeDependentOfService", "ecs", deployVersion, {});
-            let dependentOfPreDeployContext = new PreDeployContext(dependentOfServiceContext);
-            dependentOfPreDeployContext.securityGroups.push({
-                GroupId: 'OtherId'
-            });
-
-            let addIngressRuleToSgIfNotExistsStub = sandbox.stub(ec2Calls, 'addIngressRuleToSgIfNotExists').returns(Promise.resolve({}));
-
-            return memcached.bind(ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext)
+            return memcached.bind({}, {}, {}, {})
                 .then(bindContext => {
                     expect(bindContext).to.be.instanceof(BindContext);
-                    expect(addIngressRuleToSgIfNotExistsStub.calledOnce).to.be.true;
+                    expect(bindSgStub.callCount).to.equal(1);
                 });
         });
     });

--- a/test/services/mysql/mysql-test.js
+++ b/test/services/mysql/mysql-test.js
@@ -16,15 +16,14 @@
  */
 const accountConfig = require('../../../lib/common/account-config')(`${__dirname}/../../test-account-config.yml`).getAccountConfig();
 const mysql = require('../../../lib/services/mysql');
-const ec2Calls = require('../../../lib/aws/ec2-calls');
 const ssmCalls = require('../../../lib/aws/ssm-calls');
 const cloudFormationCalls = require('../../../lib/aws/cloudformation-calls');
 const ServiceContext = require('../../../lib/datatypes/service-context');
 const DeployContext = require('../../../lib/datatypes/deploy-context');
 const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
 const BindContext = require('../../../lib/datatypes/bind-context');
-const deployPhaseCommon = require('../../../lib/common/deploy-phase-common');
 const preDeployPhaseCommon = require('../../../lib/common/pre-deploy-phase-common');
+const bindPhaseCommon = require('../../../lib/common/bind-phase-common');
 const deletePhasesCommon = require('../../../lib/common/delete-phases-common');
 const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../../lib/datatypes/un-bind-context');
@@ -67,44 +66,31 @@ describe('mysql deployer', function () {
     describe('preDeploy', function () {
         it('should create a security group', function () {
             let groupId = "FakeSgGroupId";
-            let createSecurityGroupStub = sandbox.stub(preDeployPhaseCommon, 'createSecurityGroupForService').returns(Promise.resolve({
-                GroupId: groupId
-            }));
-
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "mysql", "1", {});
+            let preDeployContext = new PreDeployContext(serviceContext);
+            preDeployContext.securityGroups.push({
+                GroupId: groupId
+            });
+            let createSgStub = sandbox.stub(preDeployPhaseCommon, 'preDeployCreateSecurityGroup').returns(Promise.resolve(preDeployContext));
+
             return mysql.preDeploy(serviceContext)
                 .then(preDeployContext => {
                     expect(preDeployContext).to.be.instanceof(PreDeployContext);
                     expect(preDeployContext.securityGroups.length).to.equal(1);
                     expect(preDeployContext.securityGroups[0].GroupId).to.equal(groupId);
-                    expect(createSecurityGroupStub.calledOnce).to.be.true;
+                    expect(createSgStub.callCount).to.equal(1);
                 });
         });
     });
 
     describe('bind', function () {
         it('should add the source sg to its own sg as an ingress rule', function () {
-            let appName = "FakeApp";
-            let envName = "FakeEnv";
-            let deployVersion = "1";
-            let ownServiceContext = new ServiceContext(appName, envName, "FakeService", "mysql", deployVersion, {});
-            let ownPreDeployContext = new PreDeployContext(ownServiceContext);
-            ownPreDeployContext.securityGroups.push({
-                GroupId: 'FakeId'
-            });
+            let bindSgStub = sandbox.stub(bindPhaseCommon, 'bindDependentSecurityGroupToSelf').returns(Promise.resolve(new BindContext({}, {})));
 
-            let dependentOfServiceContext = new ServiceContext(appName, envName, "FakeDependentOfService", "ecs", deployVersion, {});
-            let dependentOfPreDeployContext = new PreDeployContext(dependentOfServiceContext);
-            dependentOfPreDeployContext.securityGroups.push({
-                GroupId: 'OtherId'
-            });
-
-            let addIngressRuleToSgIfNotExistsStub = sandbox.stub(ec2Calls, 'addIngressRuleToSgIfNotExists').returns(Promise.resolve({}));
-
-            return mysql.bind(ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext)
+            return mysql.bind({}, {}, {}, {})
                 .then(bindContext => {
                     expect(bindContext).to.be.instanceof(BindContext);
-                    expect(addIngressRuleToSgIfNotExistsStub.calledOnce).to.be.true;
+                    expect(bindSgStub.callCount).to.equal(1);
                 });
         });
     });

--- a/test/services/postgresql/postgresql-test.js
+++ b/test/services/postgresql/postgresql-test.js
@@ -22,8 +22,8 @@ const ServiceContext = require('../../../lib/datatypes/service-context');
 const DeployContext = require('../../../lib/datatypes/deploy-context');
 const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
 const BindContext = require('../../../lib/datatypes/bind-context');
-const deployPhaseCommon = require('../../../lib/common/deploy-phase-common');
 const preDeployPhaseCommon = require('../../../lib/common/pre-deploy-phase-common');
+const bindPhaseCommon = require('../../../lib/common/bind-phase-common');
 const deletePhasesCommon = require('../../../lib/common/delete-phases-common');
 const rdsCommon = require('../../../lib/common/rds-common');
 const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
@@ -67,44 +67,31 @@ describe('postgresql deployer', function () {
     describe('preDeploy', function () {
         it('should create a security group', function () {
             let groupId = "FakeSgGroupId";
-            let createSecurityGroupStub = sandbox.stub(preDeployPhaseCommon, 'createSecurityGroupForService').returns(Promise.resolve({
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "mysql", "1", {});
+            let preDeployContext = new PreDeployContext(serviceContext);
+            preDeployContext.securityGroups.push({
                 GroupId: groupId
-            }));
+            });
+            let createSgStub = sandbox.stub(preDeployPhaseCommon, 'preDeployCreateSecurityGroup').returns(Promise.resolve(preDeployContext));
 
-            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "postgresql", "1", {});
             return postgresql.preDeploy(serviceContext)
                 .then(preDeployContext => {
                     expect(preDeployContext).to.be.instanceof(PreDeployContext);
                     expect(preDeployContext.securityGroups.length).to.equal(1);
                     expect(preDeployContext.securityGroups[0].GroupId).to.equal(groupId);
-                    expect(createSecurityGroupStub.calledOnce).to.be.true;
+                    expect(createSgStub.callCount).to.equal(1);
                 });
         });
     });
 
     describe('bind', function () {
         it('should add the source sg to its own sg as an ingress rule', function () {
-            let appName = "FakeApp";
-            let envName = "FakeEnv";
-            let deployVersion = "1";
-            let ownServiceContext = new ServiceContext(appName, envName, "FakeService", "postgresql", deployVersion, {});
-            let ownPreDeployContext = new PreDeployContext(ownServiceContext);
-            ownPreDeployContext.securityGroups.push({
-                GroupId: 'FakeId'
-            });
+            let bindSgStub = sandbox.stub(bindPhaseCommon, 'bindDependentSecurityGroupToSelf').returns(Promise.resolve(new BindContext({}, {})));
 
-            let dependentOfServiceContext = new ServiceContext(appName, envName, "FakeDependentOfService", "ecs", deployVersion, {});
-            let dependentOfPreDeployContext = new PreDeployContext(dependentOfServiceContext);
-            dependentOfPreDeployContext.securityGroups.push({
-                GroupId: 'OtherId'
-            });
-
-            let addIngressRuleToSgIfNotExistsStub = sandbox.stub(ec2Calls, 'addIngressRuleToSgIfNotExists').returns(Promise.resolve({}));
-
-            return postgresql.bind(ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext)
+            return postgresql.bind({}, {}, {}, {})
                 .then(bindContext => {
                     expect(bindContext).to.be.instanceof(BindContext);
-                    expect(addIngressRuleToSgIfNotExistsStub.calledOnce).to.be.true;
+                    expect(bindSgStub.callCount).to.equal(1);
                 });
         });
     });

--- a/test/services/s3/s3-test.js
+++ b/test/services/s3/s3-test.js
@@ -22,6 +22,8 @@ const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
 const BindContext = require('../../../lib/datatypes/bind-context');
 const deployPhaseCommon = require('../../../lib/common/deploy-phase-common');
 const deletePhasesCommon = require('../../../lib/common/delete-phases-common');
+const bindPhaseCommon = require('../../../lib/common/bind-phase-common');
+const preDeployPhaseCommon = require('../../../lib/common/pre-deploy-phase-common');
 const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../../lib/datatypes/un-bind-context');
 const UnDeployContext = require('../../../lib/datatypes/un-deploy-context');
@@ -67,8 +69,11 @@ describe('s3 deployer', function () {
     describe('preDeploy', function () {
         it('should return an empty predeploy context', function () {
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
+            let preDeployNotRequiredStub = sandbox.stub(preDeployPhaseCommon, 'preDeployNotRequired').returns(Promise.resolve(new PreDeployContext(serviceContext)));
+
             return s3.preDeploy(serviceContext)
                 .then(preDeployContext => {
+                    expect(preDeployNotRequiredStub.callCount).to.equal(1);
                     expect(preDeployContext).to.be.instanceof(PreDeployContext);
                 });
         });
@@ -77,8 +82,11 @@ describe('s3 deployer', function () {
     describe('bind', function () {
         it('should return an empty bind context', function () {
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
+            let bindNotRequiredStub = sandbox.stub(bindPhaseCommon, 'bindNotRequired').returns(Promise.resolve(new BindContext({}, {})));
+            
             return s3.bind(serviceContext)
                 .then(bindContext => {
+                    expect(bindNotRequiredStub.callCount).to.equal(1);
                     expect(bindContext).to.be.instanceof(BindContext);
                 });
         });

--- a/test/services/s3staticsite/s3staticsite-test.js
+++ b/test/services/s3staticsite/s3staticsite-test.js
@@ -23,6 +23,8 @@ const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
 const BindContext = require('../../../lib/datatypes/bind-context');
 const deployPhaseCommon = require('../../../lib/common/deploy-phase-common');
 const deletePhasesCommon = require('../../../lib/common/delete-phases-common');
+const bindPhaseCommon = require('../../../lib/common/bind-phase-common');
+const preDeployPhaseCommon = require('../../../lib/common/pre-deploy-phase-common');
 const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../../lib/datatypes/un-bind-context');
 const UnDeployContext = require('../../../lib/datatypes/un-deploy-context');
@@ -59,9 +61,12 @@ describe('s3staticsite deployer', function () {
 
     describe('preDeploy', function () {
         it('should return an empty predeploy context', function () {
-            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "s3staticsite", "1", {});
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
+            let preDeployNotRequiredStub = sandbox.stub(preDeployPhaseCommon, 'preDeployNotRequired').returns(Promise.resolve(new PreDeployContext(serviceContext)));
+
             return s3StaticSite.preDeploy(serviceContext)
                 .then(preDeployContext => {
+                    expect(preDeployNotRequiredStub.callCount).to.equal(1);
                     expect(preDeployContext).to.be.instanceof(PreDeployContext);
                 });
         });
@@ -69,9 +74,12 @@ describe('s3staticsite deployer', function () {
 
     describe('bind', function () {
         it('should return an empty bind context', function () {
-            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "s3staticsite", "1", {});
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
+            let bindNotRequiredStub = sandbox.stub(bindPhaseCommon, 'bindNotRequired').returns(Promise.resolve(new BindContext({}, {})));
+
             return s3StaticSite.bind(serviceContext)
                 .then(bindContext => {
+                    expect(bindNotRequiredStub.callCount).to.equal(1);
                     expect(bindContext).to.be.instanceof(BindContext);
                 });
         });

--- a/test/services/sns/sns-test.js
+++ b/test/services/sns/sns-test.js
@@ -24,6 +24,8 @@ const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
 const BindContext = require('../../../lib/datatypes/bind-context');
 const deployPhaseCommon = require('../../../lib/common/deploy-phase-common');
 const deletePhasesCommon = require('../../../lib/common/delete-phases-common');
+const bindPhaseCommon = require('../../../lib/common/bind-phase-common');
+const preDeployPhaseCommon = require('../../../lib/common/pre-deploy-phase-common');
 const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../../lib/datatypes/un-bind-context');
 const UnDeployContext = require('../../../lib/datatypes/un-deploy-context');
@@ -50,23 +52,27 @@ describe('sns deployer', function () {
     });
 
     describe('preDeploy', function () {
-        it('should return an empty predeploy context since it doesnt do anything', function () {
+        it('should return an empty predeploy context', function () {
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
+            let preDeployNotRequiredStub = sandbox.stub(preDeployPhaseCommon, 'preDeployNotRequired').returns(Promise.resolve(new PreDeployContext(serviceContext)));
+
             return sns.preDeploy(serviceContext)
                 .then(preDeployContext => {
+                    expect(preDeployNotRequiredStub.callCount).to.equal(1);
                     expect(preDeployContext).to.be.instanceof(PreDeployContext);
-                    expect(preDeployContext.appName).to.equal(serviceContext.appName);
                 });
         });
     });
 
     describe('bind', function () {
-        it('should return an empty bind context since it doesnt do anything', function () {
+        it('should return an empty bind context', function () {
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
+            let bindNotRequiredStub = sandbox.stub(bindPhaseCommon, 'bindNotRequired').returns(Promise.resolve(new BindContext({}, {})));
+
             return sns.bind(serviceContext)
                 .then(bindContext => {
+                    expect(bindNotRequiredStub.callCount).to.equal(1);
                     expect(bindContext).to.be.instanceof(BindContext);
-                    expect(bindContext.dependencyServiceContext.appName).to.equal(serviceContext.appName);
                 });
         });
     });

--- a/test/services/sqs/sqs-test.js
+++ b/test/services/sqs/sqs-test.js
@@ -24,6 +24,8 @@ const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
 const BindContext = require('../../../lib/datatypes/bind-context');
 const deployPhaseCommon = require('../../../lib/common/deploy-phase-common');
 const deletePhasesCommon = require('../../../lib/common/delete-phases-common');
+const bindPhaseCommon = require('../../../lib/common/bind-phase-common');
+const preDeployPhaseCommon = require('../../../lib/common/pre-deploy-phase-common');
 const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../../lib/datatypes/un-bind-context');
 const UnDeployContext = require('../../../lib/datatypes/un-deploy-context');
@@ -50,26 +52,31 @@ describe('sqs deployer', function () {
     });
 
     describe('preDeploy', function () {
-        it('should return an empty predeploy context since it doesnt do anything', function () {
+        it('should return an empty predeploy context', function () {
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
+            let preDeployNotRequiredStub = sandbox.stub(preDeployPhaseCommon, 'preDeployNotRequired').returns(Promise.resolve(new PreDeployContext(serviceContext)));
+
             return sqs.preDeploy(serviceContext)
                 .then(preDeployContext => {
+                    expect(preDeployNotRequiredStub.callCount).to.equal(1);
                     expect(preDeployContext).to.be.instanceof(PreDeployContext);
-                    expect(preDeployContext.appName).to.equal(serviceContext.appName);
                 });
         });
     });
 
     describe('bind', function () {
-        it('should return an empty bind context since it doesnt do anything', function () {
+        it('should return an empty bind context', function () {
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
+            let bindNotRequiredStub = sandbox.stub(bindPhaseCommon, 'bindNotRequired').returns(Promise.resolve(new BindContext({}, {})));
+
             return sqs.bind(serviceContext)
                 .then(bindContext => {
+                    expect(bindNotRequiredStub.callCount).to.equal(1);
                     expect(bindContext).to.be.instanceof(BindContext);
-                    expect(bindContext.dependencyServiceContext.appName).to.equal(serviceContext.appName);
                 });
         });
     });
+
 
     describe('deploy', function () {
         let appName = "FakeApp";


### PR DESCRIPTION
It turns out that all the PreDeploy and Bind phases started looking
remarkably the same, so this change consolidates them into common
modules that all the deployers invoke. I'll probably try to do
this for other phase types in the future as well.