### PR TITLE
Add initial support for service auto-scaling to ECS service.

### DIFF
--- a/docs/handel-basics/account-config-file.rst
+++ b/docs/handel-basics/account-config-file.rst
@@ -30,6 +30,5 @@ The account config file is a YAML file that must contain the following informati
   - <id for subnets in which to deploy private resources>
   data_subnets:
   - <id for subnets in which to deploy data resources>
-  ecs_ami: <AMI for the ECS agent>
+  elasticache_subnet_group: <name of the cache subnet group to use>
   ssh_bastion_sg: <id for the SSH bastion security group>
-  on_prem_cidr: <CIDR block for your on-prem resources>

--- a/docs/supported-services/ecs.rst
+++ b/docs/supported-services/ecs.rst
@@ -10,16 +10,11 @@ One service per cluster
 ~~~~~~~~~~~~~~~~~~~~~~~
 This service uses a model of one ECS service per ECS cluster. It does not support the model of one large cluster with multiple services running on it.
 
-Container auto-scaling
-~~~~~~~~~~~~~~~~~~~~~~
-Handel will auto-scale your EC2 cluster up and down, but does not yet support you configuring your own container auto-scaling. Support is planned to be added in the near future.
-
 Unsupported ECS task features
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 This service currently does not support the following ECS task features:
 
 * User-specified volumes from the EC2 host. You can specify services such as EFS that will mount a volume in your container for you, however.
-* Container links within a task.
 * Extra networking items such as manually specifying DNS Servers, DNS Search Domains, and extra hosts in the /etc/hosts file
 * Task definition options such as specifying an entry point, command, or working directory. These options are available in your Dockerfile and can be specified there.
 
@@ -112,7 +107,7 @@ If you don't specify an *image_name*, Handel will automatically choose an image 
 
     <appName>-<serviceName>-<containerName>:<environmentName>
 
-For example, if you don't specify an *image_name* in the below :ref:`ecs-example-handel-file`, the two images ECS looks for would be named the following:
+For example, if you don't specify an *image_name* in the below :ref:`ecs-example-handel-files`, the two images ECS looks for would be named the following:
 
 .. code-block:: none
 
@@ -131,10 +126,31 @@ The `auto_scaling` section is defined by the following schema:
     auto_scaling:
       min_tasks: <integer> # Required
       max_tasks: <integer> # Required
+      scaling_policies: # Optional
+      - type: <up|down>
+        adjustment:
+          type: <string> # Optional. Default: 'ChangeInCapacity'. See http://docs.aws.amazon.com/ApplicationAutoScaling/latest/APIReference/API_StepScalingPolicyConfiguration.html for allowed values
+          value: <number> # Required
+          cooldown: <number> # Optional. Default: 300. 
+        alarm:
+          namespace: <string> # Optional. Default: 'AWS/ECS'
+          dimensions: # Optional. Default: Your ECS service dimensions
+            <string>: <string>
+          metric_name: <string> # Required
+          comparison_operator: <string> # Required. See http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-comparisonoperator for allowed values.
+          threshold: <number> # Required
+          period: <number> # Optional. Default: 300
+
+
+.. TIP::
+
+  Auto-scaling in AWS is based off the CloudWatch service. Configuring auto-scaling can be a bit daunting at first if you haven't used CloudWatch metrics or alarms. 
+  
+  See the below :ref:`ecs-example-handel-files` section for some examples of configuring auto-scaling.
 
 .. NOTE::
 
-  If you don't wish to configure auto scaling for your containers, just set `min_tasks` = `max_tasks` and don't configure any other options in auto_scaling.
+  If you don't wish to configure auto scaling for your containers, just set `min_tasks` = `max_tasks` and don't configure any *scaling_policies*.
 
 .. _ecs-cluster:
 
@@ -178,10 +194,59 @@ The `tags` section is defined by the following schema:
 
 
 
-.. _ecs-example-handel-file:
+.. _ecs-example-handel-files:
 
-Example Handel File
--------------------
+Example Handel Files
+--------------------
+Simplest Possible ECS Service
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This Handel file shows an ECS service with only the required parameters:
+
+.. code-block:: yaml
+
+    version: 1
+
+    name: my-ecs-app
+
+    environments:
+      dev:
+        webapp:
+          type: ecs
+          auto_scaling:
+            min_tasks: 1
+            max_tasks: 1
+          containers:
+          - name: mywebapp
+
+Web Service
+~~~~~~~~~~~
+This Handel file shows an ECS service configured with HTTP routing to it via a load balancer:
+
+.. code-block:: yaml
+
+    version: 1
+
+    name: my-ecs-app
+
+    environments:
+      dev:
+        webapp:
+          type: ecs
+          auto_scaling:
+            min_tasks: 1
+            max_tasks: 1
+          load_balancer:
+            type: http
+          containers:
+          - name: mywebapp
+            port_mappings:
+            - 5000
+            routing:
+              base_path: /mypath
+              health_check_path: /
+
+Multiple Containers
+~~~~~~~~~~~~~~~~~~~
 This Handel file shows an ECS service with two containers being configured:
 
 .. code-block:: yaml
@@ -217,6 +282,97 @@ This Handel file shows an ECS service with two containers being configured:
               health_check_path: /
           - name: myothercontainer
             max_mb: 256
+
+Auto-Scaling On Service CPU Utilization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This Handel file shows an ECS service auto-scaling on its own CPU Utilization metric. Note that in the *alarm* section you can leave off things like *namespace* and *dimensions* and it will default to your ECS service for those values:
+
+.. code-block:: yaml
+
+    version: 1
+
+    name: my-ecs-app
+
+    environments:
+      dev:
+        webapp:
+          type: ecs
+          auto_scaling:
+            min_tasks: 1
+            max_tasks: 11
+            scaling_policies:
+            - type: up
+              adjustment:
+                value: 5
+              alarm:
+                metric_name: CPUUtilization
+                comparison_operator: GreaterThanThreshold
+                threshold: 70
+            - type: down
+              adjustment:
+                value: 5
+              alarm:
+                metric_name: CPUUtilization
+                comparison_operator: LessThanThreshold
+                threshold: 30
+          load_balancer:
+            type: http
+          containers:
+          - name: ecstest
+            port_mappings:
+            - 5000
+            routing:
+              base_path: /mypath
+
+This Handel file shows an ECS service scaling off the size of a queue it consumes:
+
+.. code-block:: yaml
+
+    version: 1
+
+    name: my-ecs-app
+
+    environments:
+      dev:
+        webapp:
+          type: ecs
+          auto_scaling:
+            min_tasks: 1
+            max_tasks: 11
+            scaling_policies:
+            - type: up
+              adjustment:
+                value: 5
+              alarm:
+                namespace: AWS/SQS
+                dimensions:
+                  QueueName: my-ecs-app-dev-queue-sqs
+                metric_name: ApproximateNumberOfMessagesVisible
+                comparison_operator: GreaterThanThreshold
+                threshold: 2000
+            - type: down
+              adjustment:
+                value: 5
+              alarm:
+                namespace: AWS/SQS
+                dimensions:
+                  QueueName: my-ecs-app-dev-queue-sqs
+                metric_name: ApproximateNumberOfMessagesVisible
+                comparison_operator: LessThanThreshold
+                threshold: 100
+          load_balancer:
+            type: http
+          containers:
+          - name: ecstest
+            port_mappings:
+            - 5000
+            routing:
+              base_path: /mypath
+          dependencies:
+          - queue
+        queue:
+          type: sqs
+
         
 Depending on this service
 -------------------------

