### PR TITLE
Support ECS custom image names.

### DIFF
--- a/docs/supported-services/ecs.rst
+++ b/docs/supported-services/ecs.rst
@@ -74,6 +74,7 @@ The `containers` section is defined by the following schema:
 
     containers:
     - name: <string> # Required
+      image_name: <string> # Optional
       port_mappings: # Optional, required if you specify 'routing'
       - <integer>
       max_mb: <integer> # Optional. Default: 128
@@ -87,6 +88,35 @@ The `containers` section is defined by the following schema:
 .. NOTE::
 
   You may currently only specify the `routing` section in a single container. Attempting to add routing to multiple containers in a single service will result in an error. This is due to a current limitation in the integration between Application Load Balancers (ALB) and ECS that only allows you to attach an ALB to a single container in your task.
+
+Container Image Names
+*********************
+In each container, you may specify an optional *image_name*. If you want to pull a public image from somewhere like DockerHub, just reference the image name:
+
+.. code-block:: none
+
+    dsw88/my-cool-image
+
+If you want to reference an image in your AWS account's EC2 Container Registry (ECR), reference it like this:
+
+.. code-block:: none
+
+    # The <account> piece will be replaced with your account's long ECR repository name
+    <account>/my-cool-image
+
+If you don't specify an *image_name*, Handel will automatically choose an image name for you based on your Handel naming information. It will use the following image naming pattern:
+
+.. code-block:: none
+
+    <appName>-<serviceName>-<containerName>:<environmentName>
+
+For example, if you don't specify an *image_name* in the below :ref:`ecs-example-handel-file`, the two images ECS looks for would be named the following:
+
+.. code-block:: none
+
+    my-ecs-app-webapp-mywebapp:dev
+    my-ecs-app-webapp-myothercontainer:dev
+
 
 .. _ecs-autoscaling:
 
@@ -144,20 +174,7 @@ The `tags` section is defined by the following schema:
 
     Handel automatically applies some tags for you. See :ref:`tagging-default-tags` for information about these tags.
 
-Container Image Names
----------------------
-This ECS service looks in the EC2 Container Registry for the Docker images it pulls for your service containers. It looks for images with the following naming pattern:
 
-.. code-block:: none
-
-    <appName>-<serviceName>-<containerName>:<environmentName>
-
-For example, in the below :ref:`ecs-example-handel-file`, the two images ECS looks for would be named the following:
-
-.. code-block:: none
-
-    my-ecs-app-webapp-mywebapp:dev
-    my-ecs-app-webapp-myothercontainer:dev
 
 .. _ecs-example-handel-file:
 

--- a/lib/services/ecs/index.js
+++ b/lib/services/ecs/index.js
@@ -311,13 +311,40 @@ function getMountPointsForContainer(dependenciesDeployContexts) {
     return mountPoints;
 }
 
