### PR TITLE
Route53 Support

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,6 +45,7 @@ Handel is a library that orchestrates your AWS deployments so you don't have to
    supported-services/mysql
    supported-services/postgresql
    supported-services/redis
+   supported-services/route53zone
    supported-services/s3
    supported-services/s3staticsite
    supported-services/sns

--- a/docs/supported-services/beanstalk.rst
+++ b/docs/supported-services/beanstalk.rst
@@ -72,11 +72,6 @@ Parameters
      - No
      - 
      - Any user-specified environment variables to inject in the application.
-   * - dns
-     - List<:ref:`route53zone-records`>
-     - No
-     -
-     - DNS records to create and associate with the load balancer for this application.
    * - tags
      - :ref:`beanstalk-tags`
      - No
@@ -140,6 +135,12 @@ The Routing element is defined by the following schema:
     routing:
       type: <http|https>
       https_certificate # Required if you select https as the routing type
+      dns_names:
+       - <string> # Optional
+
+DNS Names
+`````````
+The `dns_names` section creates one or more dns names that point to this load balancer. See :ref:`route53zone-records` for more.
 
 .. _beanstalk-tags:
 

--- a/docs/supported-services/beanstalk.rst
+++ b/docs/supported-services/beanstalk.rst
@@ -138,8 +138,6 @@ The Routing element is defined by the following schema:
       dns_names:
        - <string> # Optional
 
-DNS Names
-`````````
 The `dns_names` section creates one or more dns names that point to this load balancer. See :ref:`route53zone-records` for more.
 
 .. _beanstalk-tags:

--- a/docs/supported-services/beanstalk.rst
+++ b/docs/supported-services/beanstalk.rst
@@ -72,6 +72,11 @@ Parameters
      - No
      - 
      - Any user-specified environment variables to inject in the application.
+   * - dns
+     - List<:ref:`route53zone-records`>
+     - No
+     -
+     - DNS records to create and associate with the load balancer for this application.
    * - tags
      - :ref:`beanstalk-tags`
      - No

--- a/docs/supported-services/ecs.rst
+++ b/docs/supported-services/ecs.rst
@@ -182,6 +182,12 @@ The `load_balancer` section is defined by the following schema:
       type: <string> # Required. Allowed values: `http`, `https`. 
       timeout: <integer> # Optional. The connection timeout on the load balancer
       https_certificate: <string> # Required if type=https. The ID of the ACM certificate to use on the load balancer.
+      dns_names:
+       - <string> # Optional.
+
+DNS Names
+`````````
+The `dns_names` section creates one or more dns names that point to this load balancer. See :ref:`route53zone-records` for more.
 
 .. _ecs-tags:
 

--- a/docs/supported-services/ecs.rst
+++ b/docs/supported-services/ecs.rst
@@ -53,6 +53,11 @@ Parameters
      - No
      - 
      - If your task needs routing from a load balancer, this section can be used to configure the load balancer's options.
+   * - dns
+     - List<:ref:`route53zone-records`>
+     - No
+     -
+     - DNS records to create and associate with the load balancer for this task.
    * - tags
      - :ref:`ecs-tags`
      - No

--- a/docs/supported-services/ecs.rst
+++ b/docs/supported-services/ecs.rst
@@ -185,8 +185,6 @@ The `load_balancer` section is defined by the following schema:
       dns_names:
        - <string> # Optional.
 
-DNS Names
-`````````
 The `dns_names` section creates one or more dns names that point to this load balancer. See :ref:`route53zone-records` for more.
 
 .. _ecs-tags:

--- a/docs/supported-services/route53zone.rst
+++ b/docs/supported-services/route53zone.rst
@@ -1,0 +1,209 @@
+.. _route53zone:
+
+Route 53 Hosted Zone
+====================
+This document contains information about the Route 53 Hosted Zone service supported in Handel. This Handel service provisions a Route 53 Hosted Zone, in which you can create other DNS records.
+
+Service Limitations
+-------------------
+The following Route 53 features are not currently supported in this service:
+
+* Domain Name Registration - all public zones must be subdomains of byu.edu.
+
+Parameters
+----------
+.. list-table::
+   :header-rows: 1
+
+   * - Parameter
+     - Type
+     - Required
+     - Default
+     - Description
+   * - type
+     - string
+     - Yes
+     -
+     - This must always be *route53zone* for this service type.
+   * - name
+     - string
+     - Yes
+     -
+     - The DNS name for this hosted zone. If this is a public zone, it must end with .byu.edu.
+   * - private
+     - boolean
+     - No
+     - false
+     - Whether or not this is a private zone. If it is a private zone, it is only accessible by the VPCs listed below
+   * - vpcs
+     - List<string>
+     - No
+     - [ <account> ]
+     - List of VPC ids. Must only be specified if this is a private zone. The special value <account> references the VPC listed in the account configuration.
+   * - tags
+     - :ref:`route53zone-tags`
+     - No
+     -
+     - Any tags you want to apply to your Lambda
+
+
+.. _route53zone-tags:
+
+Tags
+~~~~
+The Tags element is defined by the following schema:
+
+.. code-block:: yaml
+
+  tags:
+   <your_tag_name>: <your_tag_value>
+
+.. NOTE::
+
+    Handel automatically applies some tags for you. See :ref:`tagging-default-tags` for information about these tags.
+
+Example Handel File
+-------------------
+
+.. code-block:: yaml
+
+    version: 1
+
+    name: my-dns
+
+    environments:
+      dev:
+        public-zone:
+          type: route53zone
+          name: mydomain.byu.edu
+          tags:
+            mytag: mytagvalue
+        private-zone:
+          type: route53zone
+          name: private.myapp # Doesn't have to be a .byu.edu domain
+          private: true
+          vpcs:
+            - vpc-123456
+            - <account>
+          tags:
+            mytag: mytagvalue
+
+Depending on this service
+-------------------------
+This service outputs the following environment variables:
+
+
+.. list-table::
+   :header-rows: 1
+
+   * - Environment Variable
+     - Description
+   * - <ENV_PREFIX>_DNS_NAME
+     - The DNS name of hosted zone.
+   * - <ENV_PREFIX>_NAME_SERVERS
+     - A comma-delimited list of the name servers for this hosted zone. For example: ns1.example.com,ns2.example.co.uk
+
+
+The <ENV_PREFIX> is a consistent prefix applied to all information injected for service dependencies.  See :ref:`environment-variable-prefix` for information about the structure of this prefix.
+
+
+.. _route53zone-records:
+
+DNS Records
+~~~~~~~~~~~
+
+Certain supported services can create an alias record in this zone.  The currently supported services are:
+
+* Beanstalk
+* ECS
+* S3 Static Site (requires that the bucket be named with the corresponding DNS name)
+
+Beanstalk and ECS configurations will point at the load balancer that was created.  S3 static site configurations
+will point at the S3 bucket itself.
+
+The DNS configuration for each of these services is the same. Multiple DNS configurations may be specified.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Parameter
+     - Type
+     - Required
+     - Default
+     - Description
+   * - name
+     - string
+     - Yes
+     -
+     - The DNS name to assign.
+   * - protocols
+     - List<string>
+     - No
+     - [ ipv4, ipv6 ]
+     - The IP protocols for which to create records. The only valid values are 'ipv4' and 'ipv6', which will recreate 'A' and 'AAAA' records.
+   * - comment
+     - string
+     - No
+     - Handel-created alias
+     - Description of this zone
+   * - tags
+     - :ref:`route53zone-tags`
+     - No
+     -
+     - Any tags you want to apply to your DNS record
+
+The DNS must either match or be a subdomain of an existing Route 53 hosted zone name. If the hosted zone is configured
+in the same Handel environment, you must declare it as a dependency of the service consuming it.
+
+.. code-block:: yaml
+
+    version: 1
+
+    name: my-app
+
+    environments:
+      dev:
+        dns:
+          type: route53zone
+          name: myapp.byu.edu
+        private-dns:
+          type: route53zone
+          name: internal.myapp
+          private: true
+        beanstalk-app:
+          type: beanstalk
+          ...
+          dns:
+            - name: beanstalk.myapp.byu.edu
+          dependencies:
+            - dns
+        ecs-app:
+          type: ecs
+          ...
+          dns:
+            - name: ecs.myapp.byu.edu
+              protocols: [ ipv6 ] #no ipv4 support - don't do this!
+            - name: ecs.internal.myapp
+              protocols: [ ipv4 ]
+              comment: Private Service Discovery DNS
+              tags:
+                mytag: myvalue
+          dependencies:
+            - dns
+            - private-dns
+        s3site:
+          type: s3staticsite
+          bucket_name: mysite.byu.edu # must match the public dns name assigned to it
+          ...
+          dns:
+            - name: mysite.byu.edu # This requires that a hosted zone for mysite.byu.edu have already been configured.
+
+
+
+Events produced by this service
+-------------------------------
+The Route 53 Hosted Zone service does not currently produce events for other Handel services to consume.
+
+Events consumed by this service
+-------------------------------
+The Route 53 Hosted Zone service does not currently consume events from other Handle services.