--- a/lib/aws/ssm-calls.js
+++ b/lib/aws/ssm-calls.js
@@ -49,4 +49,13 @@ exports.deleteParameters = function (parameterNames) {
         .then(() => {
             return true;
         })
+        .catch(err => {
+            //If the param is already gone we won't count it as an error
+            if(err.code === "ParameterNotFound") { 
+                return true;
+            }
+            else {
+                throw err;
+            }
+        });
 }

--- a/lib/lifecycles/check.js
+++ b/lib/lifecycles/check.js
@@ -38,9 +38,7 @@ exports.check = function (handelFile) {
             'subnet-eeeeeeee',
             'subnet-99999999'
         ],
-        ecs_ami: 'ami-66666666',
-        ssh_bastion_sg: 'sg-44444444',
-        on_prem_cidr: '10.10.10.10/0'
+        ssh_bastion_sg: 'sg-44444444'
     }).getAccountConfig();
 
     //Load all the currently implemented service deployers from the 'services' directory

--- a/lib/services/ecs/cluster-auto-scaling.js
+++ b/lib/services/ecs/cluster-auto-scaling.js
@@ -1,0 +1,143 @@
+const cloudformationCalls = require('../../aws/cloudformation-calls');
+const deployPhaseCommon = require('../../common/deploy-phase-common');
+const winston = require('winston');
+const handlebarsUtils = require('../../common/handlebars-utils');
+
+//Values are specified in MiB
+const EC2_INSTANCE_MEMORY_MAP = {
+    "t2.nano": "500",
+    "t2.micro": "1000",
+    "t2.small": "2000",
+    "t2.medium": "4000",
+    "t2.large": "8000",
+    "t2.xlarge": "16000",
+    "t2.2xlarge": "32000",
+    "m1.small": "1700",
+    "m1.medium": "3750",
+    "m1.large": "7500",
+    "m1.xlarge": "15000",
+    "m2.xlarge": "17100",
+    "m2.2xlarge": "34200",
+    "m2.4xlarge": "68400",
+    "m4.large": "8000",
+    "m4.xlarge": "16000",
+    "m4.2xlarge": "32000",
+    "m4.3xlarge": "64000",
+    "m4.10xlarge": "160000",
+    "m4.16xlarge": "256000",
+    "m3.medium": "3750",
+    "m3.large": "7500",
+    "m3.xlarge": "15000",
+    "m3.2xlarge": "30000",
+    "c1.medium": "1700",
+    "c1.xlarge": "7000",
+    "c4.large": "3750",
+    "c4.xlarge": "7500",
+    "c4.2xlarge": "15000",
+    "c4.4xlarge": "30000",
+    "c4.8xlarge": "60000",
+    "c3.large": "3750",
+    "c3.xlarge": "7500",
+    "c3.2xlarge": "15000",
+    "c3.4xlarge": "30000",
+    "c3.8xlarge": "60000",
+    "r4.large": "15250",
+    "r4.xlarge": "30500",
+    "r4.2xlarge": "61000",
+    "r4.4xlarge": "122000",
+    "r4.8xlarge": "240000",
+    "r4.16xlarge": "488000",
+    "r3.large": "15250",
+    "r3.xlarge": "30500",
+    "r3.2xlarge": "61000",
+    "r3.4xlarge": "122000",
+    "r3.8xlarge": "244000",
+    "i3.large": "15250",
+    "i3.xlarge": "30500",
+    "i3.2xlarge": "61000",
+    "i3.4xlarge": "122000",
+    "i3.8xlarge": "244000",
+    "i3.16xlarge": "488000"
+}
+
+/**
+ * This function creates an account-wide Lambda for ECS cluster auto-scaling if it doesn't already exist.
+ * 
+ * This Lambda looks at every cluster in the account and logs two CloudWatch metrics for each every minute:
+ * * ClusterNeedsScalingUp
+ * * ClusterNeedsScalingDown
+ * 
+ * These metrics are used by Handel ECS clusters to scale up and down the instances.
+ * 
+ * The code for the auto-scaling Lambda can be found in the "cluster-scaling-lambda" directory inside
+ * the ECS service deployer directory.
+ */
+exports.createAutoScalingLambdaIfNotExists = function() {
+    let stackName = 'HandelEcsAutoScalingLambda';
+    return cloudformationCalls.getStack(stackName)
+        .then(stack => {
+            if (!stack) {
+                return deployPhaseCommon.uploadDirectoryToHandelBucket(`${__dirname}/cluster-scaling-lambda/`, 'handel/ecs-cluster-auto-scaling-lambda', 'lambda-code')
+                    .then(s3ObjectInfo => {
+                        let handlebarsParams = {
+                            s3Bucket: s3ObjectInfo.Bucket,
+                            s3Key: s3ObjectInfo.Key
+                        }
+                        return handlebarsUtils.compileTemplate(`${__dirname}/cluster-scaling-lambda/scaling-lambda-template.yml`, handlebarsParams)
+                            .then(compiledTemplate => {
+                                winston.info(`Creating Lambda for ECS auto-scaling`);
+                                return cloudformationCalls.createStack(stackName, compiledTemplate, [], null);
+                            });
+                    });
+            }
+            else {
+                return stack;
+            }
+        });
+}
+
+/**
+ * This function calculates the required instance count for the ECS cluster based on the requested tasks.
+ * 
+ * This function is used for both 'min' and 'max' auto-scaling group calculations.
+ */
+exports.getInstanceCountForCluster = function(instanceType, autoScaling, containerConfigs, calculationType, serviceName) {
+    let instanceMemory = EC2_INSTANCE_MEMORY_MAP[instanceType];
+    if (!instanceMemory) {
+        throw new Error(`${serviceName} - Unhandled instance type specified: ${instanceType}`);
+    }
+    let maxInstanceMemoryToUse = instanceMemory * .9; //Fill up instances to 90% of capacity
+
+    // Calculate the total number of tasks to fit
+    let tasksCount = null;
+    if (calculationType === 'max') { //Calculate max containers
+        tasksCount = autoScaling.maxTasks;
+    }
+    else { //Calculate min containers
+        tasksCount = autoScaling.minTasks;
+    }
+
+    // Calculate the total size of a single task
+    let totalTaskMb = 0;
+    for (let containerConfig of containerConfigs) {
+        totalTaskMb += containerConfig.maxMb;
+    }
+
+    // Calculate the number of instances needed to fit the number of tasks
+    let numInstances = 1; //Need at least one instance
+    let currentInstanceMem = 0;
+    for (let i = 0; i < tasksCount; i++) {
+        if ((currentInstanceMem + totalTaskMb) > maxInstanceMemoryToUse) {
+            numInstances += 1;
+            currentInstanceMem = 0;
+        }
+        currentInstanceMem += totalTaskMb;
+    }
+
+    //When calculating maxInstances, multiple maxContainers by two so that we can temporarily have more instances during deployments if necessary
+    if (calculationType === 'max') {
+        numInstances *= 2;
+    }
+
+    return numInstances;
+}