+/**
+ * This function chooses the image name to use for the ECS container in a task
+ * It defaults to a particular naming scheme, but supports giving your own image
+ * name as well.
+ * 
+ * If you want to give an image name in the ECR registry in the account, specify
+ * "<account>/myimagename", and <account> will be auto-replaced by the appropriate
+ * repository name.
+ * 
+ * @param {*} container - The container definition from the Handel file service
+ * @param {*} ownServiceContext - The ServiceContext of the Handel file
+ */
+function getImageName(container, ownServiceContext) {
+    if (container.image_name) { //Custom user-provided image
+        let customImageName = container.image_name;
+        if (customImageName.startsWith('<account>')) { //Comes from own account registry
+            let imageNameAndTag = customImageName.substring(9);
+            return `${accountConfig.account_id}.dkr.ecr.${accountConfig.region}.amazonaws.com${imageNameAndTag}`;
+        }
+        else { //Must come from somewhere else (Docker Hub, Quay.io, etc.)
+            return customImageName;
+        }
+    }
+    else { //Else try to use default image name
+        return `${accountConfig.account_id}.dkr.ecr.${accountConfig.region}.amazonaws.com/${ownServiceContext.appName}-${ownServiceContext.serviceName}-${container.name}:${ownServiceContext.environmentName}`;
+    }
+}
 
 function getCompiledEcsTemplate(stackName, clusterName, ownServiceContext, ownPreDeployContext, dependenciesDeployContexts, userDataScript, ecsServiceRole) {
     return getLatestEcsAmiId()
         .then(latestEcsAmi => {
             let serviceParams = ownServiceContext.params;
             let instanceType = "t2.micro";
-            if(serviceParams.cluster && serviceParams.cluster.instance_type) {
+            if (serviceParams.cluster && serviceParams.cluster.instance_type) {
                 instanceType = serviceParams.cluster.instance_type;
             }
 
@@ -360,9 +387,7 @@ function getCompiledEcsTemplate(stackName, clusterName, ownServiceContext, ownPr
                     }
                 }
 
-                //Configure image name
-                //TODO - ALLOW SPECIFYING CUSTOM IMAGE NAMES OTHER THAN DEFAULT
-                containerConfig.imageName = `${accountConfig.account_id}.dkr.ecr.${accountConfig.region}.amazonaws.com/${ownServiceContext.appName}-${ownServiceContext.serviceName}-${container.name}:${ownServiceContext.environmentName}`
+                containerConfig.imageName = getImageName(container, ownServiceContext);
 
                 //Add mount points if present
                 containerConfig.mountPoints = getMountPointsForContainer(dependenciesDeployContexts);
@@ -427,45 +452,45 @@ exports.check = function (serviceContext) {
     let errors = [];
     let params = serviceContext.params;
 
-    if(!params.auto_scaling) {
+    if (!params.auto_scaling) {
         errors.push(`${SERVICE_NAME} - The 'auto_scaling' section is required`);
     }
     else {
-        if(!params.auto_scaling.min_tasks) {
+        if (!params.auto_scaling.min_tasks) {
             errors.push(`${SERVICE_NAME} - The 'min_tasks' parameter is required in the 'auto_scaling' section`);
         }
-        if(!params.auto_scaling.max_tasks) {
+        if (!params.auto_scaling.max_tasks) {
             errors.push(`${SERVICE_NAME} - The 'max_tasks' parameter is required in the 'auto_scaling' section`);
         }
     }
 
-    if(params.load_balancer) {
+    if (params.load_balancer) {
         //Require the load balancer listener type
-        if(!params.load_balancer.type) {
+        if (!params.load_balancer.type) {
             errors.push(`${SERVICE_NAME} - The 'type' parameter is required in the 'load_balancer' section`);
         }
 
         //If type = https, require https_certificate
-        if(params.load_balancer.type === 'https' && !params.load_balancer.https_certificate) {
+        if (params.load_balancer.type === 'https' && !params.load_balancer.https_certificate) {
             errors.push(`${SERVICE_NAME} - The 'https_certificate' parameter is required in the 'load_balancer' section when you use HTTPS`);
         }
     }
 
     //Require at least one container definition
-    if(!params.containers || params.containers.length === 0) {
+    if (!params.containers || params.containers.length === 0) {
         errors.push(`${SERVICE_NAME} - You must specify at least one container in the 'containers' section`);
     }
     else {
         let alreadyHasOneRouting = false;
-        for(let container of params.containers) {
+        for (let container of params.containers) {
             //Require 'name'
-            if(!container.name) {
+            if (!container.name) {
                 errors.push(`${SERVICE_NAME} - The 'name' parameter is required in each container in the 'containers' section`);
             }
 
-            if(container.routing) {
+            if (container.routing) {
                 //Only allow one 'routing' section currently
-                if(alreadyHasOneRouting) {
+                if (alreadyHasOneRouting) {
                     errors.push(`${SERVICE_NAME} - You may not specify a 'routing' section in more than one container. This is due to a current limitation in ECS load balancing`);
                 }
                 else {
@@ -473,7 +498,7 @@ exports.check = function (serviceContext) {
                 }
 
                 //Require port_mappings if routing is specified
-                if(!container.port_mappings) {
+                if (!container.port_mappings) {
                     errors.push(`${SERVICE_NAME} - The 'port_mappings' parameter is required when you specify the 'routing' element`);
                 }
             }


### PR DESCRIPTION
This change adds the ability for people to specify an image name
from another place like Docker Hub or Quay.io

Resolves #197 