--- a/docs/supported-services/route53zone.rst
+++ b/docs/supported-services/route53zone.rst
@@ -12,9 +12,9 @@ The following Route 53 features are not currently supported in this service:
 
 Manual Steps
 ------------
-If creating a public zone as a subdomain of another domain (like myapp.byu.edu), you must register it with your DNS provider.
+If you are creating a public zone as a subdomain of another domain (like myapp.mydomain.com), you must register it with your DNS provider.
 
-For BYU users, please refer to `this document <https://byuoit.atlassian.net/wiki/spaces/OAPP/pages/40075276/Routing+BYU+DNS+into+AWS>`_.
+If you are using Handel for your work at a company or organization of some kind, they likely have a process for registering these hosted zones with their DNS provider. Check with the networking groups in your organization to find out how you can do this.
 
 Parameters
 ----------
@@ -75,12 +75,12 @@ Example Handel File
       dev:
         public-zone:
           type: route53zone
-          name: mydomain.byu.edu
+          name: mydomain.example.com
           tags:
             mytag: mytagvalue
         private-zone:
           type: route53zone
-          name: private.myapp # Doesn't have to be a .byu.edu domain
+          name: private.myapp # Doesn't have to have a normal top-level domain
           private: true
           tags:
             mytag: mytagvalue
@@ -119,7 +119,8 @@ Certain supported services can create an alias record in this zone.  The current
 Each service can support multiple DNS entries. See the individual service documentation for how to define the DNS names.
 
 The DNS name must either match or be a subdomain of an existing Route 53 hosted zone name. If the hosted zone is configured
-in the same Handel environment, you must declare it as a dependency of the service consuming it.
+in the same Handel environment, you must declare it as a dependency of the service consuming it, so that Handel can make
+sure that your resources are constructed in the right order.
 
 .. code-block:: yaml
 
@@ -131,7 +132,7 @@ in the same Handel environment, you must declare it as a dependency of the servi
       dev:
         dns:
           type: route53zone
-          name: myapp.byu.edu
+          name: myapp.example.com
         private-dns:
           type: route53zone
           name: internal.myapp
@@ -141,7 +142,7 @@ in the same Handel environment, you must declare it as a dependency of the servi
           routing:
             type: http
             dns_names:
-              - beanstalk.mymapp.byu.edu
+              - beanstalk.mymapp.example.com
           ...
           dependencies:
             - dns
@@ -150,7 +151,7 @@ in the same Handel environment, you must declare it as a dependency of the servi
           load_balancer:
             type: http
             dns_names:
-              - ecs.myapp.byu.edu
+              - ecs.myapp.example.com
               - ecs.internal.myapp
           ...
           dependencies:
@@ -161,7 +162,7 @@ in the same Handel environment, you must declare it as a dependency of the servi
           routing:
             type: http
             dns_names:
-              - mysite.byu.edu # This requires that a hosted zone for mysite.byu.edu have already been configured.
+              - mysite.example.com # This requires that a hosted zone for mysite.example.com have already been configured.
           ...
 
 

--- a/docs/supported-services/route53zone.rst
+++ b/docs/supported-services/route53zone.rst
@@ -95,9 +95,11 @@ This service outputs the following environment variables:
 
    * - Environment Variable
      - Description
-   * - <ENV_PREFIX>_DNS_NAME
+   * - <ENV_PREFIX>_ZONE_NAME
      - The DNS name of hosted zone.
-   * - <ENV_PREFIX>_NAME_SERVERS
+   * - <ENV_PREFIX>_ZONE_ID
+     - The id of the hosted zone
+   * - <ENV_PREFIX>_ZONE_NAME_SERVERS
      - A comma-delimited list of the name servers for this hosted zone. For example: ns1.example.com,ns2.example.co.uk
 
 

