### PR TITLE
Add support for evaluation_periods in auto scaling

### DIFF
--- a/docs/supported-services/beanstalk.rst
+++ b/docs/supported-services/beanstalk.rst
@@ -103,6 +103,7 @@ The `auto_scaling` section is defined by the following schema:
           statistic: <string> # Optional. Default: 'Average'
           threshold: <number> # Required
           period: <number> # Optional. Default: 300
+          evaluation_periods: <number> # Optional. Default: 5
 
 .. TIP::
 

--- a/docs/supported-services/ecs.rst
+++ b/docs/supported-services/ecs.rst
@@ -140,6 +140,7 @@ The `auto_scaling` section is defined by the following schema:
           comparison_operator: <string> # Required. See http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-comparisonoperator for allowed values.
           threshold: <number> # Required
           period: <number> # Optional. Default: 300
+          evaluation_periods: <number> # Optional. Default: 5
 
 
 .. TIP::

--- a/lib/services/beanstalk/autoscaling-ebextension-template.yml
+++ b/lib/services/beanstalk/autoscaling-ebextension-template.yml
@@ -29,7 +29,7 @@ Resources:
         Value: 
           Ref: AWSEBAutoScalingGroup
       {{/if}}
-      EvaluationPeriods: 1
+      EvaluationPeriods: {{evaluationPeriods}}
       {{#if scaleDown}}
       InsufficientDataActions:
       - Ref: ScalingPolicy{{@index}}

--- a/lib/services/beanstalk/index.js
+++ b/lib/services/beanstalk/index.js
@@ -224,6 +224,7 @@ function getAutoScalingEbExtension(stackName, ownServiceContext) {
             metricName: policyConfig.alarm.metric_name,
             namespace: policyConfig.alarm.namespace || "AWS/EC2",
             period: policyConfig.alarm.period || 60,
+            evaluationPeriods: policyConfig.alarm.evaluation_periods || 5,
             threshold: policyConfig.alarm.threshold
         }
 

--- a/lib/services/ecs/ecs-service-template.yml
+++ b/lib/services/ecs/ecs-service-template.yml
@@ -330,7 +330,7 @@ Resources:
       - Name: ServiceName
         Value: !GetAtt EcsService.Name
       {{/if}}
-      EvaluationPeriods: 1
+      EvaluationPeriods: {{evaluationPeriods}}
       {{#if scaleDown}}
       InsufficientDataActions:
       - !Ref ServiceScalingPolicy{{@index}}

--- a/lib/services/ecs/service-auto-scaling.js
+++ b/lib/services/ecs/service-auto-scaling.js
@@ -35,6 +35,7 @@ exports.getTemplateAutoScalingConfig = function(ownServiceContext, clusterName) 
                 metricName: policyConfig.alarm.metric_name,
                 namespace: policyConfig.alarm.namespace || "AWS/ECS",
                 period: policyConfig.alarm.period || 60,
+                evaluationPeriods: policyConfig.alarm.evaluation_periods || 5,
                 threshold: policyConfig.alarm.threshold
             }
 


### PR DESCRIPTION
This parameter turns out to be important when balancing auto-scaling.