### PR TITLE
added acl parameter to s3 service

### DIFF
--- a/docs/supported-services/s3.rst
+++ b/docs/supported-services/s3.rst
@@ -12,7 +12,6 @@ Service Limitations
 -------------------
 This service currently only provisions a bare-bones S3 bucket for data storage. It does support versioning, but the following other features are not currently supported:
 
-* Bucket-level ACLs.
 * CORS configuration
 * Bucket lifecycle
 * Bucket logging
@@ -40,6 +39,11 @@ This service takes the following parameters:
      - No
      - <appName>-<environmentName>-<serviceName>-<serviceType>
      - The name of the bucket to create. This name must be globally unique across all AWS accounts, so 'myBucket' will likely be taken. :)
+   * - bucket_acl
+     - string
+     - No
+     - disabled
+     - **Warning:** A canned access control list (ACL) that grants predefined permissions to the bucket. These are global permissions ie, PublicRead means the bucket is open to the world. Allowed values: *AuthenticatedRead*, *AwsExecRead*, *BucketOwnerRead*, *BucketOwnerFullControl*, *LogDeliveryWrite*, *Private*, *PublicRead*
    * - versioning
      - string
      - No

--- a/lib/services/s3/index.js
+++ b/lib/services/s3/index.js
@@ -108,7 +108,7 @@ exports.check = function (serviceContext) {
     if (params.versioning && (params.versioning !== 'enabled' && params.versioning !== 'disabled')) {
         errors.push(`${SERVICE_NAME} - 'versioning' parameter must be either 'enabled' or 'disabled'`);
     }
-    if (!(valid_acls.indexOf(params.bucket_acl) in valid_acls)) {
+    if (params.bucket_acl && (!(valid_acls.indexOf(params.bucket_acl) in valid_acls))) {
         errors.push(`${SERVICE_NAME} - 'bucket_acl' parameter must be 'AuthenticatedRead', 'AwsExecRead', 'BucketOwnerRead', 'BucketOwnerFullControl', 'LogDeliveryWrite', 'Private' or 'PublicRead'`);
     }
 

--- a/lib/services/s3/index.js
+++ b/lib/services/s3/index.js
@@ -81,6 +81,7 @@ function getCompiledS3Template(stackName, ownServiceContext, loggingBucketName) 
 
     let handlebarsParams = {
         bucketName: bucketName,
+        bucketACL: serviceParams.bucket_acl,
         versioningStatus: versioningStatus,
         tags: deployPhaseCommon.getTags(ownServiceContext)
     };
@@ -101,10 +102,14 @@ function getCompiledS3Template(stackName, ownServiceContext, loggingBucketName) 
 
 exports.check = function (serviceContext) {
     let errors = [];
+    let valid_acls = ['AuthenticatedRead', 'AwsExecRead', 'BucketOwnerRead', 'BucketOwnerFullControl', 'LogDeliveryWrite', 'Private', 'PublicRead'];
 
     let params = serviceContext.params;
     if (params.versioning && (params.versioning !== 'enabled' && params.versioning !== 'disabled')) {
         errors.push(`${SERVICE_NAME} - 'versioning' parameter must be either 'enabled' or 'disabled'`);
+    }
+    if (!(valid_acls.indexOf(params.bucket_acl) in valid_acls)) {
+        errors.push(`${SERVICE_NAME} - 'bucket_acl' parameter must be 'AuthenticatedRead', 'AwsExecRead', 'BucketOwnerRead', 'BucketOwnerFullControl', 'LogDeliveryWrite', 'Private' or 'PublicRead'`);
     }
 
     return errors;

--- a/lib/services/s3/s3-template.yml
+++ b/lib/services/s3/s3-template.yml
@@ -6,6 +6,9 @@ Resources:
   Bucket:
     Type: "AWS::S3::Bucket"
     Properties: 
+      {{#if bucketACL}}
+      AccessControl: {{bucketACL}}
+      {{/if}}
       BucketName: {{bucketName}}
       {{#if loggingBucketName}}
       LoggingConfiguration:

--- a/test/services/s3/s3-test.js
+++ b/test/services/s3/s3-test.js
@@ -64,6 +64,29 @@ describe('s3 deployer', function () {
             let errors = s3.check(serviceContext);
             expect(errors.length).to.equal(0);
         });
+
+        it('should fail if PublicReadWrite set as an ACL', function () {
+            let serviceContext = {
+                params: {
+                    bucket_name: 'somename',
+                    bucket_acl: 'PublicReadWrite'
+                }
+            }
+            let errors = s3.check(serviceContext);
+            expect(errors.length).to.equal(1);
+            expect(errors[0]).to.contain("'bucket_acl' parameter must be 'AuthenticatedRead', 'AwsExecRead', 'BucketOwnerRead', 'BucketOwnerFullControl', 'LogDeliveryWrite', 'Private' or 'PublicRead'");
+        });
+
+        it('should work with valid bucket_acl', function () {
+            let serviceContext = {
+                params: {
+                    bucket_name: 'somename',
+                    bucket_acl: 'PublicRead'
+                }
+            }
+            let errors = s3.check(serviceContext);
+            expect(errors.length).to.equal(0);
+        });
     });
 
     describe('preDeploy', function () {


### PR DESCRIPTION
This adds the bucket-level ACL's to the S3 service. It should be noted that by AWS specs this applies to the bucket. New objects added to the bucket need there own permissions added. For example if I create a bucket with the ACL PublicRead and then after the bucket is created I add a text file without specifying an ACL or policy the text file _will not_ inherit the PublicRead ACL, the result is a bucket that you can see the object but not access the object.

Hope that all makes sense.

resolves #167 