### PR TITLE
Use the latest ECS AMI.

### DIFF
--- a/lib/aws/ec2-calls.js
+++ b/lib/aws/ec2-calls.js
@@ -201,3 +201,38 @@ exports.addIngressRuleToSecurityGroup = function (sourceSg, destSg,
             return exports.getSecurityGroup(destSg['GroupName'], vpcId);
         });
 }
+
+/**
+ * Given an owner (such as 'amazon' or '111111111111'), returns the latest
+ * AMI for the given name substring, or null if no such AMI exists
+ */
+exports.getLatestAmiByName = function (owner, nameSubstring) {
+    const ec2 = new AWS.EC2({
+        apiVersion: '2016-11-15'
+    });
+    let describeParams = {
+        Owners: [owner],
+        Filters: [{
+            Name: 'name',
+            Values: [`*${nameSubstring}*`]
+        }]
+    }
+    return ec2.describeImages(describeParams).promise()
+        .then(describeResult => {
+            let images = describeResult.Images;
+            if (images.length === 0) {
+                return null;
+            }
+            else {
+                let latestImage = images[0];
+                for (let image of images) {
+                    let latestDate = new Date(latestImage.CreationDate);
+                    let currentDate = new Date(image.CreationDate);
+                    if (currentDate > latestDate) {
+                        latestImage = image;
+                    }
+                }
+                return latestImage;
+            }
+        });
+}

--- a/lib/services/ecs/index.js
+++ b/lib/services/ecs/index.js
@@ -15,6 +15,7 @@
  *
  */
 const winston = require('winston');
+const ec2Calls = require('../../aws/ec2-calls');
 const DeployContext = require('../../datatypes/deploy-context');
 const accountConfig = require('../../common/account-config')().getAccountConfig();
 const deployPhaseCommon = require('../../common/deploy-phase-common');
@@ -166,107 +167,114 @@ function getTaskRoleStatements(serviceContext, dependenciesDeployContexts) {
     return deployPhaseCommon.getAllPolicyStatementsForServiceRole(ownPolicyStatements, dependenciesDeployContexts);
 }
 
