### PR TITLE
Add 'app' and 'env' tags by default

### DIFF
--- a/lib/common/deploy-phase-common.js
+++ b/lib/common/deploy-phase-common.js
@@ -206,3 +206,10 @@ exports.getEventConsumerConfigParams = function (producerServiceContext, consume
     }
     return null; //Return null if nothing found for the consumer service in the producer service config
 }
+
+exports.getCommonTagsFromServiceContext = function(serviceContext) {
+    return {
+        app: serviceContext.appName,
+        env: serviceContext.environmentName
+    }
+}

--- a/lib/services/apigateway/index.js
+++ b/lib/services/apigateway/index.js
@@ -77,12 +77,13 @@ function getCompiledApiGatewayTemplate(stackName, ownServiceContext, dependencie
         handlerFunction: serviceParams.handler_function,
         functionTimeout: functionTimeout.toString(),
         lambdaRuntime: serviceParams.lambda_runtime,
-        policyStatements
+        policyStatements,
+        tags: deployPhaseCommon.getCommonTagsFromServiceContext(ownServiceContext)
     }
 
-    //Add tags if necessary
+    //Add user-defined tags if specified
     if (serviceParams.tags) {
-        handlebarsParams.tags = serviceParams.tags;
+        handlebarsParams.tags = Object.assign(handlebarsParams.tags, serviceParams.tags);
     }
 
     //Add env vars

--- a/lib/services/beanstalk/index.js
+++ b/lib/services/beanstalk/index.js
@@ -75,7 +75,8 @@ function getCompiledBeanstalkTemplate(stackName, preDeployContext, serviceContex
                 applicationVersionKey: s3ArtifactInfo.Key,
                 solutionStack: serviceParams.solution_stack,
                 optionSettings: [],
-                policyStatements
+                policyStatements,
+                tags: deployPhaseCommon.getCommonTagsFromServiceContext(serviceContext)
             };
 
             //Configure min and max size of ASG
