### PR TITLE
Update ECS ASG cooldown to 60 seconds

### DIFF
--- a/lib/services/ecs/index.js
+++ b/lib/services/ecs/index.js
@@ -72,7 +72,7 @@ function getCompiledEcsTemplate(stackName, clusterName, ownServiceContext, ownPr
                 userData: new Buffer(userDataScript).toString('base64'),
                 privateSubnetIds: accountConfig.private_subnets,
                 publicSubnetIds: accountConfig.public_subnets,
-                asgCooldown: "300",
+                asgCooldown: "60", //This is set pretty short because we handel the instance-level auto-scaling from a Lambda that runs every minute.
                 minimumHealthyPercentDeployment: "50", //TODO - Do we need to support more than just 50?
                 vpcId: accountConfig.vpc,
                 ecsServiceRoleArn: ecsServiceRole.Arn,


### PR DESCRIPTION
We're setting it shorter because we handle the instance-level auto-scaling from a Lambda that runs every minute, so it doesn't make sense to wait for 5 minutes.