--- a/lib/services/ecs/cluster.js
+++ b/lib/services/ecs/cluster.js
@@ -1,0 +1,53 @@
+const deployPhaseCommon = require('../../common/deploy-phase-common');
+const handlebarsUtils = require('../../common/handlebars-utils');
+
+/**
+ * This function calculates the user data script to be run on the cluster EC2 instances when launching.
+ * 
+ * This script is calculated from the injected scripts from any dependencies that export them, such as EFS.
+ */
+exports.getUserDataScript = function(clusterName, dependenciesDeployContexts) {
+    let variables = {
+        ECS_CLUSTER_NAME: clusterName,
+        DEPENDENCY_SCRIPTS: []
+    }
+
+    for (let deployContext of dependenciesDeployContexts) {
+        for (let script of deployContext.scripts) {
+            variables.DEPENDENCY_SCRIPTS.push(script);
+        }
+    }
+
+    return handlebarsUtils.compileTemplate(`${__dirname}/ecs-cluster-userdata-template.sh`, variables);
+}
+
+/**
+ * This function creates the ECS service role if it doesn't exist. This role is used by the
+ * ECS service to interact with the ALB for auto-scaling and other things.
+ */
+exports.createEcsServiceRoleIfNotExists = function() {
+    let roleName = 'HandelEcsServiceRole';
+    let trustedService = 'ecs.amazonaws.com';
+    let policyStatementsToConsume = [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:Describe*",
+                "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+                "elasticloadbalancing:DeregisterTargets",
+                "elasticloadbalancing:Describe*",
+                "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+                "elasticloadbalancing:RegisterTargets"
+            ],
+            "Resource": [
+                "*"
+            ]
+        }
+    ]
+
+    return deployPhaseCommon.createCustomRole(trustedService, roleName, policyStatementsToConsume)
+        .then(role => {
+            return role;
+        });
+}

