### PR TITLE
Fix ElastiCache cluster naming bug

### DIFF
--- a/lib/common/elasticache-deployers-common.js
+++ b/lib/common/elasticache-deployers-common.js
@@ -1,0 +1,14 @@
+const uuid = require('uuid');
+
+/**
+ * Given the stack name, returns the name of the Elasticache cluster
+ * 
+ * ElastiCache only allows for a 20-char max cluster name, which means we have to truncate our stack
+ * name to fit in it.
+ */
+exports.getClusterName = function(serviceContext) {
+    let appFragment = serviceContext.appName.substring(0, 9);
+    let envFragement = serviceContext.environmentName.substring(0, 3);
+    let serviceFragment = serviceContext.serviceName.substring(0, 6);
+    return `${appFragment}-${envFragement}-${serviceFragment}`;
+}

--- a/lib/services/memcached/index.js
+++ b/lib/services/memcached/index.js
@@ -22,8 +22,8 @@ const deployPhaseCommon = require('../../common/deploy-phase-common');
 const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
 const bindPhaseCommon = require('../../common/bind-phase-common');
 const deletePhasesCommon = require('../../common/delete-phases-common');
+const elasticacheDeployersCommon = require('../../common/elasticache-deployers-common');
 const handlebarsUtils = require('../../common/handlebars-utils');
-const uuid = require('uuid');
 
 const SERVICE_NAME = "Memcached";
 const MEMCACHED_PORT = 11211;
@@ -42,24 +42,10 @@ function getDeployContext(serviceContext, cfStack) {
     return deployContext;
 }
 
-/**
- * Given the stack name, returns the name of the Memcached cluster
- * 
- * ElastiCache only allows for a 20-char max cluster name, which means we have to truncate our stack
- * name to fit in it.
- */
-function getClusterName(serviceContext) {
-    let appFragment = serviceContext.appName.substring(0, 8);
-    let envFragement = serviceContext.environmentName.substring(0, 3);
-    let serviceFragment = serviceContext.serviceName.substring(0, 3);
-    let uuidFragment = uuid().substring(0, 3); //Add a few randomish characters on the end in case there are any collisions by truncating the app, env, and service values
-    return `${appFragment}-${envFragement}-${serviceFragment}-${uuidFragment}`;
-}
-
 function getCompiledMemcachedTemplate(stackName, ownServiceContext, ownPreDeployContext) {
     let serviceParams = ownServiceContext.params;
 
-    let clusterName = getClusterName(ownServiceContext);
+    let clusterName = elasticacheDeployersCommon.getClusterName(ownServiceContext);
     let memcachedSecurityGroupId = ownPreDeployContext['securityGroups'][0].GroupId;
     let cacheSubnetGroup = accountConfig.elasticache_subnet_group;
     let instanceType = serviceParams.instance_type;

--- a/lib/services/redis/index.js
+++ b/lib/services/redis/index.js
@@ -23,7 +23,7 @@ const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
 const bindPhaseCommon = require('../../common/bind-phase-common');
 const deletePhasesCommon = require('../../common/delete-phases-common');
 const handlebarsUtils = require('../../common/handlebars-utils');
-const uuid = require('uuid');
+const elasticacheDeployersCommon = require('../../common/elasticache-deployers-common');
 
 const SERVICE_NAME = "Redis";
 const REDIS_PORT = 6379;
@@ -40,20 +40,6 @@ function getDeployContext(serviceContext, cfStack) {
     let address = cloudFormationCalls.getOutput('CacheAddress', cfStack);
     deployContext.environmentVariables[addressEnv] = address;
     return deployContext;
-}
-
-/**
- * Given the stack name, returns the name of the Redis cluster
- * 
- * ElastiCache only allows for a 20-char max cluster name, which means we have to truncate our stack
- * name to fit in it.
- */
-function getClusterName(serviceContext) {
-    let appFragment = serviceContext.appName.substring(0, 8);
-    let envFragement = serviceContext.environmentName.substring(0, 3);
-    let serviceFragment = serviceContext.serviceName.substring(0, 3);
-    let uuidFragment = uuid().substring(0, 3); //Add a few randomish characters on the end in case there are any collisions by truncating the app, env, and service values
-    return `${appFragment}-${envFragement}-${serviceFragment}-${uuidFragment}`;
 }
 
 function getCacheParameterGroupFamily(redisVersion) {
@@ -86,7 +72,7 @@ function getDefaultCacheParameterGroup(redisVersion, numShards) {
 function getCompiledRedisTemplate(stackName, ownServiceContext, ownPreDeployContext) {
     let serviceParams = ownServiceContext.params;
 
-    let clusterName = getClusterName(ownServiceContext);
+    let clusterName = elasticacheDeployersCommon.getClusterName(ownServiceContext);
     let redisVersion = serviceParams.redis_version;
     // let shards = serviceParams.shards || 1;
     let readReplicas = serviceParams.read_replicas || 0;

--- a/test/common/elasticache-deployers-common-test.js
+++ b/test/common/elasticache-deployers-common-test.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const elasticacheDeployersCommon = require('../../lib/common/elasticache-deployers-common');
+const ServiceContext = require('../../lib/datatypes/service-context');
+const sinon = require('sinon');
+const expect = require('chai').expect;
+
+describe('elasticache deployers common module', function () {
+    let sandbox;
+
+    beforeEach(function () {
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    describe('getClusterName', function () {
+        it('should return the shortened cluster name from the ServiceContext', function () {
+            let serviceContext = new ServiceContext("MyFakeAppWithALongNameWithManyCharacters", "MyLongEnvName", "MyLongishServiceName", "redis", "1", {});
+            let clusterName = elasticacheDeployersCommon.getClusterName(serviceContext);
+            expect(clusterName).to.equal("MyFakeApp-MyL-MyLong");
+        });
+    });
+});


### PR DESCRIPTION
CloudFormation was creating a new cluster on every deploy because
of the random characters appended to the end of the cluster name.

This change removes those random characters and just uses more of
the app and service names.