@@ -138,9 +139,9 @@ function getCompiledBeanstalkTemplate(stackName, preDeployContext, serviceContex
             handlebarsParams.optionSettings.push(getEbConfigurationOption("aws:elasticbeanstalk:environment:process:default", "Port", "80"));
             handlebarsParams.optionSettings.push(getEbConfigurationOption("aws:elasticbeanstalk:environment:process:default", "Protocol", "HTTP"));
 
-            //Add tags (if present)
+            //Add user-defined tags if specified
             if (serviceParams.tags) {
-                handlebarsParams.tags = serviceParams.tags;
+                handlebarsParams.tags = Object.assign(handlebarsParams.tags, serviceParams.tags);
             }
 
             return handlebarsUtils.compileTemplate(`${__dirname}/beanstalk-template.yml`, handlebarsParams);

--- a/lib/services/dynamodb/index.js
+++ b/lib/services/dynamodb/index.js
@@ -93,8 +93,8 @@ function getCompiledDynamoTemplate(stackName, ownServiceContext) {
 
     //Add sort key if provided
     if (serviceParams.sort_key) {
-        handlebarsParams.sortKeyName = serviceParams.sort_key.name,
-            handlebarsParams.sortKeyType = KEY_TYPE_TO_ATTRIBUTE_TYPE[serviceParams.sort_key.type]
+        handlebarsParams.sortKeyName = serviceParams.sort_key.name;
+        handlebarsParams.sortKeyType = KEY_TYPE_TO_ATTRIBUTE_TYPE[serviceParams.sort_key.type]
     }
 
     return handlebarsUtils.compileTemplate(`${__dirname}/dynamodb-template.yml`, handlebarsParams);

--- a/lib/services/ecs/index.js
+++ b/lib/services/ecs/index.js
@@ -204,7 +204,8 @@ function getCompiledEcsTemplate(stackName, clusterName, ownServiceContext, ownPr
         policyStatements: taskRoleStatements,
         maxMb: maxMb.toString(),
         cpuUnits: cpuUnits.toString(),
-        deployVersion: ownServiceContext.deployVersion.toString()
+        deployVersion: ownServiceContext.deployVersion.toString(),
+        tags: deployPhaseCommon.getCommonTagsFromServiceContext(ownServiceContext)
     };
 
     //Add port mappings if routing is specified
@@ -265,9 +266,9 @@ function getCompiledEcsTemplate(stackName, clusterName, ownServiceContext, ownPr
         handlebarsParams.sshKeyName = serviceParams.key_name
     }
 
-    //Add tags (if specified)
+    //Add user-defined tags if specified
     if (serviceParams.tags) {
-        handlebarsParams.tags = serviceParams.tags
+        handlebarsParams.tags = Object.assign(handlebarsParams.tags, serviceParams.tags);
     }
 
     return handlebarsUtils.compileTemplate(`${__dirname}/ecs-service-template.yml`, handlebarsParams)

--- a/lib/services/efs/index.js
+++ b/lib/services/efs/index.js
@@ -23,8 +23,6 @@ const deployPhaseCommon = require('../../common/deploy-phase-common');
 const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
 const bindPhaseCommon = require('../../common/bind-phase-common');
 const deletePhasesCommon = require('../../common/delete-phases-common');
-const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
-const UnBindContext = require('../../datatypes/un-bind-context');
 
 const SERVICE_NAME = "EFS";
 const EFS_PORT = 2049;
@@ -92,12 +90,13 @@ function getCompiledEfsTemplate(stackName, ownServiceContext, ownPreDeployContex
         performanceMode,
         securityGroupId,
         subnetAId,
-        subnetBId
+        subnetBId,
+        tags: deployPhaseCommon.getCommonTagsFromServiceContext(ownServiceContext)
     };
 
-    //Inject tags (if any)
+    //Add user-defined tags if specified
     if (serviceParams.tags) {
-        handlebarsParams.tags = serviceParams.tags;
+        handlebarsParams.tags = Object.assign(handlebarsParams.tags, serviceParams.tags);
     }
 
     return handlebarsUtils.compileTemplate(`${__dirname}/efs-template.yml`, handlebarsParams)

--- a/lib/services/lambda/index.js
+++ b/lib/services/lambda/index.js
@@ -59,7 +59,8 @@ function getCompiledLambdaTemplate(stackName, ownServiceContext, dependenciesDep
         runtime: serviceParams.runtime,
         memorySize: memorySize,
         timeout: timeout,
-        policyStatements
+        policyStatements,
+        tags: deployPhaseCommon.getCommonTagsFromServiceContext(ownServiceContext)
     };
 
     //Inject environment variables (if any)
@@ -68,9 +69,9 @@ function getCompiledLambdaTemplate(stackName, ownServiceContext, dependenciesDep
         handlebarsParams.environmentVariables = envVarsToInject;
     }
 
-    //Inject tags (if any)
+    //Add user-defined tags if specified
     if (serviceParams.tags) {
-        handlebarsParams.tags = serviceParams.tags;
+        handlebarsParams.tags = Object.assign(handlebarsParams.tags, serviceParams.tags);
     }
 
     return handlebarsUtils.compileTemplate(`${__dirname}/lambda-template.yml`, handlebarsParams)

--- a/lib/services/memcached/index.js
+++ b/lib/services/memcached/index.js
@@ -22,8 +22,6 @@ const deployPhaseCommon = require('../../common/deploy-phase-common');
 const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
 const bindPhaseCommon = require('../../common/bind-phase-common');
 const deletePhasesCommon = require('../../common/delete-phases-common');
-const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
-const UnBindContext = require('../../datatypes/un-bind-context');
 const handlebarsUtils = require('../../common/handlebars-utils');
 const uuid = require('uuid');
 
@@ -76,12 +74,13 @@ function getCompiledMemcachedTemplate(stackName, ownServiceContext, ownPreDeploy
         clusterName,
         memcachedSecurityGroupId,
         nodeCount,
-        memcachedPort: MEMCACHED_PORT
+        memcachedPort: MEMCACHED_PORT,
+        tags: deployPhaseCommon.getCommonTagsFromServiceContext(ownServiceContext)
     }
 
-    //Add tags (if present)
+    //Add user-defined tags if specified
     if (serviceParams.tags) {
-        handlebarsParams.tags = serviceParams.tags;
+        handlebarsParams.tags = Object.assign(handlebarsParams.tags, serviceParams.tags);
     }
 
     //Either create custom parameter group if params are specified, or just use default

--- a/lib/services/mysql/index.js
+++ b/lib/services/mysql/index.js
@@ -23,8 +23,6 @@ const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
 const bindPhaseCommon = require('../../common/bind-phase-common');
 const deletePhasesCommon = require('../../common/delete-phases-common');
 const rdsCommon = require('../../common/rds-common');
-const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
-const UnBindContext = require('../../datatypes/un-bind-context');
 const uuid = require('uuid');
 
 const SERVICE_NAME = "MySQL";
@@ -66,7 +64,8 @@ function getCompiledMysqlTemplate(stackName, ownServiceContext, ownPreDeployCont
         dbPort: MYSQL_PORT,
         storageType,
         dbSecurityGroupId,
-        parameterGroupFamily: getParameterGroupFamily(mysqlVersion)
+        parameterGroupFamily: getParameterGroupFamily(mysqlVersion),
+        tags: deployPhaseCommon.getCommonTagsFromServiceContext(ownServiceContext)
     };
 
     //Add parameters to parameter group if specified
@@ -79,9 +78,9 @@ function getCompiledMysqlTemplate(stackName, ownServiceContext, ownPreDeployCont
         handlebarsParams.multi_az = true;
     }
 
-    //Add tags (if present)
+    //Add user-defined tags if specified
     if (serviceParams.tags) {
-        handlebarsParams.tags = serviceParams.tags;
+        handlebarsParams.tags = Object.assign(handlebarsParams.tags, serviceParams.tags);
     }
 
     return handlebarsUtils.compileTemplate(`${__dirname}/mysql-template.yml`, handlebarsParams)

--- a/lib/services/postgresql/index.js
+++ b/lib/services/postgresql/index.js
@@ -23,8 +23,6 @@ const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
 const bindPhaseCommon = require('../../common/bind-phase-common');
 const deletePhasesCommon = require('../../common/delete-phases-common');
 const rdsCommon = require('../../common/rds-common');
-const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
-const UnBindContext = require('../../datatypes/un-bind-context');
 const uuid = require('uuid');
 
 const SERVICE_NAME = "PostgreSQL";
@@ -69,7 +67,8 @@ function getCompiledPostgresTemplate(stackName, ownServiceContext, ownPreDeployC
         dbPort: POSTGRES_PORT,
         storageType,
         dbSecurityGroupId,
-        parameterGroupFamily: getParameterGroupFamily(postgresVersion)
+        parameterGroupFamily: getParameterGroupFamily(postgresVersion),
+        tags: deployPhaseCommon.getCommonTagsFromServiceContext(ownServiceContext)
     };
 
     //Add parameters to parameter group if specified
@@ -82,9 +81,9 @@ function getCompiledPostgresTemplate(stackName, ownServiceContext, ownPreDeployC
         handlebarsParams.multi_az = true;
     }
 
-    //Add tags (if present)
+    //Add user-defined tags if specified
     if (serviceParams.tags) {
-        handlebarsParams.tags = serviceParams.tags;
+        handlebarsParams.tags = Object.assign(handlebarsParams.tags, serviceParams.tags);
     }
 
     return handlebarsUtils.compileTemplate(`${__dirname}/postgresql-template.yml`, handlebarsParams)

--- a/lib/services/redis/index.js
+++ b/lib/services/redis/index.js
@@ -22,8 +22,6 @@ const deployPhaseCommon = require('../../common/deploy-phase-common');
 const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
 const bindPhaseCommon = require('../../common/bind-phase-common');
 const deletePhasesCommon = require('../../common/delete-phases-common');
-const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
-const UnBindContext = require('../../datatypes/un-bind-context');
 const handlebarsUtils = require('../../common/handlebars-utils');
 const uuid = require('uuid');
 
@@ -104,12 +102,13 @@ function getCompiledRedisTemplate(stackName, ownServiceContext, ownPreDeployCont
         clusterName,
         redisSecurityGroupId,
         // shards,
-        numNodes: readReplicas + 1
+        numNodes: readReplicas + 1,
+        tags: deployPhaseCommon.getCommonTagsFromServiceContext(ownServiceContext)
     }
 
-    //Add tags (if present)
+    //Add user-defined tags if specified
     if (serviceParams.tags) {
-        handlebarsParams.tags = serviceParams.tags;
+        handlebarsParams.tags = Object.assign(handlebarsParams.tags, serviceParams.tags);
     }
 
     //Either create custom parameter group if params are specified, or just use default

--- a/lib/services/s3/index.js
+++ b/lib/services/s3/index.js
@@ -80,12 +80,13 @@ function getCompiledS3Template(stackName, ownServiceContext) {
 
     let handlebarsParams = {
         bucketName: bucketName,
-        versioningStatus: versioningStatus
+        versioningStatus: versioningStatus,
+        tags: deployPhaseCommon.getCommonTagsFromServiceContext(ownServiceContext)
     };
 
-    //Inject tags (if any)
+    //Add user-defined tags if specified
     if (serviceParams.tags) {
-        handlebarsParams.tags = serviceParams.tags;
+        handlebarsParams.tags = Object.assign(handlebarsParams.tags, serviceParams.tags);
     }
 
     return handlebarsUtils.compileTemplate(`${__dirname}/s3-template.yml`, handlebarsParams)

--- a/lib/services/s3staticsite/index.js
+++ b/lib/services/s3staticsite/index.js
@@ -46,11 +46,13 @@ function getCompiledS3Template(ownServiceContext, stackName, loggingBucketName) 
         loggingBucketName,
         logFilePrefix,
         indexDocument,
-        errorDocument
+        errorDocument,
+        tags: deployPhaseCommon.getCommonTagsFromServiceContext(ownServiceContext)
     };
-    //Inject tags (if any)
+    
+    //Add user-defined tags if specified
     if (serviceParams.tags) {
-        handlebarsParams.tags = serviceParams.tags;
+        handlebarsParams.tags = Object.assign(handlebarsParams.tags, serviceParams.tags);
     }
 
     return handlebarsUtils.compileTemplate(`${__dirname}/s3-static-site-template.yml`, handlebarsParams)


### PR DESCRIPTION
This change adds these two tags by default since their values are
present in the Handel file.

Resolves #128 