+function getLatestEcsAmiId() {
+    return ec2Calls.getLatestAmiByName('amazon', 'amazon-ecs')
+}
+
 function getCompiledEcsTemplate(stackName, clusterName, ownServiceContext, ownPreDeployContext, dependenciesDeployContexts, userDataScript, ecsServiceRole) {
-    let serviceParams = ownServiceContext.params;
+    return getLatestEcsAmiId()
+        .then(latestEcsAmi => {
+            let serviceParams = ownServiceContext.params;
 
-    let taskRoleStatements = getTaskRoleStatements(ownServiceContext, dependenciesDeployContexts);
+            let taskRoleStatements = getTaskRoleStatements(ownServiceContext, dependenciesDeployContexts);
 
-    let minContainers = parseInt(serviceParams.min_containers) || 1;
-    let maxContainers = parseInt(serviceParams.max_containers) || 1;
-    let instanceType = serviceParams.instance_type || "t2.micro";
-    let maxMb = serviceParams.max_mb || 128;
-    let minInstances = getInstanceCountForCluster(instanceType, minContainers, maxMb);
-    let maxInstances = getInstanceCountForCluster(instanceType, maxContainers * 2, maxMb); //Multiply maxContainers by two so that we can temporarily have more instances during deployments if necessary
-    let imageName = `${accountConfig.account_id}.dkr.ecr.${accountConfig.region}.amazonaws.com/${ownServiceContext.appName}-${ownServiceContext.serviceName}:${ownServiceContext.environmentName}`
-    let cpuUnits = serviceParams.cpu_units || 100;
+            let minContainers = parseInt(serviceParams.min_containers) || 1;
+            let maxContainers = parseInt(serviceParams.max_containers) || 1;
+            let instanceType = serviceParams.instance_type || "t2.micro";
+            let maxMb = serviceParams.max_mb || 128;
+            let minInstances = getInstanceCountForCluster(instanceType, minContainers, maxMb);
+            let maxInstances = getInstanceCountForCluster(instanceType, maxContainers * 2, maxMb); //Multiply maxContainers by two so that we can temporarily have more instances during deployments if necessary
+            let imageName = `${accountConfig.account_id}.dkr.ecr.${accountConfig.region}.amazonaws.com/${ownServiceContext.appName}-${ownServiceContext.serviceName}:${ownServiceContext.environmentName}`
+            let cpuUnits = serviceParams.cpu_units || 100;
 
-    let handlebarsParams = {
-        portMappings: [],
-        clusterName,
-        stackName,
-        minContainers,
-        maxContainers,
-        instanceType,
-        minInstances: minInstances.toString(),
-        maxInstances: maxInstances.toString(),
-        ecsSecurityGroupId: ownPreDeployContext.securityGroups[0].GroupId,
-        amiImageId: accountConfig.ecs_ami,
-        userData: new Buffer(userDataScript).toString('base64'),
-        privateSubnetIds: accountConfig.private_subnets,
-        asgCooldown: "300",
-        desiredCount: minContainers.toString(),
-        minimumHealthyPercentDeployment: "50", //TODO - Do we need to support more than just 50?
-        publicSubnetIds: accountConfig.public_subnets,
-        containerName: clusterName,
-        dockerImage: imageName,
-        vpcId: accountConfig.vpc,
-        ecsServiceRoleArn: ecsServiceRole.Arn,
-        policyStatements: taskRoleStatements,
-        maxMb: maxMb.toString(),
-        cpuUnits: cpuUnits.toString(),
-        deployVersion: ownServiceContext.deployVersion.toString(),
-        tags: deployPhaseCommon.getTags(ownServiceContext)
-    };
+            let handlebarsParams = {
+                portMappings: [],
+                clusterName,
+                stackName,
+                minContainers,
+                maxContainers,
+                instanceType,
+                minInstances: minInstances.toString(),
+                maxInstances: maxInstances.toString(),
+                ecsSecurityGroupId: ownPreDeployContext.securityGroups[0].GroupId,
+                amiImageId: latestEcsAmi.ImageId,
+                userData: new Buffer(userDataScript).toString('base64'),
+                privateSubnetIds: accountConfig.private_subnets,
+                asgCooldown: "300",
+                desiredCount: minContainers.toString(),
+                minimumHealthyPercentDeployment: "50", //TODO - Do we need to support more than just 50?
+                publicSubnetIds: accountConfig.public_subnets,
+                containerName: clusterName,
+                dockerImage: imageName,
+                vpcId: accountConfig.vpc,
+                ecsServiceRoleArn: ecsServiceRole.Arn,
+                policyStatements: taskRoleStatements,
+                maxMb: maxMb.toString(),
+                cpuUnits: cpuUnits.toString(),
+                deployVersion: ownServiceContext.deployVersion.toString(),
+                tags: deployPhaseCommon.getTags(ownServiceContext)
+            };
 
-    //Add port mappings if routing is specified
-    if (serviceParams.routing) {
-        //Wire up first port to Load Balancer
-        handlebarsParams.containerPort = serviceParams.port_mappings[0].toString();
+            //Add port mappings if routing is specified
+            if (serviceParams.routing) {
+                //Wire up first port to Load Balancer
+                handlebarsParams.containerPort = serviceParams.port_mappings[0].toString();
 
-        //Add port mappings to container
-        for (let portToMap of serviceParams['port_mappings']) {
-            handlebarsParams.portMappings.push(portToMap);
-        }
-    }
+                //Add port mappings to container
+                for (let portToMap of serviceParams['port_mappings']) {
+                    handlebarsParams.portMappings.push(portToMap);
+                }
+            }
 
-    //Inject env vars from various sources
-    handlebarsParams.environmentVariables = {};
+            //Inject env vars from various sources
+            handlebarsParams.environmentVariables = {};
 
-    //Inject env vars defined by service (if any)
-    let serviceEnvVars = serviceParams['environment_variables']
-    if (serviceEnvVars) {
-        handlebarsParams.environmentVariables = _.assign(handlebarsParams.environmentVariables, serviceEnvVars);
-    }
+            //Inject env vars defined by service (if any)
+            let serviceEnvVars = serviceParams['environment_variables']
+            if (serviceEnvVars) {
+                handlebarsParams.environmentVariables = _.assign(handlebarsParams.environmentVariables, serviceEnvVars);
+            }
 
-    //Inject env vars defined by dependencies
-    let dependenciesEnvVars = deployPhaseCommon.getEnvVarsFromDependencyDeployContexts(dependenciesDeployContexts);
-    handlebarsParams.environmentVariables = _.assign(handlebarsParams.environmentVariables, dependenciesEnvVars);
+            //Inject env vars defined by dependencies
+            let dependenciesEnvVars = deployPhaseCommon.getEnvVarsFromDependencyDeployContexts(dependenciesDeployContexts);
+            handlebarsParams.environmentVariables = _.assign(handlebarsParams.environmentVariables, dependenciesEnvVars);
 
-    //Inject env vars from Handel file
-    let handelInjectedEnvVars = deployPhaseCommon.getEnvVarsFromServiceContext(ownServiceContext);
-    handlebarsParams.environmentVariables = _.assign(handlebarsParams.environmentVariables, handelInjectedEnvVars);
+            //Inject env vars from Handel file
+            let handelInjectedEnvVars = deployPhaseCommon.getEnvVarsFromServiceContext(ownServiceContext);
+            handlebarsParams.environmentVariables = _.assign(handlebarsParams.environmentVariables, handelInjectedEnvVars);
 
-    //Add volumes and mount points
-    let dependenciesMountPoints = getDependenciesDeployContextMountPoints(dependenciesDeployContexts);
-    if (Object.keys(dependenciesMountPoints).length > 0) {
-        handlebarsParams.volumes = [];
-        handlebarsParams.mountPoints = [];
+            //Add volumes and mount points
+            let dependenciesMountPoints = getDependenciesDeployContextMountPoints(dependenciesDeployContexts);
+            if (Object.keys(dependenciesMountPoints).length > 0) {
+                handlebarsParams.volumes = [];
+                handlebarsParams.mountPoints = [];
 
-        for (let taskDefMountPoint of dependenciesMountPoints) {
-            handlebarsParams.volumes.push({
-                sourcePath: taskDefMountPoint.mountDir,
-                name: taskDefMountPoint.name
-            });
+                for (let taskDefMountPoint of dependenciesMountPoints) {
+                    handlebarsParams.volumes.push({
+                        sourcePath: taskDefMountPoint.mountDir,
+                        name: taskDefMountPoint.name
+                    });
 
-            handlebarsParams.mountPoints.push({
-                containerPath: taskDefMountPoint.mountDir,
-                sourceVolume: taskDefMountPoint.name
-            })
-        }
-    }
+                    handlebarsParams.mountPoints.push({
+                        containerPath: taskDefMountPoint.mountDir,
+                        sourceVolume: taskDefMountPoint.name
+                    })
+                }
+            }
 
-    //Add routing if specified
-    let routingInfo = getRoutingInformationForService(ownServiceContext);
-    if (routingInfo) {
-        handlebarsParams.routingInfo = routingInfo;
-    }
+            //Add routing if specified
+            let routingInfo = getRoutingInformationForService(ownServiceContext);
+            if (routingInfo) {
+                handlebarsParams.routingInfo = routingInfo;
+            }
 
-    //Add the SSH keypair if specified
-    if (serviceParams.key_name) {
-        handlebarsParams.sshKeyName = serviceParams.key_name
-    }
+            //Add the SSH keypair if specified
+            if (serviceParams.key_name) {
+                handlebarsParams.sshKeyName = serviceParams.key_name
+            }
 
-    return handlebarsUtils.compileTemplate(`${__dirname}/ecs-service-template.yml`, handlebarsParams)
+            return handlebarsUtils.compileTemplate(`${__dirname}/ecs-service-template.yml`, handlebarsParams)
+        });
 }
 
 function createAutoScalingLambdaIfNotExists() {

--- a/test/aws/ec2-calls-test.js
+++ b/test/aws/ec2-calls-test.js
@@ -197,4 +197,36 @@ describe('ec2-calls', function () {
                 });
         });
     });