--- a/docs/supported-services/s3staticsite.rst
+++ b/docs/supported-services/s3staticsite.rst
@@ -63,6 +63,11 @@ This service takes the following parameters:
      - No 
      - error.html
      - The name of the file in S3 to serve as the error document.
+   * - dns
+     - :ref:`route53zone-records`
+     - No
+     -
+     - DNS records to create and associate with this bucket. If specified, the bucket name must match the record name.
    * - tags
      - :ref:`s3staticsite-tags`
      - No

--- a/docs/supported-services/s3staticsite.rst
+++ b/docs/supported-services/s3staticsite.rst
@@ -63,11 +63,6 @@ This service takes the following parameters:
      - No 
      - error.html
      - The name of the file in S3 to serve as the error document.
-   * - dns
-     - :ref:`route53zone-records`
-     - No
-     -
-     - DNS records to create and associate with this bucket. If specified, the bucket name must match the record name.
    * - tags
      - :ref:`s3staticsite-tags`
      - No

--- a/lib/aws/route53-calls.js
+++ b/lib/aws/route53-calls.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const AWS = require('aws-sdk');
+const winston = require('winston');
+
+exports.listHostedZones = function () {
+    let Route53 = new AWS.Route53();
+
+    return makeCall(null, []);
+
+    function makeCall(marker, previousResult) {
+        return Route53.listHostedZones({
+            Marker: marker,
+            MaxItems: '100'
+        }).promise().then(data => {
+            let result = previousResult.concat(data.HostedZones);
+            if (data.IsTruncated) {
+                return makeCall(data.Marker, result)
+            } else {
+                return result;
+            }
+        });
+    }
+};
+
+exports.getBestMatchingHostedZone = function (domain, zones) {
+    //DNS zone names end with '.'
+    let zoneName = domain.endsWith('.') ? domain : domain + '.';
+    return zones.filter(it => zoneName.endsWith(it.Name))
+        .sort((left, right) => left.Name.length - right.Name.length)
+        .pop();
+};
+
+const VALID_HOSTNAME_REGEX = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/;
+
+exports.isValidHostname = function(string) {
+   return !!string.match(VALID_HOSTNAME_REGEX);
+};

