### PR TITLE
Add initial support for IoT service.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,7 @@ Handel is a library that orchestrates your AWS deployments so you don't have to
    supported-services/dynamodb
    supported-services/ecs
    supported-services/efs
+   supported-services/iot
    supported-services/lambda
    supported-services/memcached
    supported-services/mysql

--- a/docs/supported-services/iot.rst
+++ b/docs/supported-services/iot.rst
@@ -1,0 +1,94 @@
+.. _iot:
+
+IoT
+===
+This document contains information about the IoT service supported in Handel. This Handel service currently provisions IoT topic rules that can invoke things like Lambda functions.
+
+Service Limitations
+-------------------
+This Handel service is quite new, and as such doesn't support all of IoT yet. In particular, the following are not supported:
+
+* Creating IoT Things.
+* Creating IoT Certificates.
+* Creating IoT Policies.
+
+Parameters
+----------
+.. list-table:: 
+   :header-rows: 1
+
+   * - Parameter
+     - Type
+     - Required
+     - Default
+     - Description
+   * - type
+     - string
+     - Yes
+     - 
+     - This must always be *iot* for this service type.
+
+Example Handel File
+-------------------
+The following example shows setting up an IoT topic rule to produce to a Lambda:
+
+.. code-block:: yaml
+
+    version: 1
+
+    name: my-topic-rule
+
+    environments:
+      dev:
+        topicrule:
+          type: iot
+          event_consumers:
+          - service_name: function
+            sql: "select * from 'something';"
+        function:
+          type: lambda
+          path_to_code: .
+          handler: index.handler
+          runtime: nodejs6.10
+
+Depending on this service
+-------------------------
+The IoT service cannot currently be specified as a dependency by any other services. It is currently only functioning as an event producer for other services such as Lambda.
+
+Events produced by this service
+-------------------------------
+The IoT service can produce events to the following service types:
+
+* Lambda
+
+Event consumer parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~
+When specifying event consumers on the IoT service, you may specify the following parameters:
+
+.. list-table:: 
+   :header-rows: 1
+
+   * - Parameter
+     - Type
+     - Required
+     - Default
+     - Description
+   * - service_name
+     - string
+     - Yes
+     - 
+     - This is the name of the service in your Handel file to which you would like to produce events.
+   * - sql
+     - string
+     - Yes
+     - 
+     - This is where you specify the `IoT-compatible SQL statement <http://docs.aws.amazon.com/iot/latest/developerguide/iot-sql-reference.html>`_ that will cause your rule to fire.
+   * - rule_disabled:
+     - boolean
+     - No
+     - false
+     - This defines whether the topic rule is currently enabled or disabled.
+
+Events consumed by this service
+-------------------------------
+The IoT service cannot currently consume events from other services.

--- a/docs/supported-services/lambda.rst
+++ b/docs/supported-services/lambda.rst
@@ -104,6 +104,8 @@ Example Handel File
         webapp:
           type: lambda
           path_to_code: .
+          handler: index.handler
+          runtime: nodejs6.10
           environment_variables:
             MY_ENV: myEnvValue
           tags:

--- a/lib/common/deploy-phase-common.js
+++ b/lib/common/deploy-phase-common.js
@@ -198,16 +198,6 @@ exports.getResourceName = function (serviceContext) {
     return `${serviceContext.appName}-${serviceContext.environmentName}-${serviceContext.serviceName}-${serviceContext.serviceType}`;
 }
 
