### PR TITLE
Improve ECS instance-level auto-scaling.

### DIFF
--- a/lib/common/deploy-phase-common.js
+++ b/lib/common/deploy-phase-common.js
@@ -118,7 +118,7 @@ exports.deployCloudFormationStack = function (stackName, cfTemplate, cfParameter
             }
             else {
                 if (updatesSupported) {
-                    winston.info(`${serviceType} - Updates stack '${stackName}'`);
+                    winston.info(`${serviceType} - Updating stack '${stackName}'`);
                     return cloudformationCalls.updateStack(stackName, cfTemplate, cfParameters, stackTags);
                 }
                 else {
@@ -129,10 +129,9 @@ exports.deployCloudFormationStack = function (stackName, cfTemplate, cfParameter
         })
 }
 
-exports.uploadFileToHandelBucket = function (serviceContext, diskFilePath, s3FileName) {
+exports.uploadFileToHandelBucket = function (diskFilePath, artifactPrefix, s3FileName) {
     let bucketName = `handel-${accountConfig.region}-${accountConfig.account_id}`;
 
-    let artifactPrefix = `${serviceContext.appName}/${serviceContext.environmentName}/${serviceContext.serviceName}`;
     let artifactKey = `${artifactPrefix}/${s3FileName}`;
     return s3Calls.createBucketIfNotExists(bucketName, accountConfig.region) //Ensure Handel bucket exists in this region
         .then(bucket => {
@@ -146,26 +145,28 @@ exports.uploadFileToHandelBucket = function (serviceContext, diskFilePath, s3Fil
         });
 }
 
+exports.uploadDirectoryToHandelBucket = function (directoryPath, artifactPrefix, s3FileName) {
+    let zippedPath = `${os.tmpdir()}/${s3FileName}.zip`;
+    return util.zipDirectoryToFile(directoryPath, zippedPath)
+        .then(() => {
+            return exports.uploadFileToHandelBucket(zippedPath, artifactPrefix, s3FileName)
+                .then(s3ObjectInfo => {
+                    //Delete temporary file
+                    fs.unlinkSync(zippedPath);
+                    return s3ObjectInfo;
+                });
+        });
+}
+
 exports.uploadDeployableArtifactToHandelBucket = function (serviceContext, s3FileName) {
     let pathToArtifact = serviceContext.params.path_to_code;
     let fileStats = fs.lstatSync(pathToArtifact);
-    if (fileStats.isDirectory()) { //Zip up artifact
-        let zippedPath = `${os.tmpdir()}/${s3FileName}.zip`;
-        return util.zipDirectoryToFile(pathToArtifact, zippedPath)
-            .then(() => {
-                return exports.uploadFileToHandelBucket(serviceContext, zippedPath, s3FileName)
-                    .then(s3ObjectInfo => {
-                        //Delete temporary file
-                        fs.unlinkSync(zippedPath);
-                        return s3ObjectInfo;
-                    });
-            });
+    let artifactPrefix = `${serviceContext.appName}/${serviceContext.environmentName}/${serviceContext.serviceName}`;
+    if (fileStats.isDirectory()) { //Zip up artifact and upload it
+        return exports.uploadDirectoryToHandelBucket(pathToArtifact, artifactPrefix, s3FileName);
     }
     else { //Is file (i.e. WAR file or some other already-compiled archive), just upload directly
-        return exports.uploadFileToHandelBucket(serviceContext, pathToArtifact, s3FileName)
-            .then(s3ObjectInfo => {
-                return s3ObjectInfo;
-            });
+        return exports.uploadFileToHandelBucket(pathToArtifact, artifactPrefix, s3FileName);
     }
 }
 

--- a/lib/services/beanstalk/deployable-artifact.js
+++ b/lib/services/beanstalk/deployable-artifact.js
@@ -25,7 +25,8 @@ function makeTmpDir() {
 function uploadDeployableArtifactToS3(serviceContext, fileToUpload, fileExtension) {
     let s3FileName = `beanstalk-deployable-${uuid()}.${fileExtension}`;
     winston.info(`Uploading deployable artifact to S3: ${s3FileName}`);
-    return deployPhaseCommon.uploadFileToHandelBucket(serviceContext, fileToUpload, s3FileName)
+    let artifactPrefix = `${serviceContext.appName}/${serviceContext.environmentName}/${serviceContext.serviceName}`;
+    return deployPhaseCommon.uploadFileToHandelBucket(fileToUpload, artifactPrefix, s3FileName)
         .then(s3ObjectInfo => {
             winston.info(`Uploaded deployable artifact to S3: ${s3FileName}`);
             return s3ObjectInfo;

--- a/lib/services/ecs/cluster-scaling-lambda/index.js
+++ b/lib/services/ecs/cluster-scaling-lambda/index.js
@@ -1,0 +1,278 @@
+const AWS = require('aws-sdk');
+AWS.config.region = 'us-west-2';
+
+function getClusters(ecs) {
+    return ecs.listClusters({}).promise()
+        .then(listResponse => {
+            let clusterArns = listResponse.clusterArns;
+            return clusterArns;
+        })
+        .then(clusterArns => {
+            let clusterPromises = [];
+
+            for (let clusterArn of clusterArns) {
+                let describeParams = {
+                    clusters: [clusterArn]
+                }
+                let clusterPromise = ecs.describeClusters(describeParams).promise()
+                    .then(clusterResponse => {
+                        return clusterResponse.clusters[0];
+                    });
+                clusterPromises.push(clusterPromise);
+            }
+
+            return Promise.all(clusterPromises);
+        });
+}
+
+function getContainerInstances(clusterName, ecs) {
+    let listParams = {
+        cluster: clusterName
+    }
+    return ecs.listContainerInstances(listParams).promise()
+        .then(listResponse => {
+            let containerInstanceArns = listResponse.containerInstanceArns;
+            return containerInstanceArns;
+        })
+        .then(containerInstanceArns => {
+            let containerInstancePromises = [];
+
+            for (let containerInstanceArn of containerInstanceArns) {
+                let describeParams = {
+                    cluster: clusterName,
+                    containerInstances: [containerInstanceArn]
+                }
+                let containerInstancePromise = ecs.describeContainerInstances(describeParams).promise()
+                    .then(describeResponse => {
+                        return describeResponse.containerInstances[0];
+                    });
+                containerInstancePromises.push(containerInstancePromise);
+            }
+
+            return Promise.all(containerInstancePromises);
+        });
+}
+
+function getCpuRemainingFromContainerInstance(containerInstance) {
+    for (let remainingResource of containerInstance.remainingResources) {
+        if (remainingResource.name === 'CPU') {
+            return remainingResource.integerValue;
+        }
+    }
+}
+
+function getMemoryRemainingFromContainerInstance(containerInstance) {
+    for (let remainingResource of containerInstance.remainingResources) {
+        if (remainingResource.name === 'MEMORY') {
+            return remainingResource.integerValue;
+        }
+    }
+}
+
+function getCpuRegisteredFromContainerInstance(containerInstance) {
+    for (let remainingResource of containerInstance.registeredResources) {
+        if (remainingResource.name === 'CPU') {
+            return remainingResource.integerValue;
+        }
+    }
+}
+
+function getMemoryRegisteredFromContainerInstance(containerInstance) {
+    for (let remainingResource of containerInstance.registeredResources) {
+        if (remainingResource.name === 'MEMORY') {
+            return remainingResource.integerValue;
+        }
+    }
+}
+
+function getTaskDefinitionForTask(ecs, clusterName, taskArn) {
+    let describeTaskParams = {
+        cluster: clusterName,
+        tasks: [taskArn]
+    }
+    return ecs.describeTasks(describeTaskParams).promise()
+        .then(describeTaskResponse => {
+            return describeTaskResponse.tasks[0];
+        })
+        .then(task => {
+            let describeTaskDefParams = {
+                taskDefinition: task.taskDefinitionArn
+            };
+            return ecs.describeTaskDefinition(describeTaskDefParams).promise()
+                .then(describeTaskDefResponse => {
+                    return describeTaskDefResponse.taskDefinition;
+                });
+        });
+}
+
+function getMaxTaskReservedMetrics(ecs, clusterName) {
+    let listParams = {
+        cluster: clusterName
+    }
+    return ecs.listTasks(listParams).promise()
+        .then(listResponse => {
+            return listResponse.taskArns;
+        })
+        .then(taskArns => {
+            let taskDefPromises = [];
+
+            for (let taskArn of taskArns) {
+                taskDefPromises.push(getTaskDefinitionForTask(ecs, clusterName, taskArn));
+            }
+
+            return Promise.all(taskDefPromises);
+        })
+        .then(taskDefinitions => {
+            let maxMetrics = {
+                cpu: 0,
+                memory: 0
+            };
+
+            for (let taskDefinition of taskDefinitions) {
+                for (let containerDefinition of taskDefinition.containerDefinitions) {
+                    let reservedCpu = containerDefinition.cpu;
+                    if (reservedCpu > maxMetrics.cpu) {
+                        maxMetrics.cpu = reservedCpu;
+                    }
+                    let reservedMemory = containerDefinition.memory;
+                    if (reservedMemory > maxMetrics.memory) {
+                        maxMetrics.memory = reservedMemory;
+                    }
+                }
+            }
+
+            return maxMetrics;
+        });
+}
+
+function getSchedulableMetricsForCluster(ecs, clusterName) {
+    return getContainerInstances(clusterName, ecs)
+        .then(containerInstances => {
+            return getMaxTaskReservedMetrics(ecs, clusterName)
+                .then(maxReservedMetrics => {
+                    //Calculate schedulable containers for cluster
+                    let schedulableContainers = 0;
+                    for (let instance of containerInstances) {
+                        let cpuRemaining = getCpuRemainingFromContainerInstance(instance);
+                        let memoryRemaining = getMemoryRemainingFromContainerInstance(instance);
+
+                        let containersByCpu = cpuRemaining / maxReservedMetrics.cpu;
+                        let containersByMemory = memoryRemaining / maxReservedMetrics.memory;
+                        schedulableContainers += Math.floor(Math.min(containersByCpu, containersByMemory));
+                    }
+
+                    //Calculate max number of largest schedulable containers that will fit on the largets instance in the cluster
+                    let maxRegisteredCpu = 0;
+                    let maxRegisteredMemory = 0;
+                    for (let instance of containerInstances) {
+                        let registeredCpu = getCpuRegisteredFromContainerInstance(instance);
+                        let registeredMemory = getMemoryRegisteredFromContainerInstance(instance);
+
+                        if (registeredCpu > maxRegisteredCpu) {
+                            maxRegisteredCpu = registeredCpu;
+                        }
+                        if (registeredMemory > maxRegisteredMemory) {
+                            maxRegisteredMemory = registeredMemory;
+                        }
+                    }
+
+                    let containersScaledownThreshold = Math.floor(Math.min((maxRegisteredCpu / maxReservedMetrics.cpu), (maxRegisteredMemory / maxReservedMetrics.memory)));
+
+                    return {
+                        schedulableContainers,
+                        containersScaledownThreshold
+                    }
+                });
+        });
+}
+
+function putScalingMetric(cloudwatch, clusterName, metricName, needsScaling) {
+    let putParams = {
+        MetricData: [
+            {
+                MetricName: metricName,
+                Dimensions: [
+                    {
+                        Name: 'ClusterName',
+                        Value: clusterName,
+                    }
+                ],
+                Timestamp: new Date(),
+                Unit: 'Count',
+                Value: needsScaling
+            }
+        ],
+        Namespace: 'Handel/ECS'
+    }
+    return cloudwatch.putMetricData(putParams).promise();
+}
+
+function putMultipleMetrics(cloudwatch, clusterName, metrics) {
+    let putPromises = [];
+
+    for (let metricName in metrics) {
+        let metricValue = metrics[metricName];
+        putPromises.push(putScalingMetric(cloudwatch, clusterName, metricName, metricValue));
+    }
+
+    return Promise.all(putPromises);
+}
+
+
+
+function updateScalingMetricsForCluster(cluster, ecs, cloudwatch) {
+    let clusterName = cluster.clusterName;
+
+    return getSchedulableMetricsForCluster(ecs, clusterName)
+        .then(schedulableMetrics => {
+            //TODO - Get scale down threshold
+            let schedulableContainers = schedulableMetrics.schedulableContainers;
+            console.log(`Cluster '${clusterName} has room for  ${schedulableContainers} of the largest containers on the cluster`);
+            let containerScaledownThreshold = schedulableMetrics.containersScaledownThreshold;
+            console.log(`Cluster '${clusterName} needs to have room for at least ${containerScaledownThreshold} before it will start scaling down`);
+
+            if (schedulableContainers < 1) { //Need to scale up cluster
+                console.log(`Cluster '${clusterName}' needs to scale up`);
+                return putMultipleMetrics(cloudwatch, clusterName, {
+                    ClusterNeedsScalingUp: 1,
+                    ClusterNeedsScalingDown: 0
+                });
+            }
+            else if (schedulableContainers > containerScaledownThreshold) {
+                console.log(`Cluster '${clusterName}' needs to scale down`);
+                return putMultipleMetrics(cloudwatch, clusterName, {
+                    ClusterNeedsScalingUp: 0,
+                    ClusterNeedsScalingDown: 1
+                });
+            }
+            else { //No scaling (up or down) required at this time
+                console.log(`Cluster '${clusterName}' does not need scaling at this time`);
+                return putMultipleMetrics(cloudwatch, clusterName, {
+                    ClusterNeedsScalingUp: 0,
+                    ClusterNeedsScalingDown: 0
+                });
+            }
+        });
+}
+
+
+/**
+ * Iterates through the clusters in the account and updates scaling CloudWatch metrics for the clusters
+ *
+ * This scaling decision algorithm was based heavily on Philipp Garbe's excellent blog post at 
+ * http://garbe.io/blog/2017/04/12/a-better-solution-to-ecs-autoscaling/.
+ */
+exports.handler = function (event, context) {
+    const cloudwatch = new AWS.CloudWatch({ apiVersion: '2010-08-01' });
+    const ecs = new AWS.ECS({ apiVersion: '2014-11-13' });
+
+    return getClusters(ecs)
+        .then(clusters => {
+            let updateMetricsPromises = [];
+            for (let cluster of clusters) {
+                console.log(`Updating metrics for cluster '${cluster.clusterName}'`);
+                updateMetricsPromises.push(updateScalingMetricsForCluster(cluster, ecs, cloudwatch));
+            }
+            return Promise.all(updateMetricsPromises);
+        });
+}

--- a/lib/services/ecs/cluster-scaling-lambda/scaling-lambda-template.yml
+++ b/lib/services/ecs/cluster-scaling-lambda/scaling-lambda-template.yml
@@ -1,0 +1,81 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Lambda function used by Handel for auto-scaling ECS clusters
+
+Resources:
+  EventsRule:
+    Type: 'AWS::Events::Rule'
+    Properties:
+      Description: Fires Handel ECS auto-scaling lambda on a schedule
+      ScheduleExpression: cron(0/1 * * * ? *)
+      Name: HandelEcsAutoScalingLambda
+      State: ENABLED
+      Targets:
+      - Id: 'HandelEcsAutoScalingLambda'
+        Arn: !GetAtt Function.Arn
+  Role:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: HandelEcsAutoScalingLambda
+      Path: "/services/"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service:
+              - "lambda.amazonaws.com"
+            Action:
+            - "sts:AssumeRole"
+  Policy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: HandelEcsAutoScalingLambda
+      Roles:
+      - !Ref Role
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+        - Effect: Allow
+          Action:
+          - 'logs:CreateLogGroup'
+          - 'logs:CreateLogStream'
+          - 'logs:PutLogEvents'
+          Resource:
+          - 'arn:aws:logs:*:*:*'
+        - Effect: Allow
+          Action:
+          - 'ecs:ListClusters'
+          - 'ecs:DescribeClusters'
+          - 'ecs:ListContainerInstances'
+          - 'ecs:DescribeContainerInstances'
+          - 'ecs:DescribeTasks'
+          - 'ecs:DescribeTaskDefinition'
+          - 'ecs:ListTasks'
+          Resource:
+          - '*'
+        - Effect: Allow
+          Action:
+          - 'cloudwatch:PutMetricData'
+          Resource:
+          - '*'
+  Function:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        S3Bucket: {{s3Bucket}}
+        S3Key: {{s3Key}}
+      Description: Lambda function used by Handel for auto-scaling ECS clusters
+      FunctionName: HandelEcsAutoScalingLambda
+      Handler: index.handler
+      MemorySize: 128
+      Role: !GetAtt Role.Arn
+      Runtime: nodejs6.10
+      Timeout: 300
+  PermissionForEventsToInvokeLambda:
+    Type: "AWS::Lambda::Permission"
+    Properties: 
+      FunctionName: !Ref Function
+      Action: "lambda:InvokeFunction"
+      Principal: "events.amazonaws.com"
+      SourceArn: !GetAtt EventsRule.Arn

--- a/lib/services/ecs/ecs-service-template.yml
+++ b/lib/services/ecs/ecs-service-template.yml
@@ -116,22 +116,22 @@ Resources:
       AutoScalingGroupName:
         Ref: EcsAutoScalingGroup
       ScalingAdjustment: 1
-  EcsClusterMemoryHighAlarm:
+  EcsClusterNeedsScalingUp:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmActions:
       - Ref: EcsAutoScalingPolicyUp
-      MetricName: MemoryReservation
+      MetricName: ClusterNeedsScalingUp
       ComparisonOperator: GreaterThanThreshold
-      Statistic: Average
-      AlarmDescription: ECS Cluster Memory Too High Scaling Alarm
-      Period: '300'
+      Statistic: Minimum
+      AlarmDescription: ECS cluster has been calculated to need scaling up
+      Period: '60'
       Dimensions:
-      - Value: {{clusterName}}
-        Name: ClusterName
+      - Name: ClusterName 
+        Value: {{clusterName}}
       EvaluationPeriods: '1'
-      Namespace: AWS/ECS
-      Threshold: '50'
+      Namespace: Handel/ECS
+      Threshold: '0'
   EcsAutoScalingPolicyDown:
     Type: AWS::AutoScaling::ScalingPolicy
     Properties:
@@ -139,22 +139,22 @@ Resources:
       AutoScalingGroupName:
         Ref: EcsAutoScalingGroup
       ScalingAdjustment: -1
-  EcsClusterMemoryLowAlarm:
+  EcsClusterNeedsScalingDown:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmActions:
       - Ref: EcsAutoScalingPolicyDown
-      MetricName: MemoryReservation
-      ComparisonOperator: LessThanThreshold
-      Statistic: Average
-      AlarmDescription: ECS Cluster Memory Too Low Scaling Alarm
-      Period: '300'
+      MetricName: ClusterNeedsScalingDown
+      ComparisonOperator: GreaterThanThreshold
+      Statistic: Minimum
+      AlarmDescription: ECS cluster has been calculated to need scaling down
+      Period: '60'
       Dimensions:
-      - Value: {{clusterName}}
-        Name: ClusterName
+      - Name: ClusterName 
+        Value: {{clusterName}}
       EvaluationPeriods: '1'
-      Namespace: AWS/ECS
-      Threshold: '25'
+      Namespace: Handel/ECS
+      Threshold: '0'
   EcsCluster:
     Type: AWS::ECS::Cluster
     Properties:
@@ -171,6 +171,7 @@ Resources:
         Ref: EcsCluster
       DesiredCount: {{desiredCount}}
       DeploymentConfiguration:
+        MaximumPercent: 200  #TODO - Does this need to be dynamically configured, or is just a blanket 200 ok?
         MinimumHealthyPercent: {{minimumHealthyPercentDeployment}}
       {{#if routingInfo}}
       LoadBalancers:

--- a/lib/services/ecs/index.js
+++ b/lib/services/ecs/index.js
@@ -16,9 +16,9 @@
  */
 const winston = require('winston');
 const DeployContext = require('../../datatypes/deploy-context');
-const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
 const accountConfig = require('../../common/account-config')().getAccountConfig();
 const deployPhaseCommon = require('../../common/deploy-phase-common');
+const cloudformationCalls = require('../../aws/cloudformation-calls');
 const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
 const bindPhaseCommon = require('../../common/bind-phase-common');
 const deletePhasesCommon = require('../../common/delete-phases-common');
@@ -88,7 +88,7 @@ function getInstanceCountForCluster(instanceType, containerInstances, containerM
     if (!instanceMemory) {
         throw new Error(`${SERVICE_NAME} - Unhandled instance type specified: ${instanceType}`);
     }
-    let maxInstanceMemoryToUse = instanceMemory * .5; //Fill up instances to 50% of capacity (allows for deployments)
+    let maxInstanceMemoryToUse = instanceMemory * .9; //Fill up instances to 90% of capacity
 
     let numInstances = 1; //Need at least one instance
     let currentInstanceMem = 0;
@@ -171,12 +171,12 @@ function getCompiledEcsTemplate(stackName, clusterName, ownServiceContext, ownPr
 
     let taskRoleStatements = getTaskRoleStatements(ownServiceContext, dependenciesDeployContexts);
 
-    let minContainers = serviceParams.min_containers || 1;
-    let maxContainers = serviceParams.max_containers || 1;
+    let minContainers = parseInt(serviceParams.min_containers) || 1;
+    let maxContainers = parseInt(serviceParams.max_containers) || 1;
     let instanceType = serviceParams.instance_type || "t2.micro";
     let maxMb = serviceParams.max_mb || 128;
     let minInstances = getInstanceCountForCluster(instanceType, minContainers, maxMb);
-    let maxInstances = getInstanceCountForCluster(instanceType, maxContainers, maxMb);
+    let maxInstances = getInstanceCountForCluster(instanceType, maxContainers * 2, maxMb); //Multiply maxContainers by two so that we can temporarily have more instances during deployments if necessary
     let imageName = `${accountConfig.account_id}.dkr.ecr.${accountConfig.region}.amazonaws.com/${ownServiceContext.appName}-${ownServiceContext.serviceName}:${ownServiceContext.environmentName}`
     let cpuUnits = serviceParams.cpu_units || 100;
 
@@ -195,7 +195,7 @@ function getCompiledEcsTemplate(stackName, clusterName, ownServiceContext, ownPr
         privateSubnetIds: accountConfig.private_subnets,
         asgCooldown: "300",
         desiredCount: minContainers.toString(),
-        minimumHealthyPercentDeployment: "0", //TODO - Change later
+        minimumHealthyPercentDeployment: "50", //TODO - Do we need to support more than just 50?
         publicSubnetIds: accountConfig.public_subnets,
         containerName: clusterName,
         dockerImage: imageName,
@@ -267,6 +267,30 @@ function getCompiledEcsTemplate(stackName, clusterName, ownServiceContext, ownPr
     }
 
     return handlebarsUtils.compileTemplate(`${__dirname}/ecs-service-template.yml`, handlebarsParams)
+}
+
+function createAutoScalingLambdaIfNotExists() {
+    let stackName = 'HandelEcsAutoScalingLambda';
+    return cloudformationCalls.getStack(stackName)
+        .then(stack => {
+            if (!stack) {
+                return deployPhaseCommon.uploadDirectoryToHandelBucket(`${__dirname}/cluster-scaling-lambda/`, 'handel/ecs-cluster-auto-scaling-lambda', 'lambda-code')
+                    .then(s3ObjectInfo => {
+                        let handlebarsParams = {
+                            s3Bucket: s3ObjectInfo.Bucket,
+                            s3Key: s3ObjectInfo.Key
+                        }
+                        return handlebarsUtils.compileTemplate(`${__dirname}/cluster-scaling-lambda/scaling-lambda-template.yml`, handlebarsParams)
+                            .then(compiledTemplate => {
+                                winston.info(`Creating Lambda for ECS auto-scaling`);
+                                return cloudformationCalls.createStack(stackName, compiledTemplate, [], null);
+                            });
+                    });
+            }
+            else {
+                return stack;
+            }
+        });
 }
 
 /**
@@ -350,7 +374,10 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
     winston.info(`${SERVICE_NAME} - Deploying Cluster and Service ${stackName}`);
 
     let clusterName = getShortenedClusterName(ownServiceContext);
-    return getUserDataScript(clusterName, dependenciesDeployContexts)
+    return createAutoScalingLambdaIfNotExists()
+        .then(autoScalingLambda => {
+            return getUserDataScript(clusterName, dependenciesDeployContexts)
+        })
         .then(userDataScript => {
             return createEcsServiceRoleIfNotExists()
                 .then(ecsServiceRole => {

--- a/test/services/ecs/cluster-scaling-lambda/cluster-scaling-lambda-test.js
+++ b/test/services/ecs/cluster-scaling-lambda/cluster-scaling-lambda-test.js
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const clusterScalingLambda = require('../../../../lib/services/ecs/cluster-scaling-lambda');
+const sinon = require('sinon');
+const expect = require('chai').expect;
+const AWS = require('aws-sdk-mock');
+
+describe('ecs cluster scaling lambda', function () {
+    let sandbox;
+
+    beforeEach(function () {
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+        AWS.restore('ECS');
+        AWS.restore('CloudWatch');
+    });
+
+    describe('handler method', function () {
+        function mockAwsMethods() {
+                        let clusterArn = "FakeClusterArn";
+            AWS.mock('ECS', 'listClusters', Promise.resolve({
+                clusterArns: [
+                    clusterArn
+                ]
+            }));
+            let clusterName = "FakeClusterName";
+            AWS.mock('ECS', 'describeClusters', Promise.resolve({
+                clusters: [{
+                    clusterName
+                }]
+            }));
+            let containerInstanceArn = "FakeContainerInstanceArn";
+            AWS.mock('ECS', 'listContainerInstances', Promise.resolve({
+                containerInstanceArns: [
+                    containerInstanceArn
+                ]
+            }));
+            AWS.mock('ECS', 'describeContainerInstances', Promise.resolve({
+                containerInstances: [{
+                    remainingResources: [
+                        {
+                            name: 'CPU',
+                            integerValue: '100'
+                        },
+                        {
+                            name: "MEMORY",
+                            integerValue: '128',
+                        }
+                    ],
+                    registeredResources: [
+                        {
+                            name: 'CPU',
+                            integerValue: '100'
+                        },
+                        {
+                            name: "MEMORY",
+                            integerValue: '128',
+                        }
+                    ]
+                }]
+            }));
+            let taskArn = "FakeTaskArn";
+            AWS.mock('ECS', 'listTasks', Promise.resolve({
+                taskArns: [
+                    taskArn
+                ]
+            }));
+            let taskDefinitionArn = "FakeTaskDefinitionArn";
+            AWS.mock('ECS', 'describeTasks', Promise.resolve({
+                tasks: [{
+                    taskDefinitionArn
+                }]
+            }));
+            AWS.mock('ECS', 'describeTaskDefinition', Promise.resolve({
+                taskDefinition: {
+                    containerDefinitions: [{
+                        cpu: '100',
+                        memory: '128'
+                    }]
+                }
+            }));
+            AWS.mock('CloudWatch', 'putMetricData', Promise.resolve({}));
+        }
+
+        it('should notify CloudWatch to scale up when there is no more room on the cluster', function () {
+            mockAwsMethods();
+            return clusterScalingLambda.handler({}, {})
+                .then(updateMetrics => {
+                    //TODO - Expect something?
+                });
+        });
+
+        it('should notify CloudWatch to scale down when the number of scehdulable containers is greater than what fits on the largest instance', function () {
+
+        });
+
+        it('should notify CloudWatch to do nothing if neither of the above cases apply', function () {
+
+        });
+    });
+});


### PR DESCRIPTION
This change adds a Lambda that checks every minute to check whether
clusters need to be scaled up or down. It uses the concept of the
'largest schedulable container' from
http://garbe.io/blog/2017/04/12/a-better-solution-to-ecs-autoscaling/
to decide whether the cluster should scale up, scale down, or stay
put.

Now that this is in place, I've also set the cluster minimum healthy
to 50 percent instead of 0 percent, which will now do deployments
without downtimes. This is still hard-coded for now.