### PR TITLE
Add initial support for DynamoDB secondary indexes.

### DIFF
--- a/docs/supported-services/dynamodb.rst
+++ b/docs/supported-services/dynamodb.rst
@@ -29,28 +29,40 @@ Parameters
      - 
      - This must always be *dynamodb* for this service type.
    * - partition_key
-     - PartitionKey
+     - :ref:`dynamodb-partition-key`
      - Yes
      - 
      - The ParitionKey element details how you want your partition key specified.
    * - sort_key
-     - SortKey
+     - :ref:`dynamodb-sort-key`
      - No
      - None
      - The SortKey element details how you want your sort key specified. Unlike partition_key, sort_key is not required.
    * - provisioned_throughput
-     - ProvisionedThroughput
+     - :ref:`dynamodb-provisioned-throughput`
      - No
      - 5 for read and write
      - The ProvisionedThroughput element details how much provisioned IOPS you want on your table for reads and writes.
+   * - local_indexes
+     - :ref:`dynamodb-local-indexes`
+     - No
+     - 
+     - You can configure `local secondary indexes <http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LSI.html>`_ for fast queries on a different sort key within the same partition key.
+   * - global_indexes
+     - :ref:`dynamodb-global-indexes`
+     - No
+     -
+     - You can configure `global secondary indexes <http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GSI.html>`_ for fast queries on other partition and sort keys in addition to the ones on your table.
    * - tags
      - :ref:`dynamodb-tags`
      - No
      - 
      - Any tags you want to apply to your Dynamo Table
 
-PartitionKey element
-~~~~~~~~~~~~~~~~~~~~
+.. _dynamodb-partition-key:
+
+PartitionKey
+~~~~~~~~~~~~
 The PartitionKey element tells how to configure your partition key in DynamoDB. It has the following schema:
 
 .. code-block:: yaml
@@ -59,8 +71,10 @@ The PartitionKey element tells how to configure your partition key in DynamoDB. 
       name: <key_name> 
       type: <String|Number>
 
-SortKey element
-~~~~~~~~~~~~~~~
+.. _dynamodb-sort-key:
+
+SortKey
+~~~~~~~
 The SortKey element tells how to configure your sort key in DynamoDB. It has the following schema:
 
 .. code-block:: yaml
@@ -69,21 +83,64 @@ The SortKey element tells how to configure your sort key in DynamoDB. It has the
       name: <key_name> 
       type: <String|Number>
 
-ProvisionedThroughput element
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. _dynamodb-provisioned-throughput:
+
+ProvisionedThroughput
+~~~~~~~~~~~~~~~~~~~~~
 The ProvisionedThroughput element tells many IOPS to provision for your table for reads and writes. It has the following schema:
 
 .. code-block:: yaml
 
-    sort_key:
     provisioned_throughput:
-      read_capacity_units: <Number>
-      write_capacity_units: <Number>
+      read_capacity_units: <number>
+      write_capacity_units: <number>
+
+.. _dynamodb-local-indexes:
+
+LocalIndexes
+~~~~~~~~~~~~
+The LocalIndexes element allows you to configure local secondary indexes on your table for alternate query methods. It has the following schema:
+
+.. code-block:: yaml
+
+    local_indexes:
+    - name: <string> # Required
+      sort_key: # Required
+        name: <string>
+        type: <String|Number>
+      attributes_to_copy: # Required
+      - <string>
+
+.. _dynamodb-global-indexes:
+
+GlobalIndexes
+~~~~~~~~~~~~~
+The GlobalIndexes element allows you to configure global secondary indexes on your table for alternate query methods. It allows you to specify a different partition key than the main table. It has the following schema:
+
+.. code-block:: yaml
+
+    global_indexes:
+    - name: <string> # Required
+      partition_key: # Required
+        name: <string>
+        type: <String|Number>
+      sort_key: # Optional
+        name: <string>
+        type: <String|Number>
+      attributes_to_copy: # Required
+      - <string>
+      provisioned_throughput: # Optional
+        read_capacity_units: <number> # Default: 1
+        write_capacity_units: <number> # Default: 1
+
+.. WARNING::
+
+    Be aware that using Global Secondary Indexes can greatly increase your cost. When you use global indexes, you are effectively creating a new table. This will increase your cost by the amount required for storage and allocated IOPS for the global index.
 
 .. _dynamodb-tags:
 
 Tags
-~~~~~~~~~~~~
+~~~~
 The Tags element is defined by the following schema:
 
 .. code-block:: yaml