-exports.getEventConsumerConfigParams = function (producerServiceContext, consumerServiceContext) {
-    let consumerServiceName = consumerServiceContext.serviceName;
-    for (let eventConsumerConfig of producerServiceContext.params.event_consumers) {
-        if (eventConsumerConfig.service_name === consumerServiceName) {
-            return eventConsumerConfig;
-        }
-    }
-    return null; //Return null if nothing found for the consumer service in the producer service config
-}
-
 exports.getTags = function (serviceContext) {
     let tags = {
         app: serviceContext.appName,

--- a/lib/common/iot-deployers-common.js
+++ b/lib/common/iot-deployers-common.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const accountConfig = require('../common/account-config')().getAccountConfig();
+
+exports.getTopicRuleNamePrefix = function (producerServiceContext) {
+    return `${producerServiceContext.appName}_${producerServiceContext.environmentName}_${producerServiceContext.serviceName}`.replace(/-/g, "_");
+}
+
+/**
+ * Given the service context of an IOT service that will be producing events via a topic rule,
+ * and the configuration for an event_consumer that the service will be producing to, this function
+ * returns the generated name of the topic rule.
+ * 
+ * NOTE: This doesn't use the usual deployPhaseCommon.getResourceName because the IOT service requires
+ * underscores rather than dashes, so we convert all dashes to underscores here.
+ */
+exports.getTopicRuleName = function (producerServiceContext, eventConsumerConfig) {
+    let ruleNamePrefix = exports.getTopicRuleNamePrefix(producerServiceContext);
+    return `${ruleNamePrefix}_${eventConsumerConfig.service_name}`.replace(/-/g, "_");
+}
+
+exports.getTopicRuleArnPrefix = function (topicRuleNamePrefix) {
+    let topicPrefixSub = topicRuleNamePrefix.replace(/-/g, "_");
+    return `arn:aws:iot:${accountConfig.region}:${accountConfig.account_id}:rule/${topicPrefixSub}`;
+}
+
+exports.getTopicRuleArn = function (topicRuleArnPrefix, consumerServiceName) {
+    let consumerServiceNameSub = consumerServiceName.replace(/-/g, "_")
+    return `${topicRuleArnPrefix}_${consumerServiceNameSub}`;
+}

--- a/lib/common/produce-events-phase-common.js
+++ b/lib/common/produce-events-phase-common.js
@@ -1,0 +1,8 @@
+exports.getEventConsumerConfig = function(serviceContext, eventConsumerServiceName) {
+    for(let eventConsumer of serviceContext.params.event_consumers) {
+        if(eventConsumer.service_name === eventConsumerServiceName) {
+            return eventConsumer;
+        }
+    }
+    return null;
+}

--- a/lib/phases/produce-events.js
+++ b/lib/phases/produce-events.js
@@ -39,12 +39,12 @@ exports.produceEvents = function (serviceDeployers, environmentContext, deployCo
 
     _.forEach(environmentContext.serviceContexts, function (producerServiceContext, producerServiceName) {
         if (producerServiceContext.params.event_consumers) {
-            _.forEach(producerServiceContext.params.event_consumers, function (consumerService) {
-                //Get deploy info for producer service
-                let producerDeployContext = deployContexts[producerServiceName];
-                let producerServiceDeployer = serviceDeployers[producerServiceContext.serviceType];
+            //Get deploy info for producer service
+            let producerServiceDeployer = serviceDeployers[producerServiceContext.serviceType];
+            let producerDeployContext = deployContexts[producerServiceName];
 
-                //Get deploy info for consumer service
+            //Run produce events for each service this service produces to
+            _.forEach(producerServiceContext.params.event_consumers, function (consumerService) {
                 let consumerServiceName = consumerService.service_name;
 
                 produceEventActions.push({

--- a/lib/services/cloudwatchevent/index.js
+++ b/lib/services/cloudwatchevent/index.js
@@ -24,6 +24,7 @@ const deployPhaseCommon = require('../../common/deploy-phase-common');
 const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
 const bindPhaseCommon = require('../../common/bind-phase-common');
 const deletePhasesCommon = require('../../common/delete-phases-common');
+const produceEventsPhaseCommon = require('../../common/produce-events-phase-common');
 const handlebarsUtils = require('../../common/handlebars-utils');
 const yaml = require('js-yaml');
 
@@ -121,7 +122,7 @@ exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerS
         let input;
         if (consumerServiceType === 'lambda') {
             targetArn = consumerDeployContext.eventOutputs.lambdaArn;
-            let eventConsumerConfig = deployPhaseCommon.getEventConsumerConfigParams(ownServiceContext, consumerServiceContext);
+            let eventConsumerConfig = produceEventsPhaseCommon.getEventConsumerConfig(ownServiceContext, consumerServiceContext.serviceName);
             if (!eventConsumerConfig) { throw new Error(`No event_consumer config found in producer service for '${consumerServiceContext.serviceName}'`); }
             input = eventConsumerConfig.event_input;
         }

--- a/lib/services/iot/index.js
+++ b/lib/services/iot/index.js
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const winston = require('winston');
+const handlebarsUtils = require('../../common/handlebars-utils');
+const DeployContext = require('../../datatypes/deploy-context');
+const UnDeployContext = require('../../datatypes/un-deploy-context');
+const ProduceEventsContext = require('../../datatypes/produce-events-context');
+const deployPhaseCommon = require('../../common/deploy-phase-common');
+const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
+const bindPhaseCommon = require('../../common/bind-phase-common');
+const deletePhasesCommon = require('../../common/delete-phases-common');
+const produceEventsPhaseCommon = require('../../common/produce-events-phase-common');
+const iotDeployersCommon = require('../../common/iot-deployers-common');
+const cloudformationCalls = require('../../aws/cloudformation-calls');
+
+const SERVICE_NAME = "IOT";
+
+function getDeployContext(stackName, ownServiceContext) {
+    let deployContext = new DeployContext(ownServiceContext);
+
+    let ruleNamePrefix = iotDeployersCommon.getTopicRuleNamePrefix(ownServiceContext);
+    deployContext.eventOutputs.topicRuleArnPrefix = iotDeployersCommon.getTopicRuleArnPrefix(ruleNamePrefix); //This will be suffixed by the name of the consuming service (since there may be more than one)
+    deployContext.eventOutputs.principal = "iot.amazonaws.com";
+
+    return deployContext;
+}
+
+function getCompiledTopicRuleTemplate(ruleName, sql, ruleDisabled, actions) {
+    //Default to false for ruleDisabled if not specified
+    if (ruleDisabled === null || ruleDisabled === undefined) {
+        ruleDisabled = false;
+    }
+
+    let handlebarsParams = {
+        ruleName,
+        sql,
+        ruleDisabled,
+        actions
+    }
+
+    return handlebarsUtils.compileTemplate(`${__dirname}/iot-topic-rule-template.yml`, handlebarsParams);
+}
+
+function getStackNameFromRuleName(ruleName) {
+    return ruleName.replace(/_/g, "-");
+}
+
+function deleteTopicRule(ruleName) {
+    winston.info(`${SERVICE_NAME} - Executing UnDeploy on topic rule '${ruleName}'`)
+
+    let stackName = getStackNameFromRuleName(ruleName);
+    return cloudformationCalls.getStack(stackName)
+        .then(stack => {
+            if (stack) {
+                winston.info(`${SERVICE_NAME} - Deleting stack '${stackName}'`);
+                return cloudformationCalls.deleteStack(stackName);
+            }
+            else {
+                winston.info(`${SERVICE_NAME} - Stack '${stackName}' has already been deleted`);
+            }
+        });
+}
+
+/**
+ * Service Deployer Contract Methods
+ * See https://github.com/byu-oit-appdev/handel/wiki/Creating-a-New-Service-Deployer#service-deployer-contract
+ *   for contract method documentation
+ */
+
+exports.check = function (serviceContext) {
+    let errors = [];
+
+    let serviceParams = serviceContext.params;
+    if (serviceParams.event_consumers) {
+        for (let eventConsumerConfig of serviceParams.event_consumers) {
+            if (!eventConsumerConfig.service_name) {
+                errors.push(`${SERVICE_NAME} - The 'service_name' parameter is required in each config in the 'event_consumers' section`);
+            }
+            if (!eventConsumerConfig.sql) {
+                errors.push(`${SERVICE_NAME} - The 'sql' parameter is required in each config in the 'event_consumers' section`);
+            }
+        }
+    }
+
+    return errors;
+}
+
+exports.preDeploy = function (serviceContext) {
+    return preDeployPhaseCommon.preDeployNotRequired(serviceContext, SERVICE_NAME);
+}
+
+exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
+    return bindPhaseCommon.bindNotRequired(ownServiceContext, dependentOfServiceContext, SERVICE_NAME);
+}
+
+exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
+    winston.info(`${SERVICE_NAME} - Deploy not currently required for the IoT service`);
+    let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
+    return Promise.resolve(getDeployContext(stackName, ownServiceContext)); //Empty deploy
+}
+
+exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerServiceContext, producerDeployContext) {
+    return Promise.reject(new Error(`The ${SERVICE_NAME} service doesn't consume events from other services`));
+}
+
+exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext) {
+    return new Promise((resolve, reject) => {
+        winston.info(`${SERVICE_NAME} - Producing events from '${ownServiceContext.serviceName}' for consumer '${consumerServiceContext.serviceName}'`);
+
+        //Create topic rule 
+        let eventConsumerConfig = produceEventsPhaseCommon.getEventConsumerConfig(ownServiceContext, consumerServiceContext.serviceName);
+        let consumerServiceType = consumerServiceContext.serviceType;
+        let ruleName = iotDeployersCommon.getTopicRuleName(ownServiceContext, eventConsumerConfig);
+        let sql = eventConsumerConfig.sql;
+        let ruleDisabled = eventConsumerConfig.rule_disabled;
+        let actions = [];
+        if (consumerServiceType === 'lambda') {
+            actions.push({
+                Lambda: {
+                    FunctionArn: consumerDeployContext.eventOutputs.lambdaArn
+                }
+            });
+        }
+        else {
+            return reject(new Error(`${SERVICE_NAME} - Unsupported event consumer type given: ${consumerServiceType}`));
+        }
+
+        let stackTags = deployPhaseCommon.getTags(ownServiceContext);
+        return getCompiledTopicRuleTemplate(ruleName, sql, ruleDisabled, actions)
+            .then(compiledTemplate => {
+                let stackName = getStackNameFromRuleName(ruleName);
+                return deployPhaseCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, SERVICE_NAME, stackTags)
+            })
+            .then(deployedStack => {
+                return resolve(new ProduceEventsContext(ownServiceContext, consumerServiceContext));
+            })
+    });
+}
+
+exports.unPreDeploy = function (ownServiceContext) {
+    return deletePhasesCommon.unPreDeployNotRequired(ownServiceContext, SERVICE_NAME);
+}
+
+exports.unBind = function (ownServiceContext) {
+    return deletePhasesCommon.unBindNotRequired(ownServiceContext, SERVICE_NAME);
+}
+
+exports.unDeploy = function (ownServiceContext) {
+    let deletePromises = [];
+
+    //Delete all topic rules created by produce events
+    let serviceParams = ownServiceContext.params;
+    if (serviceParams.event_consumers) {
+        for (let eventConsumerConfig of serviceParams.event_consumers) {
+            let ruleName = iotDeployersCommon.getTopicRuleName(ownServiceContext, eventConsumerConfig);
+            winston.info(`${SERVICE_NAME} - Deleting topic rule '${ruleName}'`);
+            deletePromises.push(deleteTopicRule(ruleName));
+        }
+    }
+
+    return Promise.all(deletePromises)
+        .then(() => {
+            return new UnDeployContext(ownServiceContext);
+        });
+}
+
+exports.producedEventsSupportedServices = [
+    'lambda'
+];
+
+exports.producedDeployOutputTypes = [];
+
+exports.consumedDeployOutputTypes = [];

--- a/lib/services/iot/iot-topic-rule-template.yml
+++ b/lib/services/iot/iot-topic-rule-template.yml
@@ -1,0 +1,28 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Handel-created IOT topic rule
+
+Resources:
+  TopicRule:
+    Type: "AWS::IoT::TopicRule"
+    Properties:
+      RuleName: {{ruleName}}
+      TopicRulePayload:
+        AwsIotSqlVersion: '2015-10-08'
+        Description: AWS IoT rule created by Handel for {{appName}}
+        RuleDisabled: {{ruleDisabled}}
+        Sql: "{{{sql}}}"
+        Actions:
+        {{#each actions}}
+        {{#each this}}
+        - {{@key}}:
+          {{#each this}}
+            {{@key}}: {{this}}
+          {{/each}}  
+        {{/each}}
+        {{/each}}
+
+Outputs:
+  TopicRuleName:
+    Description: The name of the topic rule
+    Value: !Ref TopicRule

--- a/lib/services/lambda/index.js
+++ b/lib/services/lambda/index.js
@@ -21,6 +21,7 @@ const ConsumeEventsContext = require('../../datatypes/consume-events-context');
 const util = require('../../common/util');
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
 const lambdaCalls = require('../../aws/lambda-calls');
+const iotDeployersCommon = require('../../common/iot-deployers-common');
 const deployPhaseCommon = require('../../common/deploy-phase-common');
 const deletePhasesCommon = require('../../common/delete-phases-common');
 const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
@@ -161,6 +162,10 @@ exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerS
         else if (producerServiceType === 'cloudwatchevent') {
             principal = producerDeployContext.eventOutputs.principal;
             sourceArn = producerDeployContext.eventOutputs.eventRuleArn;
+        }
+        else if (producerServiceType === 'iot') {
+            principal = producerDeployContext.eventOutputs.principal;
+            sourceArn = iotDeployersCommon.getTopicRuleArn(producerDeployContext.eventOutputs.topicRuleArnPrefix, ownServiceContext.serviceName);
         }
         else {
             return reject(new Error(`${SERVICE_NAME} - Unsupported event producer type given: ${producerServiceType}`));

--- a/lib/services/sns/index.js
+++ b/lib/services/sns/index.js
@@ -93,9 +93,9 @@ exports.check = function (serviceContext) {
         for (const subscription of serviceContext.params.subscriptions) {
             const allowedValues = ['http', 'https', 'email', 'email-json', 'sms'];
 
-            if (!subscription.endpoint) errors.push(`${SERVICE_NAME} - A subscription requires an 'endpoint' parameter`);
-            if (!subscription.protocol) errors.push(`${SERVICE_NAME} - A subscription requires a 'protocol' parameter`);
-            else if (!allowedValues.includes(subscription.protocol)) errors.push(`${SERVICE_NAME} - Protocol must be one of ${allowedValues.join(', ')}`);
+            if (!subscription.endpoint) { errors.push(`${SERVICE_NAME} - A subscription requires an 'endpoint' parameter`); }
+            if (!subscription.protocol) { errors.push(`${SERVICE_NAME} - A subscription requires a 'protocol' parameter`); }
+            else if (!allowedValues.includes(subscription.protocol)) { errors.push(`${SERVICE_NAME} - Protocol must be one of ${allowedValues.join(', ')}`); }
         }
     }
     return errors;

--- a/test/common/deploy-phase-common-test.js
+++ b/test/common/deploy-phase-common-test.js
@@ -278,38 +278,6 @@ describe('Deploy phase common module', function () {
         });
     });
 
-    describe('getEventConsumerConfigParams', function () {
-        let appName = "FakeApp";
-        let envName = "FakeEnv";
-        let deployVersion = "1";
-        let consumerServiceName = "ConsumerServiceName";
-        let consumerServiceContext = new ServiceContext(appName, envName, consumerServiceName, "lambda", deployVersion, {});
-        let producerServiceName = "ProducerServiceName";
-
-        it('should return the config for the consumer from the producer', function () {
-            let eventInputVal = '{"notify": false}';
-            let producerServiceContext = new ServiceContext(appName, envName, producerServiceName, "cloudwatchevent", deployVersion, {
-                event_consumers: [{
-                    service_name: consumerServiceName,
-                    event_input: eventInputVal
-                }]
-            });
-
-            let eventConsumerConfig = deployPhaseCommon.getEventConsumerConfigParams(producerServiceContext, consumerServiceContext);
-            expect(eventConsumerConfig).to.not.be.null;
-            expect(eventConsumerConfig.event_input).to.equal(eventInputVal);
-        });
-
-        it('should return null when no config exists in the producer for the consumer', function () {
-            let producerServiceContext = new ServiceContext(appName, envName, producerServiceName, "cloudwatchevent", deployVersion, {
-                event_consumers: []
-            });
-
-            let eventConsumerConfig = deployPhaseCommon.getEventConsumerConfigParams(producerServiceContext, consumerServiceContext);
-            expect(eventConsumerConfig).to.be.null;
-        });
-    });
-
     describe('getTags', function() {
         it('should return the Handel-injected tags, plus any user-defined tags', function() {
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {

--- a/test/common/iot-deployers-common-test.js
+++ b/test/common/iot-deployers-common-test.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const ServiceContext = require('../../lib/datatypes/service-context');
+const iotDeployersCommon = require('../../lib/common/iot-deployers-common');
+const sinon = require('sinon');
+const expect = require('chai').expect;
+
+describe('iot deployers common module', function () {
+    let sandbox;
+
+    beforeEach(function () {
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    let producerServiceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService-Name", "iot", "1", {});
+
+    describe('getTopicRuleNamePrefix', function () {
+        it('should return the prefix for the topic rule name (minus the consumer service name)', function () {
+            let ruleNamePrefix = iotDeployersCommon.getTopicRuleNamePrefix(producerServiceContext);
+            expect(ruleNamePrefix).to.equal("FakeApp_FakeEnv_FakeService_Name");
+        });
+    });
+
+    describe('getTopicRuleName', function() {
+        it('should return the topic rule name from the service information', function() {
+            let ruleName = iotDeployersCommon.getTopicRuleName(producerServiceContext, {
+                service_name: "FakeConsumer"
+            });
+            expect(ruleName).to.equal("FakeApp_FakeEnv_FakeService_Name_FakeConsumer");
+        });
+    });
+    
+    describe('getTopicRuleArnPrefix', function() {
+        it('should return the prefix of the arn of the topic rule for the given producer/consumer combo', function() {
+            let arnPrefix = iotDeployersCommon.getTopicRuleArnPrefix('FakeApp_FakeEnv_FakeService');
+            expect(arnPrefix).to.equal('arn:aws:iot:us-west-2:123456789012:rule/FakeApp_FakeEnv_FakeService');
+        });
+    });
+
+    describe('getTopicRuleArn', function() {
+        it("should return the arn of the topic rule for the given producer/consumer combo", function() {
+            let arn = iotDeployersCommon.getTopicRuleArn('arn:aws:iot:us-west-2:123456789012:rule/FakeApp_FakeEnv_FakeService', "Consumer-Service");
+            expect(arn).to.equal('arn:aws:iot:us-west-2:123456789012:rule/FakeApp_FakeEnv_FakeService_Consumer_Service');
+        });
+    });
+});

--- a/test/common/produce-events-phase-common-test.js
+++ b/test/common/produce-events-phase-common-test.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const ServiceContext = require('../../lib/datatypes/service-context');
+const produceEventsPhaseCommon = require('../../lib/common/produce-events-phase-common');
+const sinon = require('sinon');
+const expect = require('chai').expect;
+
+describe('produce events phase common module', function () {
+    let sandbox;
+
+    beforeEach(function () {
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    describe('getEventConsumerConfigParams', function () {
+        let appName = "FakeApp";
+        let envName = "FakeEnv";
+        let deployVersion = "1";
+        let consumerServiceName = "ConsumerServiceName";
+        let producerServiceName = "ProducerServiceName";
+
+        it('should return the config for the consumer from the producer', function () {
+            let eventInputVal = '{"notify": false}';
+            let producerServiceContext = new ServiceContext(appName, envName, producerServiceName, "cloudwatchevent", deployVersion, {
+                event_consumers: [{
+                    service_name: consumerServiceName,
+                    event_input: eventInputVal
+                }]
+            });
+
+            let eventConsumerConfig = produceEventsPhaseCommon.getEventConsumerConfig(producerServiceContext, consumerServiceName);
+            expect(eventConsumerConfig).to.not.be.null;
+            expect(eventConsumerConfig.event_input).to.equal(eventInputVal);
+        });
+
+        it('should return null when no config exists in the producer for the consumer', function () {
+            let producerServiceContext = new ServiceContext(appName, envName, producerServiceName, "cloudwatchevent", deployVersion, {
+                event_consumers: []
+            });
+
+            let eventConsumerConfig = produceEventsPhaseCommon.getEventConsumerConfig(producerServiceContext, consumerServiceName);
+            expect(eventConsumerConfig).to.be.null;
+        });
+    });
+});

--- a/test/services/iot/iot-test.js
+++ b/test/services/iot/iot-test.js
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const accountConfig = require('../../../lib/common/account-config')(`${__dirname}/../../test-account-config.yml`).getAccountConfig();
+const iot = require('../../../lib/services/iot');
+const cloudformationCalls = require('../../../lib/aws/cloudformation-calls');
+const ServiceContext = require('../../../lib/datatypes/service-context');
+const DeployContext = require('../../../lib/datatypes/deploy-context');
+const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
+const UnDeployContext = require('../../../lib/datatypes/un-deploy-context');
+const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
+const BindContext = require('../../../lib/datatypes/bind-context');
+const ProduceEventsContext = require('../../../lib/datatypes/produce-events-context');
+const UnBindContext = require('../../../lib/datatypes/un-bind-context');
+const deployPhaseCommon = require('../../../lib/common/deploy-phase-common');
+const deletePhasesCommon = require('../../../lib/common/delete-phases-common');
+const preDeployPhaseCommon = require('../../../lib/common/pre-deploy-phase-common');
+const bindPhaseCommon = require('../../../lib/common/bind-phase-common');
+const sinon = require('sinon');
+const expect = require('chai').expect;
+
+describe('lambda deployer', function () {
+    let sandbox;
+
+    beforeEach(function () {
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    describe('check', function () {
+        it('should return an error when the service_name param is not specified in event_consumers', function() {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "iot", "1", {
+                event_consumers: [{
+                    sql: "select * from 'something'"
+                }]
+            });
+            let errors = iot.check(serviceContext);
+            expect(errors.length).to.equal(1);
+            expect(errors[0]).to.include("The 'service_name' parameter is required");
+        });
+
+        it('should return an error when the sql parameter is not specified in the event_consumers seciton', function() {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "iot", "1", {
+                event_consumers: [{
+                    service_name: 'myconsumer',
+                }]
+            });
+            let errors = iot.check(serviceContext);
+            expect(errors.length).to.equal(1);
+            expect(errors[0]).to.include("The 'sql' parameter is required");
+        });
+
+        it('should return no errors when configured properly', function () {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "iot", "1", {
+                event_consumers: [{
+                    service_name: 'myconsumer',
+                    sql: "select * from 'something'"
+                }]
+            });
+            let errors = iot.check(serviceContext);
+            expect(errors.length).to.equal(0);
+        });
+    });
+
+    describe('preDeploy', function () {
+        it('should return an empty predeploy context since it doesnt do anything', function () {
+            let preDeployNotRequiredStub = sandbox.stub(preDeployPhaseCommon, 'preDeployNotRequired').returns(Promise.resolve(new PreDeployContext({})));
+
+            return iot.preDeploy({})
+                .then(preDeployContext => {
+                    expect(preDeployContext).to.be.instanceof(PreDeployContext);
+                    expect(preDeployNotRequiredStub.callCount).to.equal(1);
+                });
+        });
+    });
+
+    describe('bind', function () {
+        it('should return an empty bind context since it doesnt do anything', function () {
+            let bindNotRequiredStub = sandbox.stub(bindPhaseCommon, 'bindNotRequired').returns(Promise.resolve(new BindContext({}, {})));
+
+            return iot.bind({}, {}, {}, {})
+                .then(bindContext => {
+                    expect(bindContext).to.be.instanceof(BindContext);
+                    expect(bindNotRequiredStub.callCount).to.equal(1);
+                });
+        });
+    });
+
+    describe('deploy', function () {
+        it('should return an empty deploy context', function () {
+            return iot.deploy({}, {}, {})
+                .then(deployContext => {
+                    expect(deployContext).to.be.instanceof(DeployContext);
+                });
+        });
+    });
+
+    describe('consumeEvents', function () {
+        it('should throw an error because IOT cant consume event services', function () {
+            return iot.consumeEvents(null, null, null, null)
+                .then(consumeEventsContext => {
+                    expect(true).to.be.false; //Shouldnt get here
+                })
+                .catch(err => {
+                    expect(err.message).to.contain("IOT service doesn't consume events");
+                });
+        });
+    });
+
+    describe('produceEvents', function () {
+        let appName = "FakeApp";
+        let envName = "FakeEnv";
+        let version = "1";
+        let ownServiceContext = new ServiceContext(appName, envName, "FakeProducer", "iot", version, {
+            event_consumers: [{
+                service_name: "FakeConsumer",
+                sql: "select * from something;",
+                ruleDisabled: false
+            }]
+        });
+        let ownDeployContext = new DeployContext(ownServiceContext);
+
+
+        it('should create topic rules when lambda is the event consumer', function () {
+            let consumerServiceContext = new ServiceContext(appName, envName, "FakeConsumer", "lambda", version, {});
+            let consumerDeployContext = new DeployContext(consumerServiceContext);
+            consumerDeployContext.eventOutputs.lambdaArn = "FakeArn";
+
+            let deployStackStub = sandbox.stub(deployPhaseCommon, 'deployCloudFormationStack').returns(Promise.resolve({
+                Outputs: [
+                    {
+                        OutputKey: 'TopicRuleName',
+                        OutputValue: "MyRuleName",
+                    }
+                ]
+            }));
+
+            return iot.produceEvents(ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext)
+                .then(produceEventsContext => {
+                    expect(produceEventsContext).to.be.instanceof(ProduceEventsContext);
+                    expect(deployStackStub.callCount).to.equal(1);
+                });
+        });
+
+        it('should return an error if any other consumer type is specified', function () {
+            let consumerServiceContext = new ServiceContext(appName, envName, "FakeConsumer", "unknowntype", version, {});
+            let consumerDeployContext = new DeployContext(consumerServiceContext);
+            
+            return iot.produceEvents(ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext)
+                .then(produceEventsContext => {
+                    expect(true).to.equal(false); //Should not get here
+                })
+                .catch(err => {
+                    expect(err.message).to.contain("Unsupported event consumer type")
+                })
+        })
+    });
+
+    describe('unPreDeploy', function () {
+        it('should return an empty UnPreDeploy context', function () {
+            let unPreDeployNotRequiredStub = sandbox.stub(deletePhasesCommon, 'unPreDeployNotRequired').returns(Promise.resolve(new UnPreDeployContext({})));
+            return iot.unPreDeploy({})
+                .then(unPreDeployContext => {
+                    expect(unPreDeployContext).to.be.instanceof(UnPreDeployContext);
+                    expect(unPreDeployNotRequiredStub.callCount).to.equal(1);
+                });
+        });
+    });
+
+    describe('unBind', function () {
+        it('should return an empty UnBind context', function () {
+            let unBindNotRequiredStub = sandbox.stub(deletePhasesCommon, 'unBindNotRequired').returns(Promise.resolve(new UnBindContext({})));
+            return iot.unBind({})
+                .then(unBindContext => {
+                    expect(unBindContext).to.be.instanceof(UnBindContext);
+                    expect(unBindNotRequiredStub.callCount).to.equal(1);
+                });
+        });
+    });
+
+    describe('unDeploy', function () {
+        it('should delete the topic rule stacks', function () {
+            let ownServiceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "iot", "1", {
+                event_consumers: [
+                    {
+                        service_name: "A"
+                    },
+                    {
+                        service_name: "B"
+                    }
+                ]
+            });
+
+            let getStackStub = sandbox.stub(cloudformationCalls, 'getStack').returns(Promise.resolve({}));
+            let deleteStackStub = sandbox.stub(cloudformationCalls, 'deleteStack').returns(Promise.resolve({}));
+
+            return iot.unDeploy(ownServiceContext)
+                .then(unDeployContext => {
+                    expect(unDeployContext).to.be.instanceof(UnDeployContext);
+                    expect(getStackStub.callCount).to.equal(2);
+                    expect(deleteStackStub.callCount).to.equal(2);
+                })
+        });
+    });
+});

--- a/test/services/lambda/lambda-test.js
+++ b/test/services/lambda/lambda-test.js
@@ -178,14 +178,14 @@ describe('lambda deployer', function () {
     });
 
     describe('consumeEvents', function () {
-        it('should add permissions for the sns service type', function () {
-            let appName = "FakeApp";
-            let envName = "FakeEnv";
-            let deployVersion = "1";
-            let ownServiceContext = new ServiceContext(appName, envName, "consumerService", "lambda", deployVersion, {});
-            let ownDeployContext = new DeployContext(ownServiceContext);
-            ownDeployContext.eventOutputs.lambdaName = "FakeLambda";
+        let appName = "FakeApp";
+        let envName = "FakeEnv";
+        let deployVersion = "1";
+        let ownServiceContext = new ServiceContext(appName, envName, "consumerService", "lambda", deployVersion, {});
+        let ownDeployContext = new DeployContext(ownServiceContext);
+        ownDeployContext.eventOutputs.lambdaName = "FakeLambda";
 
+        it('should add permissions for the sns service type', function () {
             let producerServiceContext = new ServiceContext(appName, envName, "producerService", "sns", deployVersion, {});
             let producerDeployContext = new DeployContext(producerServiceContext);
             producerDeployContext.eventOutputs.principal = "FakePrincipal";
@@ -201,13 +201,6 @@ describe('lambda deployer', function () {
         });
 
         it('should add permissions for the cloudwatchevent service type', function () {
-            let appName = "FakeApp";
-            let envName = "FakeEnv";
-            let deployVersion = "1";
-            let ownServiceContext = new ServiceContext(appName, envName, "consumerService", "lambda", deployVersion, {});
-            let ownDeployContext = new DeployContext(ownServiceContext);
-            ownDeployContext.eventOutputs.lambdaName = "FakeLambda";
-
             let producerServiceContext = new ServiceContext(appName, envName, "producerService", "cloudwatchevent", deployVersion, {});
             let producerDeployContext = new DeployContext(producerServiceContext);
             producerDeployContext.eventOutputs.principal = "FakePrincipal";
@@ -219,6 +212,21 @@ describe('lambda deployer', function () {
                 .then(consumeEventsContext => {
                     expect(consumeEventsContext).to.be.instanceof(ConsumeEventsContext);
                     expect(addLambdaPermissionStub.calledOnce).to.be.true;
+                });
+        });
+
+        it('should add permissions for the iot service type', function () {
+            let producerServiceContext = new ServiceContext(appName, envName, "producerService", "iot", deployVersion, {});
+            let producerDeployContext = new DeployContext(producerServiceContext);
+            producerDeployContext.eventOutputs.principal = "FakePrincipal";
+            producerDeployContext.eventOutputs.topicRuleArnPrefix = "FakeTopicRuleArnPrefix";
+
+            let addLambdaPermissionStub = sandbox.stub(lambdaCalls, 'addLambdaPermissionIfNotExists').returns(Promise.resolve({}));
+
+            return lambda.consumeEvents(ownServiceContext, ownDeployContext, producerServiceContext, producerDeployContext)
+                .then(consumeEventsContext => {
+                    expect(consumeEventsContext).to.be.instanceof(ConsumeEventsContext);
+                    expect(addLambdaPermissionStub.callCount).to.equal(1);
                 });
         });
 
@@ -247,7 +255,7 @@ describe('lambda deployer', function () {
     });
 
     describe('produceEvents', function () {
-        it('should throw an error because EFS doesnt produce events for other services', function () {
+        it('should throw an error because Lambda doesnt produce events for other services', function () {
             return lambda.produceEvents(null, null, null, null)
                 .then(produceEventsContext => {
                     expect(true).to.be.false; //Shouldnt get here


### PR DESCRIPTION
This change adds initial bare-bones support for the IoT service.
Currently we only support configuring topic rules to go to Lambdas.
We can add more to this service as time goes on and we get more
feature requests.

Resolves #131 