### PR TITLE
Add support for adding BinaryMediaTypes to apigateway

### DIFF
--- a/docs/supported-services/apigateway.rst
+++ b/docs/supported-services/apigateway.rst
@@ -62,7 +62,7 @@ Parameters
      - array
      - No
      -
-     - A sequence (array) of BinaryMediaType strings. *Note* The '/' character must be escaped with a '~1'. So 'image/jpeg' becomes 'image~1jpeg'.
+     - A sequence (array) of BinaryMediaType strings. *Note* The handel will do the '/' to '~1' `character escaping <http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-payload-encodings-configure-with-control-service-api.html#api-gateway-payload-encodings-pass-binary-as-is>`_ for you.
    * - description
      - string
      - No

--- a/docs/supported-services/apigateway.rst
+++ b/docs/supported-services/apigateway.rst
@@ -58,6 +58,11 @@ Parameters
      - Yes
      - 
      - The function to call (such as index.handler) in your deployable code when invoking the Lambda. This is the Lambda-equivalent of your 'main' method.
+   * - binary_media_types
+     - array
+     - No
+     -
+     - A sequence (array) of BinaryMediaType strings. *Note* The '/' character must be escaped with a '~1'. So 'image/jpeg' becomes 'image~1jpeg'.
    * - description
      - string
      - No

--- a/lib/services/apigateway/apigateway-proxy-template.yml
+++ b/lib/services/apigateway/apigateway-proxy-template.yml
@@ -87,6 +87,12 @@ Resources:
   ServerlessRestApi:
     Type: AWS::ApiGateway::RestApi
     Properties:
+      {{#if binaryMediaTypes}}
+      BinaryMediaTypes:
+      {{#each binaryMediaTypes}}
+      - {{this}}
+      {{/each}}
+      {{/if}}
       Body:
         info:
           version: '1.0'

--- a/lib/services/apigateway/apigateway-proxy-template.yml
+++ b/lib/services/apigateway/apigateway-proxy-template.yml
@@ -90,7 +90,7 @@ Resources:
       {{#if binaryMediaTypes}}
       BinaryMediaTypes:
       {{#each binaryMediaTypes}}
-      - {{this}}
+      - '{{{this}}}'
       {{/each}}
       {{/if}}
       Body:

--- a/lib/services/apigateway/index.js
+++ b/lib/services/apigateway/index.js
@@ -84,7 +84,14 @@ function getCompiledApiGatewayTemplate(stackName, ownServiceContext, dependencie
     }
 
 		// Add binary media types if specified
-		if(serviceParams.binary_media_types) handlebarsParams.binaryMediaTypes=serviceParams.binary_media_types;
+		if(serviceParams.binary_media_types)
+    {
+      handlebarsParams.binaryMediaTypes=[];
+      for(let type of serviceParams.binary_media_types)
+      {
+        handlebarsParams.binaryMediaTypes.push(type.replace("/","~1"));
+      }
+    }
 
     //Add env vars
     handlebarsParams.environment_variables = getEnvVarsForService(ownServiceContext, dependenciesDeployContexts);

--- a/lib/services/apigateway/index.js
+++ b/lib/services/apigateway/index.js
@@ -83,6 +83,9 @@ function getCompiledApiGatewayTemplate(stackName, ownServiceContext, dependencie
         tags: deployPhaseCommon.getTags(ownServiceContext)
     }
 
+		// Add binary media types if specified
+		if(serviceParams.binary_media_types) handlebarsParams.binaryMediaTypes=serviceParams.binary_media_types;
+
     //Add env vars
     handlebarsParams.environment_variables = getEnvVarsForService(ownServiceContext, dependenciesDeployContexts);
 


### PR DESCRIPTION
This will add the BinaryMediaTypes support as requested.

Resolves #223 