--- a/lib/services/dynamodb/dynamodb-template.yml
+++ b/lib/services/dynamodb/dynamodb-template.yml
@@ -7,22 +7,59 @@ Resources:
     Type: "AWS::DynamoDB::Table"
     Properties:
       AttributeDefinitions:
-      - AttributeName: {{partitionKeyName}}
-        AttributeType: {{partitionKeyType}}
-      {{#if sortKeyName}}
-      - AttributeName: {{sortKeyName}}
-        AttributeType: {{sortKeyType}}
-      {{/if}}
+      {{#each attributeDefinitions}}
+      - AttributeName: {{attributeName}}
+        AttributeType: {{attributeType}}
+      {{/each}}
       KeySchema:
-      - AttributeName: {{partitionKeyName}}
+      - AttributeName: {{tablePartitionKeyName}}
         KeyType: HASH
-      {{#if sortKeyName}}
-      - AttributeName: {{sortKeyName}}
+      {{#if tableSortKeyName}}
+      - AttributeName: {{tableSortKeyName}}
         KeyType: RANGE
       {{/if}}
       ProvisionedThroughput:
-        ReadCapacityUnits: {{readCapacityUnits}}
-        WriteCapacityUnits: {{writeCapacityUnits}}
+        ReadCapacityUnits: {{tableWriteCapacityUnits}}
+        WriteCapacityUnits: {{tableWriteCapacityUnits}}
+      {{#if globalIndexes}}
+      GlobalSecondaryIndexes:
+      {{#each globalIndexes}}
+      - IndexName: {{indexName}}
+        KeySchema:
+        - AttributeName: {{indexPartitionKeyName}}
+          KeyType: HASH
+        {{#if indexSortKeyName}} 
+        - AttributeName: {{indexSortKeyName}}
+          KeyType: RANGE
+        {{/if}}
+        Projection:
+          ProjectionType: INCLUDE
+          NonKeyAttributes:
+          {{#each indexProjectionAttributes}}
+          - {{this}}
+          {{/each}}
+        ProvisionedThroughput:
+          ReadCapacityUnits: {{indexReadCapacityUnits}}
+          WriteCapacityUnits: {{indexWriteCapacityUnits}}
+      {{/each}}
+      {{/if}}
+      {{#if localIndexes}}
+      LocalSecondaryIndexes:
+      {{#each localIndexes}}
+      - IndexName: {{indexName}}
+        KeySchema:
+        - AttributeName: {{indexPartitionKeyName}}
+          KeyType: HASH
+        - AttributeName: {{indexSortKeyName}}
+          KeyType: RANGE
+        Projection:
+          ProjectionType: INCLUDE
+          NonKeyAttributes:
+          {{#each indexProjectionAttributes}}
+          - {{this}}
+          {{/each}}
+      {{/each}}
+      {{/if}}
       TableName: {{tableName}}
       {{#if tags}}
       Tags:

--- a/lib/services/dynamodb/index.js
+++ b/lib/services/dynamodb/index.js
@@ -31,6 +31,7 @@ const KEY_TYPE_TO_ATTRIBUTE_TYPE = {
 const SERVICE_NAME = "DynamoDB";
 
 function getTablePolicyForDependentServices(tableName) {
+    let tableArn = buildTableARN(tableName);
     return {
         "Effect": "Allow",
         "Action": [
@@ -52,7 +53,8 @@ function getTablePolicyForDependentServices(tableName) {
             "dynamodb:UpdateItem"
         ],
         "Resource": [
-            buildTableARN(tableName)
+            tableArn, //Grants access to the table itself
+            `${tableArn}/index/*` //Grants access to any indexes the table may have
         ]
     }
 }
@@ -75,31 +77,137 @@ function getDeployContext(serviceContext, cfStack) {
     return deployContext;
 }
 
+function addDefinedAttribute(definedAttrs, attrName, attrType) {
+    function definedAttrExists(definedAttrs, attrName) {
+        for (let definedAttr of definedAttrs) {
+            if (definedAttr.attributeName === attrName) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    if (!definedAttrExists(definedAttrs, attrName)) {
+        definedAttrs.push({
+            attributeName: attrName,
+            attributeType: attrType
+        });
+    }
+}
+
+function getDefinedAttributes(ownServiceContext) {
+    let serviceParams = ownServiceContext.params;
+
+    let definedAttributes = [];
+
+    //Add partition and sort keys from main table
+    addDefinedAttribute(definedAttributes, serviceParams.partition_key.name, KEY_TYPE_TO_ATTRIBUTE_TYPE[serviceParams.partition_key.type]);
+    if (serviceParams.sort_key) {
+        addDefinedAttribute(definedAttributes, serviceParams.sort_key.name, KEY_TYPE_TO_ATTRIBUTE_TYPE[serviceParams.sort_key.type]);
+    }
+
+    //Add attributes from global indexes
+    if (serviceParams.global_indexes) {
+        for (let globalIndexConfig of serviceParams.global_indexes) {
+            addDefinedAttribute(definedAttributes, globalIndexConfig.partition_key.name, KEY_TYPE_TO_ATTRIBUTE_TYPE[serviceParams.partition_key.type]);
+            if (globalIndexConfig.sort_key) {
+                addDefinedAttribute(definedAttributes, globalIndexConfig.sort_key.name, KEY_TYPE_TO_ATTRIBUTE_TYPE[globalIndexConfig.sort_key.type]);
+            }
+        }
+    }
+
+    //Add attributes from local indexes
+    if (serviceParams.local_indexes) {
+        for (let localIndexConfig of serviceParams.local_indexes) {
+            addDefinedAttribute(definedAttributes, localIndexConfig.sort_key.name, KEY_TYPE_TO_ATTRIBUTE_TYPE[localIndexConfig.sort_key.type]);
+        }
+    }
+
+    return definedAttributes;
+}
+
+function getReadCapacityUnits(config) {
+    let indexReadCapacityUnits = 1;
+    if (config.provisioned_throughput && config.provisioned_throughput.read_capacity_units) {
+        indexReadCapacityUnits = config.provisioned_throughput.read_capacity_units;
+    }
+    return indexReadCapacityUnits;
+}
+
+function getWriteCapacityUnits(config) {
+    let indexWriteCapacityUnits = 1;
+    if (config.provisioned_throughput && config.provisioned_throughput.write_capacity_units) {
+        indexWriteCapacityUnits = config.provisioned_throughput.write_capacity_units;
+    }
+    return indexWriteCapacityUnits;
+}
+
+function getGlobalIndexConfig(ownServiceContext) {
+    let serviceParams = ownServiceContext.params;
+
+    let handlebarsGlobalIndexes = [];
+
+    for (let globalIndexConfig of serviceParams.global_indexes) {
+        let handlebarsGlobalIndex = {
+            indexName: globalIndexConfig.name,
+            indexReadCapacityUnits: getReadCapacityUnits(globalIndexConfig),
+            indexWriteCapacityUnits: getWriteCapacityUnits(globalIndexConfig),
+            indexPartitionKeyName: globalIndexConfig.partition_key.name,
+            indexProjectionAttributes: globalIndexConfig.attributes_to_copy
+        };
+
+        //Add sort key if provided
+        if (globalIndexConfig.sort_key) {
+            handlebarsGlobalIndex.indexSortKeyName = globalIndexConfig.sort_key.name
+        }
+
+        handlebarsGlobalIndexes.push(handlebarsGlobalIndex);
+    }
+
+    return handlebarsGlobalIndexes;
+}
+
+function getLocalIndexConfig(ownServiceContext) {
+    let serviceParams = ownServiceContext.params;
+
+    let handlebarsLocalIndexes = [];
+
+    for (let localIndexConfig of serviceParams.local_indexes) {
+        let handlebarsGlobalIndex = {
+            indexName: localIndexConfig.name,
+            indexPartitionKeyName: serviceParams.partition_key.name,
+            indexSortKeyName: localIndexConfig.sort_key.name,
+            indexProjectionAttributes: localIndexConfig.attributes_to_copy
+        };
+
+        handlebarsLocalIndexes.push(handlebarsGlobalIndex);
+    }
+
+    return handlebarsLocalIndexes;
+}
+
 function getCompiledDynamoTemplate(stackName, ownServiceContext) {
     let serviceParams = ownServiceContext.params;
 
-    let readCapacityUnits = 1;
-    if (serviceParams.provisioned_throughput && serviceParams.provisioned_throughput.read_capacity_units) {
-        readCapacityUnits = serviceParams.provisioned_throughput.read_capacity_units;
-    }
-    let writeCapacityUnits = 1;
-    if (serviceParams.provisioned_throughput && serviceParams.provisioned_throughput.write_capacity_units) {
-        writeCapacityUnits = serviceParams.provisioned_throughput.write_capacity_units;
-    }
-
     let handlebarsParams = {
         tableName: stackName,
-        partitionKeyName: serviceParams.partition_key.name,
-        partitionKeyType: KEY_TYPE_TO_ATTRIBUTE_TYPE[serviceParams.partition_key.type],
-        readCapacityUnits,
-        writeCapacityUnits,
+        attributeDefinitions: getDefinedAttributes(ownServiceContext),
+        tablePartitionKeyName: serviceParams.partition_key.name,
+        tableReadCapacityUnits: getReadCapacityUnits(serviceParams),
+        tableWriteCapacityUnits: getWriteCapacityUnits(serviceParams),
         tags: deployPhaseCommon.getTags(ownServiceContext)
     }
 
     //Add sort key if provided
     if (serviceParams.sort_key) {
-        handlebarsParams.sortKeyName = serviceParams.sort_key.name;
-        handlebarsParams.sortKeyType = KEY_TYPE_TO_ATTRIBUTE_TYPE[serviceParams.sort_key.type]
+        handlebarsParams.tableSortKeyName = serviceParams.sort_key.name;
+    }
+
+    if (serviceParams.global_indexes) {
+        handlebarsParams.globalIndexes = getGlobalIndexConfig(ownServiceContext);
+    }
+    if (serviceParams.local_indexes) {
+        handlebarsParams.localIndexes = getLocalIndexConfig(ownServiceContext);
     }
 
     return handlebarsUtils.compileTemplate(`${__dirname}/dynamodb-template.yml`, handlebarsParams);
@@ -117,14 +225,56 @@ exports.check = function (serviceContext) {
     let params = serviceContext.params;
 
     if (!params.partition_key) {
-        errors.push(`${SERVICE_NAME} - partition_key section is required`);
+        errors.push(`${SERVICE_NAME} - The 'partition_key' section is required`);
     }
     else {
         if (!params.partition_key.name) {
-            errors.push(`${SERVICE_NAME} - name field in partition_key is required`);
+            errors.push(`${SERVICE_NAME} - The 'name' field in the 'partition_key' section is required`);
         }
         if (!params.partition_key.type) {
-            errors.push(`${SERVICE_NAME} - type field in partition_key is required`);
+            errors.push(`${SERVICE_NAME} - The 'type' field in the 'partition_key' section is required`);
+        }
+    }
+
+    //Check global indexes
+    if (params.global_indexes) {
+        for (let globalIndexConfig of params.global_indexes) {
+            if (!globalIndexConfig.name) {
+                errors.push(`${SERVICE_NAME} - The 'name' field is required in the 'global_indexes' section`);
+            }
+
+            if (!globalIndexConfig.partition_key) {
+                errors.push(`${SERVICE_NAME} - The 'partition_key' section is required in the 'global_indexes' section`);
+            }
+            else {
+                if (!globalIndexConfig.partition_key.name) {
+                    errors.push(`${SERVICE_NAME} - The 'name' field in the 'partition_key' section is required in the 'global_indexes' section`);
+                }
+                if (!globalIndexConfig.partition_key.type) {
+                    errors.push(`${SERVICE_NAME} - The 'type' field in the 'partition_key' section is required in the 'global_indexes' section`);
+                }
+            }
+        }
+    }
+
+    //Check local indexes
+    if (params.local_indexes) {
+        for (let localIndexConfig of params.local_indexes) {
+            if (!localIndexConfig.name) {
+                errors.push(`${SERVICE_NAME} - The 'name' field is required in the 'local_indexes' section`);
+            }
+
+            if (!localIndexConfig.sort_key) {
+                errors.push(`${SERVICE_NAME} - The 'sort_key' section is required in the 'local_indexes' section`);
+            }
+            else {
+                if (!localIndexConfig.sort_key.name) {
+                    errors.push(`${SERVICE_NAME} - The 'name' field in the 'sort_key' section is required in the 'local_indexes' section`);
+                }
+                if (!localIndexConfig.sort_key.type) {
+                    errors.push(`${SERVICE_NAME} - The 'type' field in the 'sort_key' section is required in the 'local_indexes' section`);
+                }
+            }
         }
     }
 

--- a/test/services/ecs/ecs-test.js
+++ b/test/services/ecs/ecs-test.js
@@ -82,8 +82,8 @@ describe('ecs deployer', function () {
 
         beforeEach(function () {
             configToCheck = JSON.parse(JSON.stringify(VALID_ECS_CONFIG))
-            serviceContextToCheck = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", configToCheck);
-        })
+            serviceContextToCheck = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "ecs", "1", configToCheck);
+        });
 
         it('should require the auto_scaling section', function () {
             delete configToCheck.auto_scaling;


### PR DESCRIPTION
This change adds support for local and global secondary indexes.
I'm not terribly familiar with DynamoDB's indexes myself, so there
may be a change or two once people start using this.

Resolves #31 