+
+    describe('getLatestAmiByName', function () {
+        it('should return the latest AMI from a list of AMIs with the given name substring', function () {
+            let latestCreationDate = '2017-01-27T19:23:17.000Z'
+            AWS.mock('EC2', 'describeImages', Promise.resolve({
+                Images: [
+                    {
+                        CreationDate: '2016-01-27T19:23:17.000Z'
+                    },
+                    {
+                        CreationDate: latestCreationDate
+                    }
+                ]
+            }));
+
+            return ec2Calls.getLatestAmiByName('amazon', 'some-ami-name')
+                .then(ami => {
+                    expect(ami.CreationDate).to.equal(latestCreationDate);
+                });
+        });
+
+        it('should return null if there are no results', function () {
+            AWS.mock('EC2', 'describeImages', Promise.resolve({
+                Images: []
+            }));
+
+            return ec2Calls.getLatestAmiByName('amazon', 'some-ami-name')
+                .then(ami => {
+                    expect(ami).to.be.null;
+                });
+        });
+    });
 });

--- a/test/services/ecs/ecs-test.js
+++ b/test/services/ecs/ecs-test.js
@@ -18,6 +18,7 @@ const accountConfig = require('../../../lib/common/account-config')(`${__dirname
 const ecs = require('../../../lib/services/ecs');
 const deployPhaseCommon = require('../../../lib/common/deploy-phase-common');
 const cloudformationCalls = require('../../../lib/aws/cloudformation-calls');
+const ec2Calls = require('../../../lib/aws/ec2-calls');
 const deletePhasesCommon = require('../../../lib/common/delete-phases-common');
 const preDeployPhaseCommon = require('../../../lib/common/pre-deploy-phase-common');
 const bindPhaseCommon = require('../../../lib/common/bind-phase-common');
@@ -185,6 +186,9 @@ describe('ecs deployer', function () {
             let dependenciesDeployContexts = getDependenciesDeployContextsForDeploy(appName, envName, deployVersion);
 
             //Stub out AWS calls
+            let getLatestAmiByNameStub = sandbox.stub(ec2Calls, 'getLatestAmiByName').returns(Promise.resolve({
+                ImageId: 'FakeAmiId'
+            }));
             let getStackStub = sandbox.stub(cloudformationCalls, 'getStack').returns(Promise.resolve(null));
             let uploadDirStub = sandbox.stub(deployPhaseCommon, 'uploadDirectoryToHandelBucket').returns(Promise.resolve({}));
             let createStackStub = sandbox.stub(cloudformationCalls, 'createStack').returns(Promise.resolve({}));
@@ -197,6 +201,7 @@ describe('ecs deployer', function () {
                     expect(deployContext).to.be.instanceof(DeployContext);
                     expect(getStackStub.callCount).to.equal(1);
                     expect(uploadDirStub.callCount).to.equal(1);
+                    expect(getLatestAmiByNameStub.callCount).to.equal(1);
                     expect(createStackStub.callCount).to.equal(1);
                     expect(deployStackStub.callCount).to.equal(1);
                     expect(createCustomRoleStub.callCount).to.equal(1);


### PR DESCRIPTION
Previously we were requiring that the user specify an ECS AMI in the
Handel account config. Now we will dynamically query for the latest
AMI. In the future we may add support for custom ECS AMI names and
owners, but for now we'll just use the default AWS one.

Resolves #188 