--- a/lib/services/beanstalk/dns-names-ebextension-template.yml
+++ b/lib/services/beanstalk/dns-names-ebextension-template.yml
@@ -1,0 +1,19 @@
+Resources:
+  {{#each names}}
+  DnsName{{@index}}:
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Handel-created DNS Records for {{name}}
+      HostedZoneId: {{zoneId}}
+      RecordSets:
+        - Name: {{name}}
+          Type: A
+          AliasTarget:
+            DNSName: !GetAtt AWSEBV2LoadBalancer.DNSName
+            HostedZoneId: !GetAtt AWSEBV2LoadBalancer.CanonicalHostedZoneID
+        - Name: {{name}}
+          Type: AAAA
+          AliasTarget:
+            DNSName: !GetAtt AWSEBV2LoadBalancer.DNSName
+            HostedZoneId: !GetAtt AWSEBV2LoadBalancer.CanonicalHostedZoneID
+  {{/each}}

--- a/lib/services/beanstalk/index.js
+++ b/lib/services/beanstalk/index.js
@@ -253,7 +253,7 @@ function getDnsNameEbExtension(ownServiceContext) {
             let namesParam = dnsNames.map(name => {
                 return {
                     name: name,
-                    zoneId: route53.getBestMatchingHostedZone(name, zones),
+                    zoneId: route53.getBestMatchingHostedZone(name, zones).Id,
                 }
             });
 

--- a/lib/services/beanstalk/index.js
+++ b/lib/services/beanstalk/index.js
@@ -23,6 +23,7 @@ const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
 const bindPhaseCommon = require('../../common/bind-phase-common');
 const deletePhasesCommon = require('../../common/delete-phases-common');
 const deployableArtifact = require('./deployable-artifact');
+const route53 = require('../../aws/route53-calls');
 const util = require('../../common/util');
 const _ = require('lodash');
 
@@ -228,7 +229,7 @@ function getAutoScalingEbExtension(stackName, ownServiceContext) {
             threshold: policyConfig.alarm.threshold
         }
 
-        if(policyConfig.type == "up") {
+        if (policyConfig.type == "up") {
             scalingPolicy.scaleUp = true;
         }
         else {
@@ -240,6 +241,27 @@ function getAutoScalingEbExtension(stackName, ownServiceContext) {
     }
 
     return handlebarsUtils.compileTemplate(`${__dirname}/autoscaling-ebextension-template.yml`, handlebarsParams);
+}
+
+function getDnsNameEbExtension(ownServiceContext) {
+    let serviceParams = ownServiceContext.params;
+
+    let dnsNames = serviceParams.routing.dns_names;
+
+    return route53.listHostedZones()
+        .then(zones => {
+            let namesParam = dnsNames.map(name => {
+                return {
+                    name: name,
+                    zoneId: route53.getBestMatchingHostedZone(name, zones),
+                }
+            });
+
+            let handlebarsParams = {
+                names: namesParam
+            };
+            return handlebarsUtils.compileTemplate(`${__dirname}/dns-names-ebextension-template.yml`, handlebarsParams);
+        });
 }
 
 
@@ -255,11 +277,22 @@ function getSystemInjectedEbExtensions(stackName, ownServiceContext, dependencie
             if (serviceParams.auto_scaling && serviceParams.auto_scaling.scaling_policies) {
                 return getAutoScalingEbExtension(stackName, ownServiceContext)
                     .then(scalingEbextensionContent => {
-                        ebextensionFiles['00auto-scaling.config'] = scalingEbextensionContent
+                        ebextensionFiles['00auto-scaling.config'] = scalingEbextensionContent;
                         return ebextensionFiles;
                     });
             }
             else {
+                return ebextensionFiles;
+            }
+        })
+        .then(ebextensionFiles => {
+            if (serviceParams.routing && serviceParams.routing.dns_names) {
+                return getDnsNameEbExtension(ownServiceContext)
+                    .then(content => {
+                        ebextensionFiles['02dns-names.config'] = content;
+                        return ebextensionFiles;
+                    });
+            } else {
                 return ebextensionFiles;
             }
         });
@@ -273,10 +306,18 @@ function getSystemInjectedEbExtensions(stackName, ownServiceContext, dependencie
 
 exports.check = function (serviceContext) {
     let errors = [];
+    let params = serviceContext.params;
 
     //TODO - Implement check method
 
     //solution_stack required
+
+    if (params.routing && params.routing.dns_names) {
+        let badName = params.routing.dns_names.some(it => !route53.isValidHostname(it));
+        if (badName) {
+            errors.push(`${SERVICE_NAME} - 'dns_names' values must be valid hostnames`);
+        }
+    }
     return errors;
 }
 

--- a/lib/services/ecs/ecs-service-template.yml
+++ b/lib/services/ecs/ecs-service-template.yml
@@ -473,6 +473,24 @@ Resources:
       VpcId: {{../vpcId}}
   {{/if}}
   {{/each}}
+  {{#each loadBalancer.dnsNames}}
+  DnsName{{@index}}:
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Handel-created DNS Records for {{name}}
+      HostedZoneId: {{zoneId}}
+      RecordSets:
+        - Name: {{name}}
+          Type: A
+          AliasTarget:
+            DNSName: !GetAtt Alb.DNSName
+            HostedZoneId: !GetAtt Alb.CanonicalHostedZoneID
+        - Name: {{name}}
+          Type: AAAA
+          AliasTarget:
+            DNSName: !GetAtt Alb.DNSName
+            HostedZoneId: !GetAtt Alb.CanonicalHostedZoneID
+  {{/each}}
   {{/if}}
 Outputs:
   EcsClusterId:

--- a/lib/services/ecs/index.js
+++ b/lib/services/ecs/index.js
@@ -47,7 +47,8 @@ function getLatestEcsAmiId() {
 
 function getCompiledEcsTemplate(stackName, clusterName, ownServiceContext, ownPreDeployContext, dependenciesDeployContexts, userDataScript, ecsServiceRole) {
     return Promise.all([getLatestEcsAmiId(), route53.listHostedZones()])
-        .then(([latestEcsAmi, hostedZones]) => {
+        .then(results => {
+            let [latestEcsAmi, hostedZones] = results;
             let serviceParams = ownServiceContext.params;
             let instanceType = "t2.micro";
             if (serviceParams.cluster && serviceParams.cluster.instance_type) {

--- a/lib/services/ecs/index.js
+++ b/lib/services/ecs/index.js
@@ -29,6 +29,7 @@ const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
 const bindPhaseCommon = require('../../common/bind-phase-common');
 const deletePhasesCommon = require('../../common/delete-phases-common');
 const handlebarsUtils = require('../../common/handlebars-utils');
+const route53 = require('../../aws/route53-calls');
 const _ = require('lodash');
 
 const SERVICE_NAME = "ECS";
@@ -45,8 +46,8 @@ function getLatestEcsAmiId() {
 
 
 function getCompiledEcsTemplate(stackName, clusterName, ownServiceContext, ownPreDeployContext, dependenciesDeployContexts, userDataScript, ecsServiceRole) {
-    return getLatestEcsAmiId()
-        .then(latestEcsAmi => {
+    return Promise.all([getLatestEcsAmiId(), route53.listHostedZones()])
+        .then(([latestEcsAmi, hostedZones]) => {
             let serviceParams = ownServiceContext.params;
             let instanceType = "t2.micro";
             if (serviceParams.cluster && serviceParams.cluster.instance_type) {
@@ -86,7 +87,7 @@ function getCompiledEcsTemplate(stackName, clusterName, ownServiceContext, ownPr
 
             //Configure routing if present in any of hte containers
             if (oneOrMoreTasksHasRouting) {
-                handlebarsParams.loadBalancer = routingSection.getLoadBalancerConfig(serviceParams, containerConfigs, clusterName);
+                handlebarsParams.loadBalancer = routingSection.getLoadBalancerConfig(serviceParams, containerConfigs, clusterName, hostedZones);
             }
 
             //Add the SSH keypair if specified

--- a/lib/services/ecs/routing.js
+++ b/lib/services/ecs/routing.js
@@ -1,4 +1,5 @@
 const accountConfig = require('../../common/account-config')().getAccountConfig();
+const route53 = require('../../aws/route53-calls');
 
 function getDefaultRouteContainer(containerConfigs) {
     for(let containerConfig of containerConfigs) {
@@ -46,7 +47,7 @@ exports.getRoutingInformationForContainer = function (container, albPriority, cl
     return routingInfo;
 }
 
-exports.getLoadBalancerConfig = function (serviceParams, containerConfigs, clusterName) {
+exports.getLoadBalancerConfig = function (serviceParams, containerConfigs, clusterName, hostedZones) {
     let defaultRouteContainer = getDefaultRouteContainer(containerConfigs);
     let loadBalancerConfig = { //Default values for load balancer
         timeout: 60,
@@ -64,6 +65,14 @@ exports.getLoadBalancerConfig = function (serviceParams, containerConfigs, clust
         }
         if (loadBalancer.https_certificate) {
             loadBalancerConfig.httpsCertificate = `arn:aws:acm:us-west-2:${accountConfig.account_id}:certificate/${loadBalancer.https_certificate}`;
+        }
+        if (loadBalancer.dns_names) {
+            loadBalancerConfig.dnsNames = loadBalancer.dns_names.map(name => {
+                return {
+                    name: name,
+                    zoneId: route53.getBestMatchingHostedZone(name, hostedZones).Id
+                };
+            });
         }
     }
 
@@ -84,6 +93,13 @@ exports.checkLoadBalancerSection = function(serviceContext, serviceName, errors)
         //If type = https, require https_certificate
         if (params.load_balancer.type === 'https' && !params.load_balancer.https_certificate) {
             errors.push(`${serviceName} - The 'https_certificate' parameter is required in the 'load_balancer' section when you use HTTPS`);
+        }
+
+        if (params.load_balancer.dns_names) {
+            let badName = params.load_balancer.dns_names.some(name => !route53.isValidHostname(name));
+            if (badName) {
+                errors.push(`${serviceName} - The 'dns_names' values must be valid hostnames`)
+            }
         }
     }
 }

--- a/lib/services/route53zone/index.js
+++ b/lib/services/route53zone/index.js
@@ -131,11 +131,10 @@ exports.unDeploy = function (ownServiceContext) {
     return deletePhasesCommon.unDeployService(ownServiceContext, SERVICE_NAME);
 }
 
-exports.producedEventsSupportedServices = []; //TODO - No events supported yet, but we will support some like Lambda
+exports.producedEventsSupportedServices = [];
 
 exports.producedDeployOutputTypes = [
-    'environmentVariables',
-    'policies'
+    'environmentVariables'
 ];
 
 exports.consumedDeployOutputTypes = [];

--- a/lib/services/route53zone/index.js
+++ b/lib/services/route53zone/index.js
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const winston = require('winston');
+const DeployContext = require('../../datatypes/deploy-context');
+const accountConfig = require('../../common/account-config')().getAccountConfig();
+const cloudFormationCalls = require('../../aws/cloudformation-calls');
+const deployPhaseCommon = require('../../common/deploy-phase-common');
+const deletePhasesCommon = require('../../common/delete-phases-common');
+const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
+const bindPhaseCommon = require('../../common/bind-phase-common');
+const handlebarsUtils = require('../../common/handlebars-utils');
+
+const SERVICE_NAME = "Route53";
+
+function getDeployContext(serviceContext, cfStack) {
+    let name = cloudFormationCalls.getOutput('ZoneName', cfStack);
+    let id = cloudFormationCalls.getOutput('ZoneId', cfStack);
+    let nameServers = cloudFormationCalls.getOutput('ZoneNameServers', cfStack);
+
+    let deployContext = new DeployContext(serviceContext);
+
+    //Env variables to inject into consuming services
+    let zoneNameEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'ZONE_NAME');
+    deployContext.environmentVariables[zoneNameEnv] = name;
+    let zoneIdEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, "ZONE_ID");
+    deployContext.environmentVariables[zoneIdEnv] = id;
+    let zoneNameServersEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, "ZONE_NAME_SERVERS");
+    deployContext.environmentVariables[zoneNameServersEnv] = nameServers;
+
+    return deployContext;
+}
+
+
+function getCompiledRoute53Template(ownServiceContext) {
+    let serviceParams = ownServiceContext.params;
+
+    let handlebarsParams = {
+        name: serviceParams.name,
+        tags: deployPhaseCommon.getTags(ownServiceContext)
+    };
+
+    if (serviceParams.private) {
+        handlebarsParams.vpcs = [{
+            id: accountConfig.vpc,
+            region: accountConfig.region
+        }];
+    }
+
+    return handlebarsUtils.compileTemplate(`${__dirname}/route53zone-template.yml`, handlebarsParams)
+}
+
+/**
+ * Service Deployer Contract Methods
+ * See https://github.com/byu-oit-appdev/handel/wiki/Creating-a-New-Service-Deployer#service-deployer-contract
+ *   for contract method documentation
+ */
+
+const VALID_HOSTNAME_REGEX = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/;
+
+exports.check = function (serviceContext) {
+    let errors = [];
+
+    let params = serviceContext.params;
+
+    if (!params.name) {
+        errors.push(`${SERVICE_NAME} - 'name' parameter must be specified`);
+    } else if (!params.name.match(VALID_HOSTNAME_REGEX)) {
+        errors.push(`${SERVICE_NAME} - 'name' parameter must be a valid hostname`);
+    }
+
+    if (params.private && typeof params.private !== 'boolean') {
+        errors.push(`${SERVICE_NAME} - 'private' parameter must be 'true' or 'false'`);
+    }
+
+    return errors;
+}
+
+exports.preDeploy = function (serviceContext) {
+    return preDeployPhaseCommon.preDeployNotRequired(serviceContext, SERVICE_NAME);
+}
+
+exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
+    return bindPhaseCommon.bindNotRequired(ownServiceContext, dependentOfServiceContext, SERVICE_NAME);
+}
+
+exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
+    let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Deploying Route53 Zone ${stackName}`);
+
+    return getCompiledRoute53Template(ownServiceContext)
+        .then(compiledTemplate => {
+            let stackTags = deployPhaseCommon.getTags(ownServiceContext);
+            return deployPhaseCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, SERVICE_NAME, stackTags);
+        })
+        .then(createdOrUpdatedStack => {
+            winston.info(`${SERVICE_NAME} - Finished deploying S3 bucket ${stackName}`);
+            return getDeployContext(ownServiceContext, createdOrUpdatedStack);
+        });
+}
+
+exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerServiceContext, producerDeployContext) {
+    return Promise.reject(new Error(`The ${SERVICE_NAME} service doesn't consume events from other services`));
+}
+
+exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext) {
+    return Promise.reject(new Error(`The ${SERVICE_NAME} service doesn't currently produce events for other services`));
+}
+
+exports.unPreDeploy = function (ownServiceContext) {
+    return deletePhasesCommon.unPreDeployNotRequired(ownServiceContext, SERVICE_NAME);
+}
+
+exports.unBind = function (ownServiceContext) {
+    return deletePhasesCommon.unBindNotRequired(ownServiceContext, SERVICE_NAME);
+}
+
+exports.unDeploy = function (ownServiceContext) {
+    return deletePhasesCommon.unDeployService(ownServiceContext, SERVICE_NAME);
+}
+
+exports.producedEventsSupportedServices = []; //TODO - No events supported yet, but we will support some like Lambda
+
+exports.producedDeployOutputTypes = [
+    'environmentVariables',
+    'policies'
+];
+
+exports.consumedDeployOutputTypes = [];

--- a/lib/services/route53zone/index.js
+++ b/lib/services/route53zone/index.js
@@ -23,6 +23,7 @@ const deletePhasesCommon = require('../../common/delete-phases-common');
 const preDeployPhaseCommon = require('../../common/pre-deploy-phase-common');
 const bindPhaseCommon = require('../../common/bind-phase-common');
 const handlebarsUtils = require('../../common/handlebars-utils');
+const route53 = require('../../aws/route53-calls');
 
 const SERVICE_NAME = "Route53";
 
@@ -69,8 +70,6 @@ function getCompiledRoute53Template(ownServiceContext) {
  *   for contract method documentation
  */
 
-const VALID_HOSTNAME_REGEX = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/;
-
 exports.check = function (serviceContext) {
     let errors = [];
 
@@ -78,7 +77,7 @@ exports.check = function (serviceContext) {
 
     if (!params.name) {
         errors.push(`${SERVICE_NAME} - 'name' parameter must be specified`);
-    } else if (!params.name.match(VALID_HOSTNAME_REGEX)) {
+    } else if (!route53.isValidHostname(params.name)) {
         errors.push(`${SERVICE_NAME} - 'name' parameter must be a valid hostname`);
     }
 

--- a/lib/services/route53zone/route53zone-template.yml
+++ b/lib/services/route53zone/route53zone-template.yml
@@ -1,0 +1,36 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Handel-created Route53 Hosted Zone
+
+Resources:
+  Zone:
+    Type: "AWS::Route53::HostedZone"
+    Properties:
+      Name: {{name}}
+      HostedZoneConfig:
+        Comment: Handel-generated zone for {{name}}
+      {{#if vpcs}}
+      VPCs:
+      {{#each vpcs}}
+        - VPCId: {{this.id}}
+          VPCRegion: {{this.region}}
+      {{/each}}
+      {{/if}}
+      {{#if tags}}
+      HostedZoneTags:
+      {{#each tags}}
+      - Key: {{@key}}
+        Value: {{this}}
+      {{/each}}
+      {{/if}}
+      
+Outputs:
+  ZoneId:
+    Description: The ID of the hosted zone
+    Value: !Ref Zone
+  ZoneNameServers:
+    Description: The hosted zone's name servers
+    Value:
+      Fn::Join:
+        - ","
+        - !GetAtt Zone.NameServers

--- a/test/aws/route53-calls-test.js
+++ b/test/aws/route53-calls-test.js
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const accountConfig = require('../../lib/common/account-config')(`${__dirname}/../test-account-config.yml`).getAccountConfig();
+const expect = require('chai').expect;
+const AWS = require('aws-sdk-mock');
+const route53Calls = require('../../lib/aws/route53-calls');
+const sinon = require('sinon');
+
+describe('route53Calls', function () {
+    let sandbox;
+
+    beforeEach(function () {
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+        AWS.restore('Route53');
+    });
+
+    describe('getBestMatchingHostedZone', function () {
+        it('should return a hosted zone that matches exactly', function () {
+            let zones = [
+                {
+                    Name: 'exact.test.byu.edu.'
+                }, {
+                    Name: 'deeper.exact.test.byu.edu.'
+                }, {
+                    Name: 'test.byu.edu.'
+                }
+            ];
+
+            let result = route53Calls.getBestMatchingHostedZone('exact.test.byu.edu', zones);
+            expect(result).to.exist.and.to.not.be.null;
+            expect(result).to.have.property('Name', 'exact.test.byu.edu.');
+
+        });
+
+        it('should return the most-specific parent zone of the specified name', function () {
+            let zones = [
+                {
+                    Name: 'd.c.b.a.'
+                }, {
+                    Name: 'c.b.a.'
+                }, {
+                    Name: 'b.a.'
+                }
+            ];
+
+            let result = route53Calls.getBestMatchingHostedZone('e.d.c.b.a', zones);
+            expect(result).to.exist.and.to.not.be.null;
+            expect(result).to.have.property('Name', 'd.c.b.a.');
+        });
+
+        it('should handle names ending with periods', function () {
+            let zones = [
+                {
+                    Name: 'b.a.'
+                }
+            ];
+
+            let result = route53Calls.getBestMatchingHostedZone('b.a.', zones);
+            expect(result).to.exist.and.to.not.be.null;
+            expect(result).to.have.property('Name', 'b.a.');
+        });
+    });
+
+    describe('listHostedZones', function () {
+        it('should return an array of hosted zones', function () {
+            let listStub = sandbox.stub();
+            AWS.mock('Route53', 'listHostedZones', listStub);
+
+            listStub.yields(null, {
+                IsTruncated: false,
+                HostedZones: [
+                    zone(1), zone(2), zone(3)
+                ]
+            });
+
+            return route53Calls.listHostedZones()
+                .then(zones => {
+                    expect(zones).to.exist.and.to.not.be.null;
+                    expect(zones).to.deep.equal([zone(1), zone(2), zone(3)])
+                });
+        });
+
+        it('should handle truncated results', function () {
+            let listStub = sandbox.stub();
+            AWS.mock('Route53', 'listHostedZones', listStub);
+
+            listStub.onFirstCall().yields(null, {
+                IsTruncated: true,
+                Marker: 'marker',
+                HostedZones: [
+                    zone(1), zone(2)
+                ]
+            });
+
+            listStub.onSecondCall().yields(null, {
+                IsTruncated: true,
+                Marker: 'marker2',
+                HostedZones: [
+                    zone(3), zone(4)
+                ]
+            });
+
+            listStub.onThirdCall().yields(null, {
+                IsTruncated: false,
+                HostedZones: [
+                    zone(5)
+                ]
+            });
+
+            return route53Calls.listHostedZones()
+                .then(zones => {
+                    expect(zones).to.exist.and.to.not.be.null;
+                    expect(zones).to.deep.equal([
+                        zone(1), zone(2), zone(3), zone(4), zone(5)
+                    ])
+                });
+        });
+
+        function zone(id) {
+            return {
+                Id: `${id}`,
+                Name: id + '.example.com.'
+            };
+        }
+    });
+});

--- a/test/services/beanstalk/beanstalk-test.js
+++ b/test/services/beanstalk/beanstalk-test.js
@@ -182,10 +182,10 @@ describe('beanstalk deployer', function () {
 
             sandbox.stub(route53, 'listHostedZones').returns(Promise.resolve([{
                 Id: '1',
-                Name: 'myapp.byu.edu'
+                Name: 'myapp.byu.edu.'
             }, {
                 Id: '2',
-                Name: 'myapp.internal'
+                Name: 'myapp.internal.'
             }]));
 
             let ownServiceContext = getServiceContext();

--- a/test/services/beanstalk/beanstalk-test.js
+++ b/test/services/beanstalk/beanstalk-test.js
@@ -28,6 +28,7 @@ const deployableArtifact = require('../../../lib/services/beanstalk/deployable-a
 const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
 const UnBindContext = require('../../../lib/datatypes/un-bind-context');
 const UnDeployContext = require('../../../lib/datatypes/un-deploy-context');
+const route53 = require('../../../lib/aws/route53-calls');
 const sinon = require('sinon');
 const expect = require('chai').expect;
 
@@ -49,6 +50,18 @@ describe('beanstalk deployer', function () {
             let errors = beanstalk.check(serviceContext);
             expect(errors.length).to.equal(0);
         });
+
+        it('should check for valid dns_names', function () {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {
+                routing: {
+                    dns_names: ['invalid hostname']
+                }
+            });
+            let errors = beanstalk.check(serviceContext);
+
+            expect(errors.length).to.equal(1);
+            expect(errors[0]).to.include("'dns_names' values must be valid hostnames")
+        })
     });
 
     describe('preDeploy', function () {
@@ -95,28 +108,28 @@ describe('beanstalk deployer', function () {
                         {
                             type: "up",
                             adjustment: {
-                              value: 1,
-                              cooldown: 60
+                                value: 1,
+                                cooldown: 60
                             },
                             alarm: {
-                              statistic: "Average",
-                              metric_name: "CPUUtilization",
-                              comparison_operator: "GreaterThanThreshold",
-                              threshold: 70,
-                              period: 60
+                                statistic: "Average",
+                                metric_name: "CPUUtilization",
+                                comparison_operator: "GreaterThanThreshold",
+                                threshold: 70,
+                                period: 60
                             }
                         },
                         {
                             type: "down",
                             adjustment: {
-                              value: 1,
-                              cooldown: 60
+                                value: 1,
+                                cooldown: 60
                             },
                             alarm: {
-                              metric_name: "CPUUtilization",
-                              comparison_operator: "LessThanThreshold",
-                              threshold: 30,
-                              period: 60
+                                metric_name: "CPUUtilization",
+                                comparison_operator: "LessThanThreshold",
+                                threshold: 30,
+                                period: 60
                             }
                         }
                     ]
@@ -156,6 +169,46 @@ describe('beanstalk deployer', function () {
                     expect(deployContext).to.be.instanceof(DeployContext);
                 });
         });
+
+        it('should set up dns records if requested', function () {
+            let createCustomRoleStub = sandbox.stub(deployPhaseCommon, 'createCustomRole').returns(Promise.resolve({
+                RoleName: "FakeServiceRole"
+            }));
+            let prepareAndUploadDeployableArtifactStub = sandbox.stub(deployableArtifact, 'prepareAndUploadDeployableArtifact').returns(Promise.resolve({
+                Bucket: "FakeBucket",
+                Key: "FakeKey"
+            }));
+            let deployStackStub = sandbox.stub(deployPhaseCommon, 'deployCloudFormationStack').returns(Promise.resolve({}));
+
+            sandbox.stub(route53, 'listHostedZones').returns(Promise.resolve([{
+                Id: '1',
+                Name: 'myapp.byu.edu'
+            }, {
+                Id: '2',
+                Name: 'myapp.internal'
+            }]));
+
+            let ownServiceContext = getServiceContext();
+            let sgGroupId = "FakeSgId";
+            let ownPreDeployContext = getPreDeployContext(ownServiceContext, sgGroupId);
+
+            ownServiceContext.params.routing = {
+                type: 'http',
+                dns_names: [
+                    'myapp.byu.edu',
+                    'myapp.internal'
+                ]
+            };
+
+            return beanstalk.deploy(ownServiceContext, ownPreDeployContext, [])
+                .then(deployContext => {
+                    expect(createCustomRoleStub.calledOnce).to.be.true;
+                    expect(prepareAndUploadDeployableArtifactStub.calledOnce).to.be.true;
+                    expect(prepareAndUploadDeployableArtifactStub.firstCall.args[1]).to.have.property('02dns-names.config');
+                    expect(deployStackStub.calledOnce).to.be.true;
+                    expect(deployContext).to.be.instanceof(DeployContext);
+                });
+        });
     });
 
     describe('consumeEvents', function () {
@@ -185,7 +238,7 @@ describe('beanstalk deployer', function () {
     describe('unPreDeploy', function () {
         it('should delete the security group', function () {
             let unPreDeployStub = sandbox.stub(deletePhasesCommon, 'unPreDeploySecurityGroup').returns(Promise.resolve(new UnPreDeployContext({})));
-            
+
             return beanstalk.unPreDeploy({})
                 .then(unPreDeployContext => {
                     expect(unPreDeployContext).to.be.instanceof(UnPreDeployContext);

--- a/test/services/route53zone/route53zone-test.js
+++ b/test/services/route53zone/route53zone-test.js
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const accountConfig = require('../../../lib/common/account-config')(`${__dirname}/../../test-account-config.yml`).getAccountConfig();
+const route53 = require('../../../lib/services/route53zone');
+const ServiceContext = require('../../../lib/datatypes/service-context');
+const DeployContext = require('../../../lib/datatypes/deploy-context');
+const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
+const BindContext = require('../../../lib/datatypes/bind-context');
+const deployPhaseCommon = require('../../../lib/common/deploy-phase-common');
+const deletePhasesCommon = require('../../../lib/common/delete-phases-common');
+const bindPhaseCommon = require('../../../lib/common/bind-phase-common');
+const preDeployPhaseCommon = require('../../../lib/common/pre-deploy-phase-common');
+const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
+const UnBindContext = require('../../../lib/datatypes/un-bind-context');
+const UnDeployContext = require('../../../lib/datatypes/un-deploy-context');
+const sinon = require('sinon');
+const expect = require('chai').expect;
+
+describe('route53zone deployer', function () {
+    let sandbox;
+
+    beforeEach(function () {
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    describe('check', function () {
+        it('should require the name parameter', function () {
+            let serviceContext = {
+                params: {}
+            };
+
+            let errors = route53.check(serviceContext);
+            expect(errors.length).to.equal(1);
+            expect(errors[0]).to.contain("'name' parameter must be specified");
+        });
+
+        describe('should fail if name is not a valid DNS hostname', function () {
+            let invalidNames = ['-abc.def', 'abc-.def', 'ab c.def', 'has_underscores.com'];
+            let validNames = ['0.a.mixed-123-chars'];
+
+            invalidNames.forEach(function (invalid) {
+                it(`should reject '${invalid}'`, function () {
+                    let serviceContext = {
+                        params: {
+                            name: invalid
+                        }
+                    };
+
+                    let errors = route53.check(serviceContext);
+                    expect(errors.length).to.equal(1);
+                    expect(errors[0]).to.contain("'name' parameter must be a valid hostname");
+                });
+            });
+
+            validNames.forEach(function (valid) {
+                it(`should accept '${valid}'`, function () {
+                    let serviceContext = {
+                        params: {
+                            name: valid
+                        }
+                    };
+
+                    let errors = route53.check(serviceContext);
+                    expect(errors.length).to.be.empty;
+                });
+            });
+
+        });
+
+        it('should work when there are no configuration errors', function () {
+            let serviceContext = {
+                params: {
+                    name: 'somename',
+                    private: true
+                }
+            }
+            let errors = route53.check(serviceContext);
+            expect(errors.length).to.equal(0);
+        });
+
+        it('should fail if private is not a boolean', function () {
+            let serviceContext = {
+                params: {
+                    name: 'somename',
+                    private: 'foobar'
+                }
+            }
+            let errors = route53.check(serviceContext);
+            expect(errors.length).to.equal(1);
+            expect(errors[0]).to.contain("'private' parameter must be 'true' or 'false'");
+        });
+
+
+    });
+
+    describe('preDeploy', function () {
+        it('should return an empty predeploy context', function () {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
+            let preDeployNotRequiredStub = sandbox.stub(preDeployPhaseCommon, 'preDeployNotRequired').returns(Promise.resolve(new PreDeployContext(serviceContext)));
+
+            return route53.preDeploy(serviceContext)
+                .then(preDeployContext => {
+                    expect(preDeployNotRequiredStub.callCount).to.equal(1);
+                    expect(preDeployContext).to.be.instanceof(PreDeployContext);
+                });
+        });
+    });
+
+    describe('bind', function () {
+        it('should return an empty bind context', function () {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
+            let bindNotRequiredStub = sandbox.stub(bindPhaseCommon, 'bindNotRequired').returns(Promise.resolve(new BindContext({}, {})));
+
+            return route53.bind(serviceContext)
+                .then(bindContext => {
+                    expect(bindNotRequiredStub.callCount).to.equal(1);
+                    expect(bindContext).to.be.instanceof(BindContext);
+                });
+        });
+    });
+
+    describe('deploy', function () {
+        let appName = "FakeApp";
+        let envName = "FakeEnv";
+        let deployVersion = "1";
+        let dnsName = "myapp.byu.edu";
+        let zoneId = '123ABC';
+        let zoneNameServers = 'ns1.amazonaws.com,ns2.amazonaws.co.uk';
+        let serviceContext = new ServiceContext(appName, envName, "FakeService", "route53", deployVersion, {
+            name: dnsName
+        });
+        let preDeployContext = new PreDeployContext(serviceContext);
+
+        it('should deploy the hosted zone', function () {
+            let deployStackStub = sandbox.stub(deployPhaseCommon, 'deployCloudFormationStack').returns(Promise.resolve({
+                Outputs: [{
+                    OutputKey: 'ZoneName',
+                    OutputValue: dnsName
+                }, {
+                    OutputKey: 'ZoneId',
+                    OutputValue: zoneId
+                }, {
+                    OutputKey: 'ZoneNameServers',
+                    OutputValue: zoneNameServers
+                }]
+            }));
+
+            return route53.deploy(serviceContext, preDeployContext, [])
+                .then(deployContext => {
+                    expect(deployStackStub.callCount).to.equal(1);
+                    expect(deployContext).to.be.instanceof(DeployContext);
+                    expect(deployContext.policies).to.be.empty;
+                    expect(deployContext.environmentVariables["ROUTE53_FAKEAPP_FAKEENV_FAKESERVICE_ZONE_NAME"]).to.equal(dnsName);
+                    expect(deployContext.environmentVariables["ROUTE53_FAKEAPP_FAKEENV_FAKESERVICE_ZONE_ID"]).to.equal(zoneId);
+                    expect(deployContext.environmentVariables["ROUTE53_FAKEAPP_FAKEENV_FAKESERVICE_ZONE_NAME_SERVERS"]).to.equal(zoneNameServers);
+                });
+        });
+    });
+
+    describe('consumeEvents', function () {
+        it('should return an error since it cant consume events', function () {
+            return route53.consumeEvents(null, null, null, null)
+                .then(() => {
+                    expect(true).to.be.false; //Should not get here
+                })
+                .catch(err => {
+                    expect(err.message).to.contain("Route53 service doesn't consume events");
+                });
+        });
+    });
+
+    describe('produceEvents', function () {
+        it('should return an error since it doesnt yet produce events', function () {
+            return route53.produceEvents(null, null, null, null)
+                .then(() => {
+                    expect(true).to.be.false; //Should not get here
+                })
+                .catch(err => {
+                    expect(err.message).to.contain("Route53 service doesn't currently produce events");
+                });
+        });
+    });
+
+    describe('unPreDeploy', function () {
+        it('should return an empty UnPreDeploy context', function () {
+            let unPreDeployNotRequiredStub = sandbox.stub(deletePhasesCommon, 'unPreDeployNotRequired').returns(Promise.resolve(new UnPreDeployContext({})));
+            return route53.unPreDeploy({})
+                .then(unPreDeployContext => {
+                    expect(unPreDeployContext).to.be.instanceof(UnPreDeployContext);
+                    expect(unPreDeployNotRequiredStub.callCount).to.equal(1);
+                });
+        });
+    });
+
+    describe('unBind', function () {
+        it('should return an empty UnBind context', function () {
+            let unBindNotRequiredStub = sandbox.stub(deletePhasesCommon, 'unBindNotRequired').returns(Promise.resolve(new UnBindContext({})));
+            return route53.unBind({})
+                .then(unBindContext => {
+                    expect(unBindContext).to.be.instanceof(UnBindContext);
+                    expect(unBindNotRequiredStub.callCount).to.equal(1);
+                });
+        });
+    });
+
+    describe('unDeploy', function () {
+        it('should undeploy the stack', function () {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "route53", "1", {});
+            let unDeployStackStub = sandbox.stub(deletePhasesCommon, 'unDeployService').returns(Promise.resolve(new UnDeployContext(serviceContext)));
+
+            return route53.unDeploy(serviceContext)
+                .then(unDeployContext => {
+                    expect(unDeployContext).to.be.instanceof(UnDeployContext);
+                    expect(unDeployStackStub.calledOnce).to.be.ture;
+                });
+        });
+    });
+});


### PR DESCRIPTION
Adds support for a `route53zone` service and for configuring DNS records for Beanstalk and ECS.

Resolves #237 .

The only outstanding thing (which should probably be a separate PR) is adding the ability for services to give messages to the user (separate from the normal logging), so that things like the manual steps for `route53zone` can be explained.