--- a/lib/services/ecs/containers.js
+++ b/lib/services/ecs/containers.js
@@ -1,0 +1,179 @@
+const deployPhaseCommon = require('../../common/deploy-phase-common');
+const routingSection = require('./routing');
+const volumesSection = require('./volumes');
+const _ = require('lodash');
+const accountConfig = require('../../common/account-config')().getAccountConfig();
+
+function serviceDefinitionHasContainer(serviceParams, containerName) {
+    for (let container of serviceParams.containers) {
+        if (container.name === containerName) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function checkLinks(serviceContext, container, serviceName, errors) {
+    let params = serviceContext.params;
+    if (container.links) {
+        for (let link of container.links) {
+            if (!serviceDefinitionHasContainer(params, link)) {
+                errors.push(`${serviceName} - You specified a link '${link}' in the container '${container.name}', but the container '${link}' does not exist`);
+            }
+        }
+    }
+}
+
+function getEnvironmentVariablesForContainer(container, ownServiceContext, dependenciesDeployContexts) {
+    let environmentVariables = {};
+
+    //Inject env vars defined by service (if any)
+    if (container.environment_variables) {
+        environmentVariables = _.assign(environmentVariables, container.environment_variables);
+    }
+
+    //Inject env vars defined by dependencies
+    let dependenciesEnvVars = deployPhaseCommon.getEnvVarsFromDependencyDeployContexts(dependenciesDeployContexts);
+    environmentVariables = _.assign(environmentVariables, dependenciesEnvVars);
+
+    //Inject env vars from Handel file
+    let handelInjectedEnvVars = deployPhaseCommon.getEnvVarsFromServiceContext(ownServiceContext);
+    environmentVariables = _.assign(environmentVariables, handelInjectedEnvVars);
+
+    return environmentVariables;
+}
+
+
+/**
+ * This function chooses the image name to use for the ECS container in a task
+ * It defaults to a particular naming scheme, but supports giving your own image
+ * name as well.
+ * 
+ * If you want to give an image name in the ECR registry in the account, specify
+ * "<account>/myimagename", and <account> will be auto-replaced by the appropriate
+ * repository name.
+ * 
+ * @param {Object} container - The container definition from the Handel file service
+ * @param {ServiceContext} ownServiceContext - The ServiceContext of the Handel file
+ */
+function getImageName(container, ownServiceContext) {
+    if (container.image_name) { //Custom user-provided image
+        let customImageName = container.image_name;
+        if (customImageName.startsWith('<account>')) { //Comes from own account registry
+            let imageNameAndTag = customImageName.substring(9);
+            return `${accountConfig.account_id}.dkr.ecr.${accountConfig.region}.amazonaws.com${imageNameAndTag}`;
+        }
+        else { //Must come from somewhere else (Docker Hub, Quay.io, etc.)
+            return customImageName;
+        }
+    }
+    else { //Else try to use default image name
+        return `${accountConfig.account_id}.dkr.ecr.${accountConfig.region}.amazonaws.com/${ownServiceContext.appName}-${ownServiceContext.serviceName}-${container.name}:${ownServiceContext.environmentName}`;
+    }
+}
+
+/**
+ * Given a container configuration from the containers section in the Handel file,
+ * this function returns the links (if any) for that container.
+ * 
+ * This function returns null if there are no links in the container.
+ *  
+ * @param {Object} container - The container definition from the Handel file service
+ */
+function getLinksForContainer(container) {
+    let links = null;
+
+    if (container.links) {
+        links = [];
+        for (let link of container.links) {
+            links.push(link);
+        }
+    }
+
+    return links;
+}
+
+/**
+ * Given the service and dependency information, this function returns configuration for the containers
+ * in the task definition.
+ * 
+ * Users may specify from 1 to n containers in their configuration, so this function will return
+ * a list of 1 to n containers.
+ */
+exports.getContainersConfig = function (ownServiceContext, dependenciesDeployContexts) {
+    let serviceParams = ownServiceContext.params;
+    let containerConfigs = [];
+    let albPriority = 1;
+    for (let container of serviceParams.containers) {
+        let containerConfig = {};
+
+        containerConfig.name = container.name;
+        containerConfig.maxMb = container.max_mb || 128;
+        containerConfig.cpuUnits = container.cpu_units || 100;
+
+        //Inject environment variables into the container
+        containerConfig.environmentVariables = getEnvironmentVariablesForContainer(container, ownServiceContext, dependenciesDeployContexts);
+
+        //Add port mappings if routing is specified
+        if (container.routing) {
+            containerConfig.routingInfo = routingSection.getRoutingInformationForContainer(container, albPriority);
+            albPriority += 1;
+
+            //Add other port mappings to container
+            containerConfig.portMappings = [];
+            for (let portToMap of container.port_mappings) {
+                containerConfig.portMappings.push(portToMap);
+            }
+        }
+
+        containerConfig.imageName = getImageName(container, ownServiceContext);
+
+        //Add mount points if present
+        containerConfig.mountPoints = volumesSection.getMountPointsForContainer(dependenciesDeployContexts);
+
+        //Add links if present
+        containerConfig.links = getLinksForContainer(container, ownServiceContext);
+
+        containerConfigs.push(containerConfig);
+    }
+
+    return containerConfigs;
+}
+
+/**
+ * This function is called by the "check" lifecycle phase to check the information in the
+ * "containers" section in the Handel service configuration
+ */
+exports.checkContainers = function (serviceContext, serviceName, errors) {
+    let params = serviceContext.params;
+    //Require at least one container definition
+    if (!params.containers || params.containers.length === 0) {
+        errors.push(`${serviceName} - You must specify at least one container in the 'containers' section`);
+    }
+    else {
+        let alreadyHasOneRouting = false;
+        for (let container of params.containers) {
+            //Require 'name'
+            if (!container.name) {
+                errors.push(`${serviceName} - The 'name' parameter is required in each container in the 'containers' section`);
+            }
+
+            if (container.routing) {
+                //Only allow one 'routing' section currently
+                if (alreadyHasOneRouting) {
+                    errors.push(`${serviceName} - You may not specify a 'routing' section in more than one container. This is due to a current limitation in ECS load balancing`);
+                }
+                else {
+                    alreadyHasOneRouting = true;
+                }
+
+                //Require port_mappings if routing is specified
+                if (!container.port_mappings) {
+                    errors.push(`${serviceName} - The 'port_mappings' parameter is required when you specify the 'routing' element`);
+                }
+            }
+
+            checkLinks(serviceContext, container, serviceName, errors);
+        }
+    }
+}

--- a/lib/services/ecs/ecs-service-template.yml
+++ b/lib/services/ecs/ecs-service-template.yml
@@ -3,6 +3,9 @@ AWSTemplateFormatVersion: '2010-09-09'
 Description: Handel-created ECS Cluster
 
 Resources:
+  #
+  # Configure IAM resources for ECS resources
+  #
   TaskRole:
     Type: AWS::IAM::Role
     Properties:
@@ -57,6 +60,10 @@ Resources:
       Path: "/"
       Roles:
       - Ref: EcsIamRole
+  
+  #
+  # Configure ECS Cluster
+  #
   EcsLaunchConfiguration:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
@@ -158,6 +165,10 @@ Resources:
     Type: AWS::ECS::Cluster
     Properties:
       ClusterName: {{clusterName}}
+
+  # 
+  # Configure ECS Service that runs on the cluster
+  #
   EcsService:
     Type: AWS::ECS::Service
     DependsOn:
@@ -184,6 +195,7 @@ Resources:
       {{/each}}
       Role: {{ecsServiceRoleArn}}
       {{/if}}
+      ServiceName: {{clusterName}}
       TaskDefinition:
         Ref: TaskDefinition
   TaskDefinition:
@@ -235,6 +247,99 @@ Resources:
         {{/each}}
         {{/if}}
       {{/each}}
+
+  #
+  # Configure Service Auto Scaling
+  #
+  {{#if autoScaling.scalingEnabled}}
+  ServiceAutoScalingRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: {{clusterName}}-service-autoscaling
+      Path: /services/
+      AssumeRolePolicyDocument:
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: 
+            - application-autoscaling.amazonaws.com
+          Action: 
+          - 'sts:AssumeRole'
+  ServiceAutoScalingPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: {{clusterName}}-service-autoscaling
+      Roles:
+      - !Ref ServiceAutoScalingRole
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+        - Effect: Allow
+          Action: 
+          - 'application-autoscaling:*'
+          - 'cloudwatch:DescribeAlarms'
+          - 'cloudwatch:PutMetricAlarm'
+          - 'ecs:DescribeServices'
+          - 'ecs:UpdateService'
+          Resource: 
+          - '*'
+  ScalableTarget:
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
+    Properties:
+      MaxCapacity: {{autoScaling.maxTasks}}
+      MinCapacity: {{autoScaling.minTasks}}
+      ResourceId: !Join ["", [ "service/{{clusterName}}/", !GetAtt EcsService.Name]]
+      RoleARN: !GetAtt ServiceAutoScalingRole.Arn
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
+  {{#each autoScaling.scalingPolicies}}
+  ServiceScalingPolicy{{@index}}:
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: {{../clusterName}}-{{@index}}
+      PolicyType: StepScaling
+      ScalingTargetId: !Ref ScalableTarget
+      StepScalingPolicyConfiguration:
+        AdjustmentType: {{adjustmentType}}
+        Cooldown: {{cooldown}}
+        MetricAggregationType: {{metricAggregationType}}
+        StepAdjustments:
+        - ScalingAdjustment: {{adjustmentValue}}
+          {{#if scaleUp}}
+          MetricIntervalLowerBound: 0
+          {{/if}}
+          {{#if scaleDown}}
+          MetricIntervalUpperBound: 0
+          {{/if}}
+  ServiceScalingAlarm{{@index}}:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+      - !Ref ServiceScalingPolicy{{@index}}
+      AlarmDescription: Handel-created alarm for ECS cluster '{{../clusterName}}'' application auto-scaling
+      ComparisonOperator: {{comparisonOperator}}
+      Dimensions:
+      {{#each dimensions}}
+      - Name: {{name}}
+        Value: {{value}}
+      {{/each}}
+      EvaluationPeriods: 1
+      {{#if scaleDown}}
+      InsufficientDataActions:
+      - !Ref ServiceScalingPolicy{{@index}}
+      {{/if}}
+      MetricName: {{metricName}}
+      Namespace: {{namespace}}
+      Period: {{period}}
+      Statistic: {{metricAggregationType}}
+      Threshold: {{threshold}}
+  {{/each}}
+  {{/if}}
+
+  # 
+  # Configure Load Balancer if requested
+  # 
   {{#if oneOrMoreTasksHasRouting}}
   Alb:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer

--- a/lib/services/ecs/index.js
+++ b/lib/services/ecs/index.js
@@ -17,7 +17,12 @@
 const winston = require('winston');
 const ec2Calls = require('../../aws/ec2-calls');
 const DeployContext = require('../../datatypes/deploy-context');
-const cloudformationCalls = require('../../aws/cloudformation-calls');
+const cluster = require('./cluster');
+const clusterAutoScalingSection = require('./cluster-auto-scaling');
+const serviceAutoScalingSection = require('./service-auto-scaling');
+const containersSection = require('./containers');
+const volumesSection = require('./volumes');
+const routingSection = require('./routing');
 const accountConfig = require('../../common/account-config')().getAccountConfig();
 const deployPhaseCommon = require('../../common/deploy-phase-common');
 const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
@@ -27,228 +32,6 @@ const handlebarsUtils = require('../../common/handlebars-utils');
 const _ = require('lodash');
 
 const SERVICE_NAME = "ECS";
-
-//Values are specified in MiB
-const EC2_INSTANCE_MEMORY_MAP = {
-    "t2.nano": "500",
-    "t2.micro": "1000",
-    "t2.small": "2000",
-    "t2.medium": "4000",
-    "t2.large": "8000",
-    "t2.xlarge": "16000",
-    "t2.2xlarge": "32000",
-    "m1.small": "1700",
-    "m1.medium": "3750",
-    "m1.large": "7500",
-    "m1.xlarge": "15000",
-    "m2.xlarge": "17100",
-    "m2.2xlarge": "34200",
-    "m2.4xlarge": "68400",
-    "m4.large": "8000",
-    "m4.xlarge": "16000",
-    "m4.2xlarge": "32000",
-    "m4.3xlarge": "64000",
-    "m4.10xlarge": "160000",
-    "m4.16xlarge": "256000",
-    "m3.medium": "3750",
-    "m3.large": "7500",
-    "m3.xlarge": "15000",
-    "m3.2xlarge": "30000",
-    "c1.medium": "1700",
-    "c1.xlarge": "7000",
-    "c4.large": "3750",
-    "c4.xlarge": "7500",
-    "c4.2xlarge": "15000",
-    "c4.4xlarge": "30000",
-    "c4.8xlarge": "60000",
-    "c3.large": "3750",
-    "c3.xlarge": "7500",
-    "c3.2xlarge": "15000",
-    "c3.4xlarge": "30000",
-    "c3.8xlarge": "60000",
-    "r4.large": "15250",
-    "r4.xlarge": "30500",
-    "r4.2xlarge": "61000",
-    "r4.4xlarge": "122000",
-    "r4.8xlarge": "240000",
-    "r4.16xlarge": "488000",
-    "r3.large": "15250",
-    "r3.xlarge": "30500",
-    "r3.2xlarge": "61000",
-    "r3.4xlarge": "122000",
-    "r3.8xlarge": "244000",
-    "i3.large": "15250",
-    "i3.xlarge": "30500",
-    "i3.2xlarge": "61000",
-    "i3.4xlarge": "122000",
-    "i3.8xlarge": "244000",
-    "i3.16xlarge": "488000"
-}
-
-function getInstanceCountForCluster(instanceType, autoScaling, containerConfigs, calculationType) {
-    let instanceMemory = EC2_INSTANCE_MEMORY_MAP[instanceType];
-    if (!instanceMemory) {
-        throw new Error(`${SERVICE_NAME} - Unhandled instance type specified: ${instanceType}`);
-    }
-    let maxInstanceMemoryToUse = instanceMemory * .9; //Fill up instances to 90% of capacity
-
-    // Calculate the total number of tasks to fit
-    let tasksCount = null;
-    if (calculationType === 'max') { //Calculate max containers
-        tasksCount = autoScaling.maxTasks;
-    }
-    else { //Calculate min containers
-        tasksCount = autoScaling.minTasks;
-    }
-
-    // Calculate the total size of a single task
-    let totalTaskMb = 0;
-    for (let containerConfig of containerConfigs) {
-        totalTaskMb += containerConfig.maxMb;
-    }
-
-    // Calculate the number of instances needed to fit the number of tasks
-    let numInstances = 1; //Need at least one instance
-    let currentInstanceMem = 0;
-    for (let i = 0; i < tasksCount; i++) {
-        if ((currentInstanceMem + totalTaskMb) > maxInstanceMemoryToUse) {
-            numInstances += 1;
-            currentInstanceMem = 0;
-        }
-        currentInstanceMem += totalTaskMb;
-    }
-
-    //When calculating maxInstances, multiple maxContainers by two so that we can temporarily have more instances during deployments if necessary
-    if (calculationType === 'max') {
-        numInstances *= 2;
-    }
-
-    return numInstances;
-}
-
-function createAutoScalingLambdaIfNotExists() {
-    let stackName = 'HandelEcsAutoScalingLambda';
-    return cloudformationCalls.getStack(stackName)
-        .then(stack => {
-            if (!stack) {
-                return deployPhaseCommon.uploadDirectoryToHandelBucket(`${__dirname}/cluster-scaling-lambda/`, 'handel/ecs-cluster-auto-scaling-lambda', 'lambda-code')
-                    .then(s3ObjectInfo => {
-                        let handlebarsParams = {
-                            s3Bucket: s3ObjectInfo.Bucket,
-                            s3Key: s3ObjectInfo.Key
-                        }
-                        return handlebarsUtils.compileTemplate(`${__dirname}/cluster-scaling-lambda/scaling-lambda-template.yml`, handlebarsParams)
-                            .then(compiledTemplate => {
-                                winston.info(`Creating Lambda for ECS auto-scaling`);
-                                return cloudformationCalls.createStack(stackName, compiledTemplate, [], null);
-                            });
-                    });
-            }
-            else {
-                return stack;
-            }
-        });
-}
-
-
-function getRoutingInformationForContainer(container, albPriority) {
-    let routingInfo = {
-        healthCheckPath: '/',
-        basePath: '/',
-        albPriority
-    };
-    if (container.routing.health_check_path) {
-        routingInfo.healthCheckPath = container.routing.health_check_path;
-    }
-    if (container.routing.base_path) {
-        routingInfo.basePath = container.routing.base_path;
-    }
-
-    //Wire up first port to Load Balancer
-    routingInfo.containerPort = container.port_mappings[0].toString();
-
-    return routingInfo;
-}
-
-function getLoadBalancerConfig(serviceParams, defaultRouteContainer) {
-    let loadBalancerConfig = { //Default values for load balancer
-        timeout: 60,
-        type: 'http',
-        defaultRouteContainer
-    }
-
-    let loadBalancer = serviceParams.load_balancer;
-    if (loadBalancer) {
-        if (loadBalancer.timeout) {
-            loadBalancerConfig.timeout = loadBalancer.timeout;
-        }
-        if (loadBalancer.type) {
-            loadBalancerConfig.type = loadBalancer.type;
-        }
-        if (loadBalancer.https_certificate) {
-            loadBalancerConfig.httpsCertificate = `arn:aws:acm:us-west-2:${accountConfig.account_id}:certificate/${loadBalancer.https_certificate}`;
-        }
-    }
-
-    return loadBalancerConfig;
-}
-
-function getUserDataScript(clusterName, dependenciesDeployContexts) {
-    let variables = {
-        ECS_CLUSTER_NAME: clusterName,
-        DEPENDENCY_SCRIPTS: []
-    }
-
-    for (let deployContext of dependenciesDeployContexts) {
-        for (let script of deployContext.scripts) {
-            variables.DEPENDENCY_SCRIPTS.push(script);
-        }
-    }
-
-    return handlebarsUtils.compileTemplate(`${__dirname}/ecs-cluster-userdata-template.sh`, variables);
-}
-
-function createEcsServiceRoleIfNotExists() {
-    let roleName = 'HandelEcsServiceRole';
-    let trustedService = 'ecs.amazonaws.com';
-    let policyStatementsToConsume = [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ec2:AuthorizeSecurityGroupIngress",
-                "ec2:Describe*",
-                "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
-                "elasticloadbalancing:DeregisterTargets",
-                "elasticloadbalancing:Describe*",
-                "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
-                "elasticloadbalancing:RegisterTargets"
-            ],
-            "Resource": [
-                "*"
-            ]
-        }
-    ]
-
-    return deployPhaseCommon.createCustomRole(trustedService, roleName, policyStatementsToConsume)
-        .then(role => {
-            return role;
-        });
-}
-
-function getDependenciesDeployContextMountPoints(dependenciesDeployContexts) {
-    let mountPoints = [];
-    for (let deployContext of dependenciesDeployContexts) {
-        if (deployContext['serviceType'] === 'efs') { //Only EFS is supported as an external service mount point for now
-            let envVarKey = deployPhaseCommon.getInjectedEnvVarName(deployContext, 'MOUNT_DIR');
-
-            mountPoints.push({
-                mountDir: deployContext.environmentVariables[envVarKey],
-                name: envVarKey
-            });
-        }
-    }
-    return mountPoints;
-}
 
 function getTaskRoleStatements(serviceContext, dependenciesDeployContexts) {
     let ownPolicyStatements = deployPhaseCommon.getAppSecretsAccessPolicyStatements(serviceContext);
@@ -260,105 +43,6 @@ function getLatestEcsAmiId() {
     return ec2Calls.getLatestAmiByName('amazon', 'amazon-ecs')
 }
 
-function getEnvironmentVariablesForContainer(container, ownServiceContext, dependenciesDeployContexts) {
-    let environmentVariables = {};
-
-    //Inject env vars defined by service (if any)
-    if (container.environment_variables) {
-        environmentVariables = _.assign(environmentVariables, container.environment_variables);
-    }
-
-    //Inject env vars defined by dependencies
-    let dependenciesEnvVars = deployPhaseCommon.getEnvVarsFromDependencyDeployContexts(dependenciesDeployContexts);
-    environmentVariables = _.assign(environmentVariables, dependenciesEnvVars);
-
-    //Inject env vars from Handel file
-    let handelInjectedEnvVars = deployPhaseCommon.getEnvVarsFromServiceContext(ownServiceContext);
-    environmentVariables = _.assign(environmentVariables, handelInjectedEnvVars);
-
-    return environmentVariables;
-}
-
-function getVolumes(dependenciesDeployContexts) {
-    let volumes = null;
-    let dependenciesMountPoints = getDependenciesDeployContextMountPoints(dependenciesDeployContexts);
-    if (Object.keys(dependenciesMountPoints).length > 0) {
-        volumes = [];
-
-        for (let taskDefMountPoint of dependenciesMountPoints) {
-            volumes.push({
-                sourcePath: taskDefMountPoint.mountDir,
-                name: taskDefMountPoint.name
-            });
-        }
-    }
-    return volumes;
-}
-
-function getMountPointsForContainer(dependenciesDeployContexts) {
-    let mountPoints = null;
-    let dependenciesMountPoints = getDependenciesDeployContextMountPoints(dependenciesDeployContexts);
-    if (Object.keys(dependenciesMountPoints).length > 0) {
-        mountPoints = [];
-
-        for (let taskDefMountPoint of dependenciesMountPoints) {
-            mountPoints.push({
-                containerPath: taskDefMountPoint.mountDir,
-                sourceVolume: taskDefMountPoint.name
-            });
-        }
-    }
-    return mountPoints;
-}
-
-/**
- * This function chooses the image name to use for the ECS container in a task
- * It defaults to a particular naming scheme, but supports giving your own image
- * name as well.
- * 
- * If you want to give an image name in the ECR registry in the account, specify
- * "<account>/myimagename", and <account> will be auto-replaced by the appropriate
- * repository name.
- * 
- * @param {Object} container - The container definition from the Handel file service
- * @param {ServiceContext} ownServiceContext - The ServiceContext of the Handel file
- */
-function getImageName(container, ownServiceContext) {
-    if (container.image_name) { //Custom user-provided image
-        let customImageName = container.image_name;
-        if (customImageName.startsWith('<account>')) { //Comes from own account registry
-            let imageNameAndTag = customImageName.substring(9);
-            return `${accountConfig.account_id}.dkr.ecr.${accountConfig.region}.amazonaws.com${imageNameAndTag}`;
-        }
-        else { //Must come from somewhere else (Docker Hub, Quay.io, etc.)
-            return customImageName;
-        }
-    }
-    else { //Else try to use default image name
-        return `${accountConfig.account_id}.dkr.ecr.${accountConfig.region}.amazonaws.com/${ownServiceContext.appName}-${ownServiceContext.serviceName}-${container.name}:${ownServiceContext.environmentName}`;
-    }
-}
-
-/**
- * Given a container configuration from the containers section in the Handel file,
- * this function returns the links (if any) for that container.
- * 
- * This function returns null if there are no links in the container.
- *  
- * @param {Object} container - The container definition from the Handel file service
- */
-function getLinksForContainer(container) {
-    let links = null;
-
-    if(container.links) {
-        links = [];
-        for(let link of container.links) {
-            links.push(link);
-        }
-    }
-
-    return links;
-}
 
 function getCompiledEcsTemplate(stackName, clusterName, ownServiceContext, ownPreDeployContext, dependenciesDeployContexts, userDataScript, ecsServiceRole) {
     return getLatestEcsAmiId()
@@ -369,62 +53,20 @@ function getCompiledEcsTemplate(stackName, clusterName, ownServiceContext, ownPr
                 instanceType = serviceParams.cluster.instance_type;
             }
 
-            //Configure auto-scaling
-            //TODO - More work on configuring auto-scaling
-            let autoScaling = {};
-            autoScaling.minTasks = serviceParams.auto_scaling.min_tasks;
-            autoScaling.maxTasks = serviceParams.auto_scaling.max_tasks;
+            // Configure auto-scaling
+            let autoScaling = serviceAutoScalingSection.getTemplateAutoScalingConfig(ownServiceContext, clusterName);
+            
+            // Configure containers in the task definition
+            let containerConfigs = containersSection.getContainersConfig(ownServiceContext, dependenciesDeployContexts);
+            let oneOrMoreTasksHasRouting = routingSection.oneOrMoreTasksHasRouting(ownServiceContext);
 
-            let oneOrMoreTasksHasRouting = false;
-            let defaultRouteContainer = null;
-
-            let containerConfigs = [];
-            let albPriority = 1;
-            for (let container of serviceParams.containers) {
-                let containerConfig = {};
-
-                containerConfig.name = container.name;
-                containerConfig.maxMb = container.max_mb || 128;
-                containerConfig.cpuUnits = container.cpu_units || 100;
-
-                //Inject environment variables into the container
-                containerConfig.environmentVariables = getEnvironmentVariablesForContainer(container, ownServiceContext, dependenciesDeployContexts);
-
-                //Add port mappings if routing is specified
-                if (container.routing) {
-                    oneOrMoreTasksHasRouting = true;
-
-                    containerConfig.routingInfo = getRoutingInformationForContainer(container, albPriority);
-                    albPriority += 1;
-
-                    //Add other port mappings to container
-                    containerConfig.portMappings = [];
-                    for (let portToMap of container.port_mappings) {
-                        containerConfig.portMappings.push(portToMap);
-                    }
-
-                    if (!defaultRouteContainer) {
-                        defaultRouteContainer = containerConfig;
-                    }
-                }
-
-                containerConfig.imageName = getImageName(container, ownServiceContext);
-
-                //Add mount points if present
-                containerConfig.mountPoints = getMountPointsForContainer(dependenciesDeployContexts);
-
-                //Add links if present
-                containerConfig.links = getLinksForContainer(container, ownServiceContext);
-
-                containerConfigs.push(containerConfig);
-            }
-
+            //Create object used for templating the CloudFormation template
             let handlebarsParams = {
                 clusterName,
                 stackName,
                 instanceType,
-                minInstances: getInstanceCountForCluster(instanceType, autoScaling, containerConfigs, 'min'),
-                maxInstances: getInstanceCountForCluster(instanceType, autoScaling, containerConfigs, 'max'),
+                minInstances: clusterAutoScalingSection.getInstanceCountForCluster(instanceType, autoScaling, containerConfigs, 'min', SERVICE_NAME),
+                maxInstances: clusterAutoScalingSection.getInstanceCountForCluster(instanceType, autoScaling, containerConfigs, 'max', SERVICE_NAME),
                 ecsSecurityGroupId: ownPreDeployContext.securityGroups[0].GroupId,
                 amiImageId: latestEcsAmi.ImageId,
                 userData: new Buffer(userDataScript).toString('base64'),
@@ -442,8 +84,9 @@ function getCompiledEcsTemplate(stackName, clusterName, ownServiceContext, ownPr
                 oneOrMoreTasksHasRouting
             };
 
+            //Configure routing if present in any of hte containers
             if (oneOrMoreTasksHasRouting) {
-                handlebarsParams.loadBalancer = getLoadBalancerConfig(serviceParams, defaultRouteContainer);
+                handlebarsParams.loadBalancer = routingSection.getLoadBalancerConfig(serviceParams, containerConfigs);
             }
 
             //Add the SSH keypair if specified
@@ -452,7 +95,7 @@ function getCompiledEcsTemplate(stackName, clusterName, ownServiceContext, ownPr
             }
 
             //Add volumes if present (these are consumed by one or more container mount points)
-            handlebarsParams.volumes = getVolumes(dependenciesDeployContexts);
+            handlebarsParams.volumes = volumesSection.getVolumes(dependenciesDeployContexts);
 
             return handlebarsUtils.compileTemplate(`${__dirname}/ecs-service-template.yml`, handlebarsParams)
         });
@@ -466,14 +109,7 @@ function getShortenedClusterName(serviceContext) {
     return `${serviceContext.appName.substring(0, 21)}-${serviceContext.environmentName.substring(0, 4)}-${serviceContext.serviceName.substring(0, 9)}`;
 }
 
-function serviceDefinitionHasContainer(serviceParams, containerName) {
-    for(let container of serviceParams.containers) {
-        if(container.name === containerName) {
-            return true;
-        }
-    }
-    return false;
-}
+
 /**
  * Service Deployer Contract Methods
  * See https://github.com/byu-oit-appdev/handel/wiki/Creating-a-New-Service-Deployer#service-deployer-contract
@@ -481,68 +117,10 @@ function serviceDefinitionHasContainer(serviceParams, containerName) {
  */
 exports.check = function (serviceContext) {
     let errors = [];
-    let params = serviceContext.params;
 
-    if (!params.auto_scaling) {
-        errors.push(`${SERVICE_NAME} - The 'auto_scaling' section is required`);
-    }
-    else {
-        if (!params.auto_scaling.min_tasks) {
-            errors.push(`${SERVICE_NAME} - The 'min_tasks' parameter is required in the 'auto_scaling' section`);
-        }
-        if (!params.auto_scaling.max_tasks) {
-            errors.push(`${SERVICE_NAME} - The 'max_tasks' parameter is required in the 'auto_scaling' section`);
-        }
-    }
-
-    if (params.load_balancer) {
-        //Require the load balancer listener type
-        if (!params.load_balancer.type) {
-            errors.push(`${SERVICE_NAME} - The 'type' parameter is required in the 'load_balancer' section`);
-        }
-
-        //If type = https, require https_certificate
-        if (params.load_balancer.type === 'https' && !params.load_balancer.https_certificate) {
-            errors.push(`${SERVICE_NAME} - The 'https_certificate' parameter is required in the 'load_balancer' section when you use HTTPS`);
-        }
-    }
-
-    //Require at least one container definition
-    if (!params.containers || params.containers.length === 0) {
-        errors.push(`${SERVICE_NAME} - You must specify at least one container in the 'containers' section`);
-    }
-    else {
-        let alreadyHasOneRouting = false;
-        for (let container of params.containers) {
-            //Require 'name'
-            if (!container.name) {
-                errors.push(`${SERVICE_NAME} - The 'name' parameter is required in each container in the 'containers' section`);
-            }
-
-            if (container.routing) {
-                //Only allow one 'routing' section currently
-                if (alreadyHasOneRouting) {
-                    errors.push(`${SERVICE_NAME} - You may not specify a 'routing' section in more than one container. This is due to a current limitation in ECS load balancing`);
-                }
-                else {
-                    alreadyHasOneRouting = true;
-                }
-
-                //Require port_mappings if routing is specified
-                if (!container.port_mappings) {
-                    errors.push(`${SERVICE_NAME} - The 'port_mappings' parameter is required when you specify the 'routing' element`);
-                }
-            }
-
-            if(container.links) {
-                for(let link of container.links) {
-                    if(!serviceDefinitionHasContainer(params, link)) {
-                        errors.push(`${SERVICE_NAME} - You specified a link '${link}' in the container '${container.name}', but the container '${link}' does not exist`);
-                    }
-                }
-            }
-        }
-    }
+    serviceAutoScalingSection.checkAutoScalingSection(serviceContext, SERVICE_NAME, errors);
+    routingSection.checkLoadBalancerSection(serviceContext, SERVICE_NAME, errors);
+    containersSection.checkContainers(serviceContext, SERVICE_NAME, errors);
 
     return errors;
 }
@@ -560,12 +138,12 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
     winston.info(`${SERVICE_NAME} - Deploying Cluster and Service ${stackName}`);
 
     let clusterName = getShortenedClusterName(ownServiceContext);
-    return createAutoScalingLambdaIfNotExists()
-        .then(autoScalingLambda => {
-            return getUserDataScript(clusterName, dependenciesDeployContexts)
+    return clusterAutoScalingSection.createAutoScalingLambdaIfNotExists()
+        .then(() => {
+            return cluster.getUserDataScript(clusterName, dependenciesDeployContexts)
         })
         .then(userDataScript => {
-            return createEcsServiceRoleIfNotExists()
+            return cluster.createEcsServiceRoleIfNotExists()
                 .then(ecsServiceRole => {
                     return getCompiledEcsTemplate(stackName, clusterName, ownServiceContext, ownPreDeployContext, dependenciesDeployContexts, userDataScript, ecsServiceRole)
                 });
@@ -574,7 +152,7 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
             let stackTags = deployPhaseCommon.getTags(ownServiceContext)
             return deployPhaseCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, SERVICE_NAME, stackTags);
         })
-        .then(deployedStack => {
+        .then(() => {
             winston.info(`${SERVICE_NAME} - Finished Deploying Cluster and Serivce ${stackName}`);
             let deployContext = new DeployContext(ownServiceContext);
             return deployContext;

--- a/lib/services/ecs/routing.js
+++ b/lib/services/ecs/routing.js
@@ -1,0 +1,83 @@
+const accountConfig = require('../../common/account-config')().getAccountConfig();
+
+function getDefaultRouteContainer(containerConfigs) {
+    for(let containerConfig of containerConfigs) {
+        if(containerConfig.routingInfo) { //Just return the first one that has routing
+            return containerConfig;
+        }
+    }
+}
+
+/**
+ * Given a service context, this function returns a boolean that
+ * tells whether one or more of the tasks specified in the user's
+ * ECS configuration has load balancer routing configured for it.
+ */
+exports.oneOrMoreTasksHasRouting = function(ownServiceContext) {
+    let serviceParams = ownServiceContext.params;
+
+    for(let container of serviceParams.containers) {
+        if(container.routing) {
+            return true;
+        }
+    }
+    return false;
+}
+
+exports.getRoutingInformationForContainer = function (container, albPriority) {
+    let routingInfo = {
+        healthCheckPath: '/',
+        basePath: '/',
+        albPriority
+    };
+    if (container.routing.health_check_path) {
+        routingInfo.healthCheckPath = container.routing.health_check_path;
+    }
+    if (container.routing.base_path) {
+        routingInfo.basePath = container.routing.base_path;
+    }
+
+    //Wire up first port to Load Balancer
+    routingInfo.containerPort = container.port_mappings[0].toString();
+
+    return routingInfo;
+}
+
+exports.getLoadBalancerConfig = function (serviceParams, containerConfigs) {
+    let defaultRouteContainer = getDefaultRouteContainer(containerConfigs);
+    let loadBalancerConfig = { //Default values for load balancer
+        timeout: 60,
+        type: 'http',
+        defaultRouteContainer
+    }
+
+    let loadBalancer = serviceParams.load_balancer;
+    if (loadBalancer) {
+        if (loadBalancer.timeout) {
+            loadBalancerConfig.timeout = loadBalancer.timeout;
+        }
+        if (loadBalancer.type) {
+            loadBalancerConfig.type = loadBalancer.type;
+        }
+        if (loadBalancer.https_certificate) {
+            loadBalancerConfig.httpsCertificate = `arn:aws:acm:us-west-2:${accountConfig.account_id}:certificate/${loadBalancer.https_certificate}`;
+        }
+    }
+
+    return loadBalancerConfig;
+}
+
+exports.checkLoadBalancerSection = function(serviceContext, serviceName, errors) {
+    let params = serviceContext.params;
+    if (params.load_balancer) {
+        //Require the load balancer listener type
+        if (!params.load_balancer.type) {
+            errors.push(`${serviceName} - The 'type' parameter is required in the 'load_balancer' section`);
+        }
+
+        //If type = https, require https_certificate
+        if (params.load_balancer.type === 'https' && !params.load_balancer.https_certificate) {
+            errors.push(`${serviceName} - The 'https_certificate' parameter is required in the 'load_balancer' section when you use HTTPS`);
+        }
+    }
+}

--- a/lib/services/ecs/service-auto-scaling.js
+++ b/lib/services/ecs/service-auto-scaling.js
@@ -1,0 +1,79 @@
+function getDimensions(dimensionsConfig, clusterName, ecsServiceName) {
+    let dimensions = [];
+
+    if (dimensionsConfig) { //User-provided dimensions
+        for (let dimensionName in dimensionsConfig) {
+            dimensions.push({
+                name: dimensionName,
+                value: dimensionsConfig[dimensionName]
+            });
+        }
+    }
+    else { //Default to default dimensions
+        dimensions.push({
+            name: "ClusterName",
+            value: clusterName
+        });
+        dimensions.push({
+            name: "ServiceName",
+            value: ecsServiceName
+        });
+    }
+
+    return dimensions;
+}
+
+exports.getTemplateAutoScalingConfig = function(ownServiceContext, clusterName) {
+    let serviceParams = ownServiceContext.params;
+    let autoScaling = {
+        minTasks: serviceParams.auto_scaling.min_tasks,
+        maxTasks: serviceParams.auto_scaling.max_tasks
+    };
+
+    if (serviceParams.auto_scaling.scaling_policies) {
+        autoScaling.scalingEnabled = true;
+        autoScaling.scalingPolicies = [];
+        for (let policyConfig of serviceParams.auto_scaling.scaling_policies) {
+            let scalingPolicy = {
+                adjustmentType: policyConfig.adjustment.type || "ChangeInCapacity",
+                adjustmentValue: policyConfig.adjustment.value,
+                cooldown: policyConfig.cooldown || 300,
+                metricAggregationType: policyConfig.alarm.aggregation_type || "Average",
+                comparisonOperator: policyConfig.alarm.comparison_operator,
+                dimensions: getDimensions(policyConfig.alarm.dimensions, clusterName, clusterName), //Cluster and service names are the same
+                metricName: policyConfig.alarm.metric_name,
+                namespace: policyConfig.alarm.namespace || "AWS/ECS",
+                period: policyConfig.alarm.period || 60,
+                threshold: policyConfig.alarm.threshold
+            }
+
+            //Determine whehter scaling up or down.
+            if (policyConfig.type === "up") {
+                scalingPolicy.scaleUp = true;
+            }
+            else {
+                scalingPolicy.scaleDown = true;
+                scalingPolicy.adjustmentValue = -scalingPolicy.adjustmentValue; //Remove instead of add on scale down
+            }
+
+            autoScaling.scalingPolicies.push(scalingPolicy)
+        }
+    }
+
+    return autoScaling;
+}
+
+exports.checkAutoScalingSection = function(serviceContext, serviceName, errors) {
+    let params = serviceContext.params;
+    if (!params.auto_scaling) {
+        errors.push(`${serviceName} - The 'auto_scaling' section is required`);
+    }
+    else {
+        if (!params.auto_scaling.min_tasks) {
+            errors.push(`${serviceName} - The 'min_tasks' parameter is required in the 'auto_scaling' section`);
+        }
+        if (!params.auto_scaling.max_tasks) {
+            errors.push(`${serviceName} - The 'max_tasks' parameter is required in the 'auto_scaling' section`);
+        }
+    }
+}

--- a/lib/services/ecs/volumes.js
+++ b/lib/services/ecs/volumes.js
@@ -1,0 +1,48 @@
+const deployPhaseCommon = require('../../common/deploy-phase-common');
+
+function getDependenciesDeployContextMountPoints(dependenciesDeployContexts) {
+    let mountPoints = [];
+    for (let deployContext of dependenciesDeployContexts) {
+        if (deployContext['serviceType'] === 'efs') { //Only EFS is supported as an external service mount point for now
+            let envVarKey = deployPhaseCommon.getInjectedEnvVarName(deployContext, 'MOUNT_DIR');
+
+            mountPoints.push({
+                mountDir: deployContext.environmentVariables[envVarKey],
+                name: envVarKey
+            });
+        }
+    }
+    return mountPoints;
+}
+
+exports.getVolumes = function(dependenciesDeployContexts) {
+    let volumes = null;
+    let dependenciesMountPoints = getDependenciesDeployContextMountPoints(dependenciesDeployContexts);
+    if (Object.keys(dependenciesMountPoints).length > 0) {
+        volumes = [];
+
+        for (let taskDefMountPoint of dependenciesMountPoints) {
+            volumes.push({
+                sourcePath: taskDefMountPoint.mountDir,
+                name: taskDefMountPoint.name
+            });
+        }
+    }
+    return volumes;
+}
+
+exports.getMountPointsForContainer = function(dependenciesDeployContexts) {
+    let mountPoints = null;
+    let dependenciesMountPoints = getDependenciesDeployContextMountPoints(dependenciesDeployContexts);
+    if (Object.keys(dependenciesMountPoints).length > 0) {
+        mountPoints = [];
+
+        for (let taskDefMountPoint of dependenciesMountPoints) {
+            mountPoints.push({
+                containerPath: taskDefMountPoint.mountDir,
+                sourceVolume: taskDefMountPoint.name
+            });
+        }
+    }
+    return mountPoints;
+}

--- a/test/test-account-config.yml
+++ b/test/test-account-config.yml
@@ -10,5 +10,4 @@ private_subnets:
 data_subnets:
 - subnet-jjjjjjjj
 - subnet-jjjjjjjj
-ecs_ami: ami-00000000
 ssh_bastion_sg: sg-23456789


### PR DESCRIPTION
This change adds service auto-scaling support for tasks in ECS.
ECS is getting complicated enough that I've done some refactoring
into separate modules for some larger concerns in the deployer.

I would like to start testing some of these pieces in a bit more
fine detail now that ECS is getting more complex, but I haven't
added any additional tests in this PR yet. The current tests are
passing.

Resolves #1 