### PR TITLE
Use the default AssociatePublicIpAddress determine this attribute at …

### DIFF
--- a/lib/services/beanstalk/index.js
+++ b/lib/services/beanstalk/index.js
@@ -101,7 +101,7 @@ function getCompiledBeanstalkTemplate(stackName, preDeployContext, serviceContex
             handlebarsParams.optionSettings.push(getEbConfigurationOption("aws:ec2:vpc", "Subnets", accountConfig.private_subnets.join(",")));
             handlebarsParams.optionSettings.push(getEbConfigurationOption("aws:ec2:vpc", "ELBSubnets", accountConfig.public_subnets.join(",")));
             handlebarsParams.optionSettings.push(getEbConfigurationOption("aws:ec2:vpc", "DBSubnets", accountConfig.data_subnets.join(",")));
-            handlebarsParams.optionSettings.push(getEbConfigurationOption("aws:ec2:vpc", "AssociatePublicIpAddress", false));
+            //handlebarsParams.optionSettings.push(getEbConfigurationOption("aws:ec2:vpc", "AssociatePublicIpAddress", false));
 
             //Add environment variables
             let envVarsToInject = getEnvVariablesToInject(serviceContext, dependenciesDeployContexts);


### PR DESCRIPTION
Turn off default setting of false. Let the subnet/beanstalk default setting define this.