### PR TITLE
Improved logging in library.

### DIFF
--- a/bin/handel
+++ b/bin/handel
@@ -82,7 +82,7 @@ switch (deployPhase.toLowerCase()) {
         }
         break;
     case "check":
-        cli.checkAction(handelFile);
+        cli.checkAction(handelFile, argv);
         break;
     case "delete":
         errors = cli.validateDeleteArgs(argv, handelFile);

--- a/lib/aws/cloudformation-calls.js
+++ b/lib/aws/cloudformation-calls.js
@@ -62,15 +62,15 @@ exports.getStack = function (stackName) {
     var params = {
         StackName: stackName
     };
-    winston.debug(`Attempting to get CloudFormation stack ${stackName}`);
+    winston.verbose(`Looking for CloudFormation stack '${stackName}`);
     return cloudformation.describeStacks(params).promise()
         .then(describeResult => {
-            winston.debug(`Found CloudFormation stack ${stackName}`);
+            winston.verbose(`Found CloudFormation stack '${stackName}'`);
             return describeResult.Stacks[0];
         })
         .catch(err => {
             if (err.code === "ValidationError") { //Stack does not exist
-                winston.debug(`CloudFormation stack ${stackName} not found`);
+                winston.verbose(`CloudFormation stack '${stackName}' does not exist`);
                 return null;
             }
             throw err;
@@ -85,7 +85,7 @@ exports.getStack = function (stackName) {
  * @returns {Promise.<Object>} - The stack that was waited for.
  */
 exports.waitForStack = function (stackName, stackState) {
-    winston.debug(`Waiting for ${stackName} to be in ${stackState}`);
+    winston.verbose(`Waiting for stack '${stackName}' to be in ${stackState}`);
     const cloudformation = new AWS.CloudFormation({
         apiVersion: '2010-05-15'
     });
@@ -94,7 +94,7 @@ exports.waitForStack = function (stackName, stackState) {
     };
     return cloudformation.waitFor(stackState, waitParams).promise()
         .then(waitResponse => {
-            winston.debug(`Stack ${stackName} is in ${stackState}`);
+            winston.verbose(`Stack '${stackName}' is in ${stackState}`);
             return waitResponse.Stacks[0];
         });
 }
@@ -129,11 +129,11 @@ exports.createStack = function (stackName, templateBody, parameters, tags) {
         params.Tags = getCfTags(tags)
     }
 
-    winston.debug(`Creating CloudFormation stack ${stackName}`);
+    winston.verbose(`Creating CloudFormation stack '${stackName}'`);
     return cloudformation.createStack(params).promise()
         .then(createResult => {
             let stackId = createResult.StackId;
-            winston.debug(`Created CloudFormation stack ${stackName}`);
+            winston.verbose(`Created CloudFormation stack '${stackName}'`);
             return exports.waitForStack(stackName, 'stackCreateComplete')
                 .catch(err => {
                     return getErrorsForFailedStack(cloudformation, stackId)
@@ -172,11 +172,11 @@ exports.updateStack = function (stackName, templateBody, parameters, tags) {
         params.Tags = getCfTags(tags)
     }
 
-    winston.debug(`Updating CloudFormation stack ${stackName}`);
+    winston.verbose(`Updating CloudFormation stack '${stackName}'`);
     return cloudformation.updateStack(params).promise()
         .then(createResult => {
             let stackId = createResult.StackId;
-            winston.debug(`Updated CloudFormation stack ${stackName}`);
+            winston.verbose(`Updated CloudFormation stack '${stackName}'`);
             return exports.waitForStack(stackName, 'stackUpdateComplete')
                 .catch(err => {
                     return getErrorsForFailedStack(cloudformation, stackId)
@@ -187,7 +187,7 @@ exports.updateStack = function (stackName, templateBody, parameters, tags) {
         })
         .catch(err => {
             if (err.message.includes('No updates are to be performed')) {
-                winston.debug(`No stack updates were required for stack ${stackName}`);
+                winston.verbose(`No stack updates were required for stack '${stackName}'`);
                 return exports.getStack(stackName);
             }
             throw err;
@@ -210,7 +210,7 @@ exports.deleteStack = function (stackName) {
     var deleteParams = {
         StackName: stackName
     };
-    winston.debug(`Deleting CloudFormation stack ${stackName}`);
+    winston.verbose(`Deleting CloudFormation stack '${stackName}'`);
     return cloudformation.deleteStack(deleteParams).promise()
         .then(deleteResult => {
             var waitParams = {
@@ -218,6 +218,7 @@ exports.deleteStack = function (stackName) {
             };
             return cloudformation.waitFor('stackDeleteComplete', waitParams).promise()
                 .then(waitResponse => {
+                    winston.verbose(`Deleted CloudFormation stack '${stackName}'`);
                     return true;
                 });
         });

--- a/lib/aws/cloudwatch-events-calls.js
+++ b/lib/aws/cloudwatch-events-calls.js
@@ -40,10 +40,10 @@ exports.addTarget = function (ruleName, targetArn, targetId, input) {
     if (input) { //Not all targets will want to override input, but some like scheduled Lambda will.
         putParams.Targets[0].Input = input;
     }
-    winston.debug(`Adding target '${targetArn}' to rule '${ruleName}'`)
+    winston.verbose(`Adding target '${targetArn}' to rule '${ruleName}'`)
     return cloudWatchEvents.putTargets(putParams).promise()
         .then(putResponse => {
-            winston.debug(`Added target '${targetArn}' to rule '${ruleName}'`);
+            winston.verbose(`Added target '${targetArn}' to rule '${ruleName}'`);
             return targetId;
         });
 }
@@ -57,8 +57,10 @@ exports.getTargets = function (ruleName) {
     let listParams = {
         Rule: ruleName
     };
+    winston.verbose(`Getting targets for rule '${ruleName}'`);
     return cloudWatchEvents.listTargetsByRule(listParams).promise()
         .then(listResponse => {
+            winston.verbose(`Finished getting targets for rule '${ruleName}'`)
             return listResponse.Targets;
         });
 }
@@ -71,13 +73,16 @@ exports.getRule = function (ruleName) {
     let listParams = {
         NamePrefix: ruleName
     };
+    winston.verbose(`Looking for rule '${ruleName}'`)
     return cloudWatchEvents.listRules(listParams).promise()
         .then(listResponse => {
             for (let rule of listResponse.Rules) {
                 if (rule.Name === ruleName) {
+                    winston.verbose(`Found rule '${ruleName}'`);
                     return rule;
                 }
             }
+            winston.verbose(`Rule '${ruleName}' doesn't exist`);
             return null;
         });
 }
@@ -97,12 +102,15 @@ exports.removeTargets = function (ruleName, targets) {
         Ids: targetIds,
         Rule: ruleName
     };
+    winston.verbose(`Removing targets from '${ruleName}'`);
     return cloudWatchEvents.removeTargets(deleteParams).promise()
         .then(removeResponse => {
             if (removeResponse.FailedEntryCount > 0) {
+                winston.verbose(`Finished removing targets from '${ruleName}'`);
                 return false;
             }
             else {
+                winston.verbose(`One or more targets was not successfully removed from '${ruleName}'`);
                 return true;
             }
         });
@@ -113,10 +121,15 @@ exports.removeTargets = function (ruleName, targets) {
  * Removes all targets from the given event rule
  */
 exports.removeAllTargets = function (ruleName) {
+    winston.info(`Removing all targets from '${ruleName}'`);
     return exports.getTargets(ruleName)
         .then(targets => {
             if (targets.length > 0) {
                 return exports.removeTargets(ruleName, targets)
+                    .then(result => {
+                        winston.verbose(`Finished removing all targets from '${ruleName}'`);
+                        return result;
+                    });
             }
             else {
                 return true;

--- a/lib/aws/ec2-calls.js
+++ b/lib/aws/ec2-calls.js
@@ -40,15 +40,15 @@ exports.getSecurityGroup = function (groupName, vpcId) {
             }
         ]
     }
-    winston.debug(`Getting security group ${groupName} in VPC ${vpcId}`);
+    winston.verbose(`Getting security group ${groupName} in VPC ${vpcId}`);
     return ec2.describeSecurityGroups(describeSgParams).promise()
         .then(describeResults => {
             if (describeResults['SecurityGroups'].length > 0) {
-                winston.debug(`Found security group ${groupName} in VPC ${vpcId}`);
+                winston.verbose(`Found security group ${groupName} in VPC ${vpcId}`);
                 return describeResults['SecurityGroups'][0];
             }
             else {
-                winston.debug(`Security group ${groupName} does not exist in VPC ${vpcId}`);
+                winston.verbose(`Security group ${groupName} does not exist in VPC ${vpcId}`);
                 return null;
             }
         });
@@ -74,15 +74,15 @@ exports.getSecurityGroupById = function (groupId, vpcId) {
             }
         ]
     }
-    winston.debug(`Getting security group ${groupId} in VPC ${vpcId}`);
+    winston.verbose(`Getting security group ${groupId} in VPC ${vpcId}`);
     return ec2.describeSecurityGroups(describeSgParams).promise()
         .then(describeResults => {
             if (describeResults['SecurityGroups'].length > 0) {
-                winston.debug(`Found security group ${groupId} in VPC ${vpcId}`);
+                winston.verbose(`Found security group ${groupId} in VPC ${vpcId}`);
                 return describeResults['SecurityGroups'][0];
             }
             else {
-                winston.debug(`Security group ${groupId} does not exist in VPC ${vpcId}`);
+                winston.verbose(`Security group ${groupId} does not exist in VPC ${vpcId}`);
                 return null;
             }
         });
@@ -194,10 +194,10 @@ exports.addIngressRuleToSecurityGroup = function (sourceSg, destSg,
             }
         ]
     };
-    winston.debug(`Adding ingress rule to security group ${destSg.GroupId} from group ${sourceSg.GroupId}`);
+    winston.verbose(`Adding ingress rule to security group ${destSg.GroupId} from group ${sourceSg.GroupId}`);
     return ec2.authorizeSecurityGroupIngress(addIngressParams).promise()
         .then(authorizeResult => {
-            winston.debug(`Added ingress rule to security group ${destSg.GroupId} from group ${sourceSg.GroupId}`);
+            winston.verbose(`Added ingress rule to security group ${destSg.GroupId} from group ${sourceSg.GroupId}`);
             return exports.getSecurityGroup(destSg['GroupName'], vpcId);
         });
 }
@@ -217,6 +217,7 @@ exports.getLatestAmiByName = function (owner, nameSubstring) {
             Values: [`*${nameSubstring}*`]
         }]
     }
+    winston.verbose(`Getting latest AMI for owner '${owner}' with substring '${nameSubstring}'`);
     return ec2.describeImages(describeParams).promise()
         .then(describeResult => {
             let images = describeResult.Images;
@@ -232,6 +233,7 @@ exports.getLatestAmiByName = function (owner, nameSubstring) {
                         latestImage = image;
                     }
                 }
+                winston.verbose(`Found AMI '${latestImage.ImageId}'`);
                 return latestImage;
             }
         });

--- a/lib/aws/iam-calls.js
+++ b/lib/aws/iam-calls.js
@@ -43,10 +43,10 @@ exports.createRole = function (roleName, trustedService) {
         Path: "/services/",
         RoleName: roleName
     };
-    winston.debug(`Creating role ${roleName}`);
+    winston.verbose(`Creating role ${roleName}`);
     return iam.createRole(createParams).promise()
         .then(createResponse => {
-            winston.debug(`Created role ${roleName}`);
+            winston.verbose(`Created role ${roleName}`);
             return createResponse.Role;
         });
 }
@@ -60,15 +60,15 @@ exports.getRole = function (roleName) {
     var getParams = {
         RoleName: roleName
     };
-    winston.debug(`Attempting to find role ${roleName}`);
+    winston.verbose(`Attempting to find role ${roleName}`);
     return iam.getRole(getParams).promise()
         .then(role => {
-            winston.debug(`Found role ${roleName}`);
+            winston.verbose(`Found role ${roleName}`);
             return role.Role;
         })
         .catch(err => {
             if (err.code === 'NoSuchEntity') {
-                winston.debug(`Role ${roleName} does not exist`);
+                winston.verbose(`Role ${roleName} does not exist`);
                 return null
             }
             throw err;
@@ -100,15 +100,15 @@ exports.getPolicy = function (policyArn) {
     var params = {
         PolicyArn: policyArn
     };
-    winston.debug(`Attempting to find policy ${policyArn}`);
+    winston.verbose(`Attempting to find policy ${policyArn}`);
     return iam.getPolicy(params).promise()
         .then(policy => {
-            winston.debug(`Found policy ${policyArn}`);
+            winston.verbose(`Found policy ${policyArn}`);
             return policy.Policy;
         })
         .catch(err => {
             if (err.code === 'NoSuchEntity') {
-                winston.debug(`Policy ${policyArn} does not exist`);
+                winston.verbose(`Policy ${policyArn} does not exist`);
                 return null;
             }
             throw err;
@@ -128,10 +128,10 @@ exports.createPolicy = function (policyName, policyDocument) {
         Description: `Auto-generated policy for the service ${policyName}`,
         Path: '/services/'
     };
-    winston.debug(`Creating policy ${policyName}`);
+    winston.verbose(`Creating policy ${policyName}`);
     return iam.createPolicy(createParams).promise()
         .then(createResponse => {
-            winston.debug(`Created new policy ${policyName}`)
+            winston.verbose(`Created new policy ${policyName}`)
             return createResponse.Policy;
         });
 }
@@ -143,7 +143,7 @@ exports.createPolicy = function (policyName, policyDocument) {
  */
 exports.createPolicyVersion = function (policyArn, policyDocument) {
     const iam = new AWS.IAM({ apiVersion: '2010-05-08' });
-    winston.debug(`Creating new policy version for ${policyArn}`)
+    winston.verbose(`Creating new policy version for ${policyArn}`)
     var createVersionParams = {
         PolicyArn: policyArn,
         PolicyDocument: JSON.stringify(policyDocument),
@@ -151,7 +151,7 @@ exports.createPolicyVersion = function (policyArn, policyDocument) {
     };
     return iam.createPolicyVersion(createVersionParams).promise()
         .then(createVersionResponse => {
-            winston.debug(`Created new policy version for ${policyArn}`)
+            winston.verbose(`Created new policy version for ${policyArn}`)
             return createVersionResponse.PolicyVersion;
         });
 }
@@ -162,7 +162,7 @@ exports.createPolicyVersion = function (policyArn, policyDocument) {
  */
 exports.deleteAllPolicyVersionsButProvided = function (policyArn, policyVersionToKeep) {
     const iam = new AWS.IAM({ apiVersion: '2010-05-08' });
-    winston.debug(`Deleting all old policy versions for ${policyArn} but ${policyVersionToKeep.VersionId}`);
+    winston.verbose(`Deleting all old policy versions for ${policyArn} but ${policyVersionToKeep.VersionId}`);
     var listPolicyVersionsParams = {
         PolicyArn: policyArn
     };
@@ -182,7 +182,7 @@ exports.deleteAllPolicyVersionsButProvided = function (policyArn, policyVersionT
             return Promise.all(deletePolicyPromises);
         })
         .then(deleteResponses => {
-            winston.debug(`Deleted all old policy versions for ${policyArn} but ${policyVersionToKeep.VersionId}`)
+            winston.verbose(`Deleted all old policy versions for ${policyArn} but ${policyVersionToKeep.VersionId}`)
             return policyVersionToKeep; //Return kept version
         });
 }
@@ -192,14 +192,14 @@ exports.deleteAllPolicyVersionsButProvided = function (policyArn, policyVersionT
  */
 exports.attachPolicyToRole = function (policyArn, roleName) {
     const iam = new AWS.IAM({ apiVersion: '2010-05-08' });
-    winston.debug(`Attaching policy ${policyArn} to role ${roleName}`)
+    winston.verbose(`Attaching policy ${policyArn} to role ${roleName}`)
     var params = {
         PolicyArn: policyArn,
         RoleName: roleName
     };
     return iam.attachRolePolicy(params).promise()
         .then(attachResponse => {
-            winston.debug(`Attached policy ${policyArn} to role ${roleName}`)
+            winston.verbose(`Attached policy ${policyArn} to role ${roleName}`)
             return attachResponse;
         });
 }
@@ -265,18 +265,15 @@ exports.constructPolicyDoc = function (policyStatements) {
  * 
  * This method is used to determine the account id
  */
-exports.showAccount = function()
-{
-  const iam = new AWS.IAM({ apiVersion: '2010-05-08' });
-  let parmLstRoles = { MaxItems: 1 };
-  winston.debug('List roles',parmLstRoles);
-  return iam.listRoles(parmLstRoles).promise()
-    .then( rsp =>
-    {
-      winston.debug('Roles','\n'+JSON.stringify(rsp,null,2));
-      if(!rsp||!rsp.Roles||rsp.Roles.length<1||!rsp.Roles[0].Arn||rsp.Roles[0].Arn.indexOf('arn:aws:iam::')!=0) return null;
-      let acctId = rsp.Roles[0].Arn.split(':')[4];
-      return acctId;
-    }
-  );
+exports.showAccount = function () {
+    const iam = new AWS.IAM({ apiVersion: '2010-05-08' });
+    let parmLstRoles = { MaxItems: 1 };
+    winston.verbose('Finding account ID');
+    return iam.listRoles(parmLstRoles).promise()
+        .then(rsp => {
+            if (!rsp || !rsp.Roles || rsp.Roles.length < 1 || !rsp.Roles[0].Arn || rsp.Roles[0].Arn.indexOf('arn:aws:iam::') != 0) { return null };
+            let acctId = rsp.Roles[0].Arn.split(':')[4];
+            winston.verbose(`Found account ID: ${acctId}`);
+            return parseInt(acctId, 10);
+        });
 }

--- a/lib/aws/lambda-calls.js
+++ b/lib/aws/lambda-calls.js
@@ -42,10 +42,10 @@ exports.addLambdaPermission = function (functionName, principal, sourceArn) {
         StatementId: `${uuid()}`
     };
 
-    winston.debug(`Adding Lambda permission to ${functionName}`);
+    winston.verbose(`Adding Lambda permission to ${functionName}`);
     return lambda.addPermission(addPermissionParams).promise()
         .then(response => {
-            winston.debug(`Added Lambda permission to ${functionName}`);
+            winston.verbose(`Added Lambda permission to ${functionName}`);
             return exports.getLambdaPermission(functionName, principal, sourceArn);
         });
 }
@@ -57,22 +57,22 @@ exports.getLambdaPermission = function (functionName, principal, sourceArn) {
         FunctionName: functionName
     };
 
-    winston.debug(`Attempting to find permission ${sourceArn} in function ${functionName}`);
+    winston.verbose(`Attempting to find permission ${sourceArn} in function ${functionName}`);
     return lambda.getPolicy(getParams).promise()
         .then(getPolicyResponse => {
             let policy = JSON.parse(getPolicyResponse.Policy);
             for (let statement of policy.Statement) {
                 if (statementIsSame(functionName, principal, sourceArn, statement)) {
-                    winston.debug(`Found permission ${sourceArn} in function ${functionName}`);
+                    winston.verbose(`Found permission ${sourceArn} in function ${functionName}`);
                     return statement;
                 }
             }
-            winston.debug(`Permission ${sourceArn} in function ${functionName} does not exist`);
+            winston.verbose(`Permission ${sourceArn} in function ${functionName} does not exist`);
             return null;
         })
         .catch(err => {
             if (err.code === 'ResourceNotFoundException') {
-                winston.debug(`Permission ${sourceArn} in function ${functionName} does not exist`);
+                winston.verbose(`Permission ${sourceArn} in function ${functionName} does not exist`);
                 return null;
             }
             throw err; //Throw error on any other kind of error

--- a/lib/aws/s3-calls.js
+++ b/lib/aws/s3-calls.js
@@ -58,7 +58,7 @@ exports.deleteMatchingPrefix = function(bucketName,prefix)
   };
   return s3.listObjectsV2(parms).promise()
     .then(data=>{
-      winston.debug('Delete list',data);
+      winston.verbose('Delete list',data);
       let parmDelete = {
         Bucket: data.Name,
         Delete: {
@@ -68,17 +68,17 @@ exports.deleteMatchingPrefix = function(bucketName,prefix)
       };
       for(let fl of data.Contents)
       {
-        winston.debug(`Deleting service file ${fl.Key} from ${data.Name}`);
+        winston.verbose(`Deleting service file ${fl.Key} from ${data.Name}`);
         parmDelete.Delete.Objects.push({Key:fl.Key});
       }
       return parmDelete;
     })
     .then(pDel=>{
-      winston.debug('Delete',pDel);
+      winston.verbose('Delete',pDel);
       if(pDel.Delete.Objects.length==0)return null;
       return s3.deleteObjects(pDel).promise()
       .then(rc=>{
-        winston.debug('Delete results',rc);
+        winston.verbose('Delete results',rc);
         return rc;
       });
     })
@@ -103,10 +103,10 @@ exports.uploadFile = function (bucketName, key, filePath) {
         Body: fileStream
     }
 
-    winston.debug(`Uploading file ${filePath} to ${bucketName}/${key}`);
+    winston.verbose(`Uploading file ${filePath} to ${bucketName}/${key}`);
     return s3.upload(uploadParams).promise()
         .then(uploadResponse => {
-            winston.debug(`Uploaded file ${filePath} to ${bucketName}/${key}`);
+            winston.verbose(`Uploaded file ${filePath} to ${bucketName}/${key}`);
             return uploadResponse;
         });
 }
@@ -224,10 +224,10 @@ exports.createBucket = function (bucketName, region) {
             LocationConstraint: region
         }
     }
-    winston.debug(`Creating S3 bucket ${bucketName}`);
+    winston.verbose(`Creating S3 bucket ${bucketName}`);
     return s3.createBucket(createParams).promise()
         .then(bucket => {
-            winston.debug(`Created S3 bucket ${bucketName}`);
+            winston.verbose(`Created S3 bucket ${bucketName}`);
             return bucket;
         });
 }
@@ -238,17 +238,17 @@ exports.createBucket = function (bucketName, region) {
  */
 exports.getBucket = function (bucketName) {
     let s3 = new AWS.S3({ apiVersion: '2006-03-01' });
-    winston.debug(`Getting S3 bucket ${bucketName}`)
+    winston.verbose(`Getting S3 bucket ${bucketName}`)
     return s3.listBuckets().promise()
         .then(listResponse => {
             let buckets = listResponse.Buckets;
             for (let bucket of buckets) {
                 if (bucket.Name === bucketName) {
-                    winston.debug(`Found bucket ${bucketName}`);
+                    winston.verbose(`Found bucket ${bucketName}`);
                     return bucket;
                 }
             }
-            winston.debug(`Bucket ${bucketName} does not exist`);
+            winston.verbose(`Bucket ${bucketName} does not exist`);
             return null;
         })
 }

--- a/lib/aws/sns-calls.js
+++ b/lib/aws/sns-calls.js
@@ -24,10 +24,10 @@ exports.subscribeToTopic = function (topicArn, protocol, endpoint) {
         TopicArn: topicArn,
         Endpoint: endpoint
     };
-    winston.debug(`Subscribing ${endpoint} to SNS topic ${topicArn}`);
+    winston.verbose(`Subscribing ${endpoint} to SNS topic ${topicArn}`);
     return sns.subscribe(subscribeParams).promise()
         .then(subscribeResponse => {
-            winston.debug(`Subscribed ${endpoint} to SNS topic ${topicArn}`);
+            winston.verbose(`Subscribed ${endpoint} to SNS topic ${topicArn}`);
             return subscribeResponse.SubscriptionArn;
         });
 }

--- a/lib/aws/sqs-calls.js
+++ b/lib/aws/sqs-calls.js
@@ -72,10 +72,10 @@ exports.addSqsPermission = function (queueUrl, queueArn, sourceArn, policyStatem
                 },
                 QueueUrl: queueUrl
             };
-            winston.debug(`Adding permission to SQS queue ${queueUrl} from ${sourceArn}`);
+            winston.verbose(`Adding permission to SQS queue ${queueUrl} from ${sourceArn}`);
             return sqs.setQueueAttributes(setQueueAttributesParams).promise()
                 .then(queueAttributesResponse => {
-                    winston.debug(`Added permission to SQS queue ${queueUrl} from ${sourceArn}`);
+                    winston.verbose(`Added permission to SQS queue ${queueUrl} from ${sourceArn}`);
                     return queueAttributesResponse;
                 });
         });
@@ -83,22 +83,22 @@ exports.addSqsPermission = function (queueUrl, queueArn, sourceArn, policyStatem
 
 exports.getSqsPermission = function (queueUrl, policyStatementToGet) {
     let sqs = new AWS.SQS({ apiVersion: '2012-11-05' });
-    winston.debug(`Attempting to find permission in policy doc for ${queueUrl}`);
+    winston.verbose(`Attempting to find permission in policy doc for ${queueUrl}`);
     return getSqsQueuePolicyDoc(sqs, queueUrl)
         .then(policyDoc => {
             if (policyDoc) {
                 let permissionFromPolicyDoc = getPermissionInPolicyDoc(policyDoc, policyStatementToGet);
                 if (permissionFromPolicyDoc) {
-                    winston.debug(`Found permission in policy doc for ${queueUrl}`);
+                    winston.verbose(`Found permission in policy doc for ${queueUrl}`);
                     return permissionFromPolicyDoc;
                 }
                 else {
-                    winston.debug(`Permission does not exist in policy doc for ${queueUrl}`);
+                    winston.verbose(`Permission does not exist in policy doc for ${queueUrl}`);
                     return null;
                 }
             }
             else {
-                winston.debug(`No policy defined for ${queueUrl}`);
+                winston.verbose(`No policy defined for ${queueUrl}`);
                 return null;
             }
         });

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -23,6 +23,7 @@ const path = require('path');
 const winston = require('winston');
 const util = require('../common/util');
 const inquirer = require('inquirer');
+const IAM = require('../aws/iam-calls');
 
 function getAbsoluteConfigFilePath(filePath) {
     var absolutePath;
@@ -36,13 +37,56 @@ function getAbsoluteConfigFilePath(filePath) {
     return absolutePath;
 }
 
-function setLogLevel(argv) {
+function configureLogger(argv) {
+    let level = "info";
     if (argv.d) {
-        winston.level = 'debug';
+        level = 'debug';
+    }
+    winston.level = level;
+    winston.cli();
+}
+
+function logCaughtError(msg, err) {
+    winston.error(`${msg}: ${err.message}`);
+    if (winston.level === 'debug') {
+        winston.error(err);
+    }
+}
+
+function logFinalResult(lifecycleName, envResults) {
+    let success = true;
+    for (let envResult of envResults) {
+        if (envResult.status !== 'success') {
+            winston.error(`Error during environment ${lifecycleName}: ${envResult.message}`);
+            if (winston.level === 'debug') {
+                winston.error(envResult.error);
+            }
+            success = false;
+        }
+    }
+
+    if (success) {
+        winston.info(`Finished ${lifecycleName} successfully`);
     }
     else {
-        winston.level = 'info';
+        winston.error(`Finished ${lifecycleName} with errors`);
+        process.exit(1);
     }
+}
+
+function validateCredentials(accountConfig) {
+    let deployAccount = accountConfig.account_id;
+    winston.debug(`Checking that current credentials match account ${deployAccount}`);
+    return IAM.showAccount().then(discoveredId => {
+        winston.debug(`Currently logged in under account ${discoveredId}`);
+        if (deployAccount === discoveredId) { 
+            return;
+        }
+        else {
+            winston.error(`You are trying to deploy to the account ${deployAccount}, but you are logged into the account ${discoveredId}`);
+            process.exit(1);
+        }        
+    });
 }
 
 function getAccountConfigFilePath(configFilePath) {
@@ -185,35 +229,21 @@ exports.validateDeleteArgs = function (argv, handelFile) {
  * Handel CLI. It goes and deploys the requested environment(s) to AWS.
  */
 exports.deployAction = function (handelFile, argv) {
-    setLogLevel(argv);
+    configureLogger(argv);
     let accountConfig = loadAccountConfig(argv.c);
     let deployVersion = argv.v;
     let environmentsToDeploy = argv.e.split(',');
-    deployLifecycle.deploy(accountConfig, handelFile, environmentsToDeploy, deployVersion)
+    validateCredentials(accountConfig)
+        .then(() => {
+            return deployLifecycle.deploy(accountConfig, handelFile, environmentsToDeploy, deployVersion)
+        })
         .then(envDeployResults => {
-            let success = true;
-            for (let envDeployResult of envDeployResults) {
-                if (envDeployResult.status !== 'success') {
-                    winston.warn(`Error while deploying environment: ${envDeployResult.message}`);
-                    if (winston.level === 'debug') {
-                        winston.warn(envDeployResult.error);
-                    }
-                    success = false;
-                }
-            }
-
-            if (success) {
-                winston.info("Finished deploying everything successfully");
-            }
-            else {
-                winston.warn("Finished deployment with errors");
-                process.exit(1);
-            }
+            logFinalResult('deploy', envDeployResults);
         })
         .catch(err => {
-            winston.warn(err);
+            logCaughtError("Unexpected error occurred during deploy", err);
             process.exit(1);
-        })
+        });
 }
 
 /**
@@ -221,7 +251,8 @@ exports.deployAction = function (handelFile, argv) {
  * Handel CLI. It goes and validates the Handel file so you can see if the file looks
  * correct
  */
-exports.checkAction = function (handelFile) {
+exports.checkAction = function (handelFile, argv) {
+    configureLogger(argv); //Don't enable debug on check?
     let errors = checkLifecycle.check(handelFile);
     let foundErrors = false;
     for (let env in errors) {
@@ -243,26 +274,21 @@ exports.checkAction = function (handelFile) {
  * Handel CLI. It asks for a confirmation, then deletes the requested environment.
  */
 exports.deleteAction = function (handelFile, argv) {
-    setLogLevel(argv);
+    configureLogger(argv);
     let accountConfig = loadAccountConfig(argv.c);
     let environmentToDelete = argv.e;
-    confirmDelete(environmentToDelete, argv.d)
+    validateCredentials(accountConfig)
+        .then(() => {
+            return confirmDelete(environmentToDelete, argv.d);
+        })
         .then(confirmDelete => {
             if (confirmDelete) {
                 deleteLifecycle.delete(accountConfig, handelFile, environmentToDelete)
                     .then(envDeleteResult => {
-                        if (envDeleteResult.status !== 'success') {
-                            winston.warn(`Error while deleting environment: ${envDeleteResult.message}`);
-                            winston.warn(envDeleteResult.error);
-                            winston.warn("Finished deletion with errors");
-                            process.exit(1);
-                        }
-                        else {
-                            winston.info("Finished deleting everything successfully");
-                        }
+                        logFinalResult('delete', [envDeleteResult]);
                     })
                     .catch(err => {
-                        winston.warn(err);
+                        logCaughtError("Unexpected error occurred during delete", err);
                         process.exit(1);
                     })
             }

--- a/lib/common/bind-phase-common.js
+++ b/lib/common/bind-phase-common.js
@@ -29,7 +29,7 @@ exports.bindDependentSecurityGroupToSelf = function (ownServiceContext,
     serviceName) {
         
     let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
-    winston.info(`${serviceName} - Executing Bind on ${stackName}`);
+    winston.info(`${serviceName} - Binding security group from '${dependentOfServiceContext.serviceName}' to '${ownServiceContext.serviceName}'`);
     let ownSg = ownPreDeployContext.securityGroups[0];
     let sourceSg = dependentOfPreDeployContext.securityGroups[0];
 
@@ -37,12 +37,12 @@ exports.bindDependentSecurityGroupToSelf = function (ownServiceContext,
         protocol, port,
         port, accountConfig['vpc'])
         .then(efsSecurityGroup => {
-            winston.info(`${serviceName} - Finished Bind on ${stackName}`);
+            winston.info(`${serviceName} - Finished binding security group from '${dependentOfServiceContext.serviceName}' to '${ownServiceContext.serviceName}'`);
             return new BindContext(ownServiceContext, dependentOfServiceContext);
         });
 }
 
 exports.bindNotRequired = function (ownServiceContext, dependentOfServiceContext, serviceName) {
-    winston.info(`${serviceName} - Bind is not required for this service, skipping it`);
+    winston.debug(`${serviceName} - Bind is not required for this service, skipping it`);
     return Promise.resolve(new BindContext(ownServiceContext, dependentOfServiceContext));
 }

--- a/lib/common/delete-phases-common.js
+++ b/lib/common/delete-phases-common.js
@@ -47,16 +47,16 @@ function deleteSecurityGroupForService(stackName) {
 
 exports.unDeployService = function (serviceContext, serviceType) {
     let stackName = deployPhaseCommon.getResourceName(serviceContext);
-    winston.info(`${serviceType} - Executing UnDeploy on '${stackName}'`)
+    winston.info(`${serviceType} - Undeploying service '${stackName}'`)
 
     return cloudformationCalls.getStack(stackName)
         .then(stack => {
             if (stack) {
-                winston.info(`${serviceType} - Deleting stack '${stackName}'`);
+                winston.debug(`${serviceType} - Deleting stack '${stackName}'`);
                 return cloudformationCalls.deleteStack(stackName);
             }
             else {
-                winston.info(`${serviceType} - Stack '${stackName}' has already been deleted`);
+                winston.debug(`${serviceType} - Stack '${stackName}' has already been deleted`);
             }
         })
         .then(() => {
@@ -67,43 +67,44 @@ exports.unDeployService = function (serviceContext, serviceType) {
           return s3Calls.deleteMatchingPrefix(name.bucket,name.prefix);
         })
         .then(() => {
+            winston.info(`${serviceType} -- Finished undeploying service '${stackName}'`)
             return new UnDeployContext(serviceContext);
         });
 }
 
 exports.unPreDeploySecurityGroup = function (ownServiceContext, serviceName) {
     let sgName = deployPhaseCommon.getResourceName(ownServiceContext);
-    winston.info(`${serviceName} - Executing UnPreDeploy on '${sgName}'`);
+    winston.info(`${serviceName} - Deleting security group '${sgName}'`);
 
     return deleteSecurityGroupForService(sgName)
         .then(success => {
-            winston.info(`${serviceName} - Finished UnPreDeploy on '${sgName}'`);
+            winston.info(`${serviceName} - Finished deleting security group '${sgName}'`);
             return new UnPreDeployContext(ownServiceContext);
         });
 }
 
 exports.unBindSecurityGroups = function (ownServiceContext, serviceName) {
     let sgName = deployPhaseCommon.getResourceName(ownServiceContext);
-    winston.info(`${serviceName} - Executing UnBind on ${sgName}`);
+    winston.info(`${serviceName} - Unbinding security group '${sgName}'`);
 
     return unBindAllOnSg(sgName)
         .then(success => {
-            winston.info(`${serviceName} - Finished UnBind on ${sgName}`);
+            winston.info(`${serviceName} - Finished unbinding seucrity group '${sgName}'`);
             return new UnBindContext(ownServiceContext);
         });
 }
 
 exports.unPreDeployNotRequired = function (ownServiceContext, serviceName) {
-    winston.info(`${serviceName} - UnPreDeploy is not required for this service`);
+    winston.debug(`${serviceName} - UnPreDeploy is not required for this service`);
     return Promise.resolve(new UnPreDeployContext(ownServiceContext));
 }
 
 exports.unBindNotRequired = function (ownServiceContext, serviceName) {
-    winston.info(`${serviceName} - UnBind is not required for this service`);
+    winston.debug(`${serviceName} - UnBind is not required for this service`);
     return Promise.resolve(new UnBindContext(ownServiceContext));
 }
 
 exports.unDeployNotRequired = function (ownServiceContext, serviceName) {
-    winston.info(`${serviceName} - UnDeploy is not required for this service`);
+    winston.debug(`${serviceName} - UnDeploy is not required for this service`);
     return Promise.resolve(new UnDeployContext(ownServiceContext));
 }

--- a/lib/common/deploy-phase-common.js
+++ b/lib/common/deploy-phase-common.js
@@ -114,12 +114,12 @@ exports.deployCloudFormationStack = function (stackName, cfTemplate, cfParameter
     return cloudformationCalls.getStack(stackName)
         .then(stack => {
             if (!stack) {
-                winston.info(`${serviceType} - Creating stack '${stackName}'`);
+                winston.debug(`${serviceType} - Creating stack '${stackName}'`);
                 return cloudformationCalls.createStack(stackName, cfTemplate, cfParameters, stackTags);
             }
             else {
                 if (updatesSupported) {
-                    winston.info(`${serviceType} - Updating stack '${stackName}'`);
+                    winston.debug(`${serviceType} - Updating stack '${stackName}'`);
                     return cloudformationCalls.updateStack(stackName, cfTemplate, cfParameters, stackTags);
                 }
                 else {
@@ -215,6 +215,6 @@ exports.getTags = function (serviceContext) {
 }
 
 exports.deployNotRequired = function (ownServiceContext, serviceName) {
-    winston.info(`${serviceName} - Deploy is not required for this service, skipping it`);
+    winston.debug(`${serviceName} - Deploy is not required for this service, skipping it`);
     return Promise.resolve(new DeployContext(ownServiceContext));
 }

--- a/lib/common/pre-deploy-phase-common.js
+++ b/lib/common/pre-deploy-phase-common.js
@@ -53,11 +53,11 @@ function createSecurityGroupForService(stackName, sshBastionIngressPort) {
 
 exports.preDeployCreateSecurityGroup = function (serviceContext, sshBastionIngressPort, serviceName) {
     let sgName = deployPhaseCommon.getResourceName(serviceContext);
-    winston.info(`${serviceName} - Executing PreDeploy on ${sgName}`);
+    winston.info(`${serviceName} - Creating security group '${sgName}'`);
 
     return createSecurityGroupForService(sgName, sshBastionIngressPort)
         .then(securityGroup => {
-            winston.info(`${serviceName} - Finished PreDeploy on ${sgName}`);
+            winston.info(`${serviceName} - Finished creating security group '${sgName}'`);
             let preDeployContext = new PreDeployContext(serviceContext);
             preDeployContext.securityGroups.push(securityGroup);
             return preDeployContext;
@@ -65,7 +65,7 @@ exports.preDeployCreateSecurityGroup = function (serviceContext, sshBastionIngre
 }
 
 exports.preDeployNotRequired = function (serviceContext, serviceName) {
-    winston.info(`${serviceName} - PreDeploy is not required for this service, skipping it`);
+    winston.debug(`${serviceName} - PreDeploy is not required for this service, skipping it`);
     return Promise.resolve(new PreDeployContext(serviceContext));
 }
 

--- a/lib/common/util.js
+++ b/lib/common/util.js
@@ -20,7 +20,6 @@ const yaml = require('js-yaml');
 const archiver = require('archiver');
 const winston = require('winston');
 const AWS = require('aws-sdk');
-const IAM = require('../aws/iam-calls');
 const ncp = require('ncp').ncp;
 ncp.limit = 16;
 
@@ -189,7 +188,7 @@ exports.createEnvironmentContext = function (handelFile, handelFileParser, envir
 
 
 exports.configureAwsSdk = function (accountConfig) {
-    AWS.config.update({ 
+    AWS.config.update({
         region: accountConfig.region,
         maxRetries: 10
     });
@@ -231,28 +230,17 @@ exports.copyDirectory = function (sourceDir, targetDir) {
 /**
  * Courtesy of https://stackoverflow.com/a/32197381/1031406
  */
-exports.deleteFolderRecursive = function(path) {
-  if( fs.existsSync(path) ) {
-    fs.readdirSync(path).forEach(function(file,index){
-      var curPath = path + "/" + file;
-      if(fs.lstatSync(curPath).isDirectory()) { // recurse
-        exports.deleteFolderRecursive(curPath);
-      } else { // delete file
-        fs.unlinkSync(curPath);
-      }
-    });
-    fs.rmdirSync(path);
-  }
-};
-
-exports.validateCredentials = function(accountConfig) {
-  winston.info('Check current credentials',accountConfig.account_id);
-  return IAM.showAccount().then(discoveredId=>{
-    winston.info('Check current credentials',accountConfig.account_id,'discovered',discoveredId);
-    if(accountConfig.account_id==discoveredId) return;
-    let err = new Error('Account number mismatch. The account config file specified does not match the account you are logged into.');
-    err.name = 'HandelAcct';
-    throw err;
-  });
+exports.deleteFolderRecursive = function (path) {
+    if (fs.existsSync(path)) {
+        fs.readdirSync(path).forEach(function (file, index) {
+            var curPath = path + "/" + file;
+            if (fs.lstatSync(curPath).isDirectory()) { // recurse
+                exports.deleteFolderRecursive(curPath);
+            } else { // delete file
+                fs.unlinkSync(curPath);
+            }
+        });
+        fs.rmdirSync(path);
+    }
 };
 

--- a/lib/lifecycles/check.js
+++ b/lib/lifecycles/check.js
@@ -45,7 +45,7 @@ exports.check = function (handelFile) {
     let serviceDeployers = util.getServiceDeployers();
 
     //Load Handel file from path and validate it
-    winston.info("Validating and parsing Handel file");
+    winston.debug("Validating and parsing Handel file");
     let handelFileParser = util.getHandelFileParser(handelFile);
     handelFileParser.validateHandelFile(handelFile, serviceDeployers);
 

--- a/lib/lifecycles/delete.js
+++ b/lib/lifecycles/delete.js
@@ -73,26 +73,23 @@ function deleteEnvironment(accountConfig, serviceDeployers, environmentContext) 
 }
 
 exports.delete = function (newAccountConfig, handelFile, environmentToDelete) {
-  return Promise.resolve().then( () => {
-    //Pull account-level config from the provided file so it can be consumed by the library
-    let accountConfig = config(newAccountConfig).getAccountConfig();
+    return Promise.resolve().then(() => {
+        //Pull account-level config from the provided file so it can be consumed by the library
+        let accountConfig = config(newAccountConfig).getAccountConfig();
 
-    //Set up AWS SDK with any global options
-    util.configureAwsSdk(accountConfig);
+        //Set up AWS SDK with any global options
+        util.configureAwsSdk(accountConfig);
 
-    //Load all the currently implemented service deployers from the 'services' directory
-    let serviceDeployers = util.getServiceDeployers();
+        //Load all the currently implemented service deployers from the 'services' directory
+        let serviceDeployers = util.getServiceDeployers();
 
-    //Load Handel file from path and validate it
-    winston.info("Validating and parsing Handel file");
-    let handelFileParser = util.getHandelFileParser(handelFile);
-    handelFileParser.validateHandelFile(handelFile, serviceDeployers);
+        //Load Handel file from path and validate it
+        winston.debug("Validating and parsing Handel file");
+        let handelFileParser = util.getHandelFileParser(handelFile);
+        handelFileParser.validateHandelFile(handelFile, serviceDeployers);
 
-    //Check current credentials against the accountConfig
-    return util.validateCredentials(accountConfig).then( () => {
-      //Run the delete on the environment specified
-      let environmentContext = util.createEnvironmentContext(handelFile, handelFileParser, environmentToDelete, "1"); //Use fake version since we're deleting it
-      return deleteEnvironment(accountConfig, serviceDeployers, environmentContext);
+        //Run the delete on the environment specified
+        let environmentContext = util.createEnvironmentContext(handelFile, handelFileParser, environmentToDelete, "1"); //Use fake version since we're deleting it
+        return deleteEnvironment(accountConfig, serviceDeployers, environmentContext);
     });
-  });
 };

--- a/lib/lifecycles/deploy.js
+++ b/lib/lifecycles/deploy.js
@@ -77,7 +77,7 @@ function deployEnvironment(accountConfig, serviceDeployers, environmentContext) 
         return Promise.resolve(new EnvironmentDeployResult("failure", "Invalid configuration"));
     }
     else {
-        winston.info(`Starting deploy for environment ${environmentContext.environmentName}, version ${environmentContext.deployVersion}`);
+        winston.info(`Starting deploy for environment ${environmentContext.environmentName}`);
 
         let errors = checkPhase.checkServices(serviceDeployers, environmentContext);
         if (errors.length === 0) {
@@ -105,29 +105,27 @@ function deployEnvironment(accountConfig, serviceDeployers, environmentContext) 
 }
 
 exports.deploy = function (newAccountConfig, handelFile, environmentsToDeploy, deployVersion) {
-  return Promise.resolve().then( () => {
-    //Pull account-level config from the provided file so it can be consumed by the library
-    let accountConfig = config(newAccountConfig).getAccountConfig();
+    return Promise.resolve().then(() => {
+        //Pull account-level config from the provided file so it can be consumed by the library
+        let accountConfig = config(newAccountConfig).getAccountConfig();
 
-    //Set up AWS SDK with any global options
-    util.configureAwsSdk(accountConfig);
+        //Set up AWS SDK with any global options
+        util.configureAwsSdk(accountConfig);
 
-    //Load all the currently implemented service deployers from the 'services' directory
-    let serviceDeployers = util.getServiceDeployers();
+        //Load all the currently implemented service deployers from the 'services' directory
+        let serviceDeployers = util.getServiceDeployers();
 
-    //Load Handel file from path and validate it
-    winston.info("Validating and parsing Handel file");
-    let handelFileParser = util.getHandelFileParser(handelFile);
-    handelFileParser.validateHandelFile(handelFile, serviceDeployers);
+        //Load Handel file from path and validate it
+        winston.debug("Validating and parsing Handel file");
+        let handelFileParser = util.getHandelFileParser(handelFile);
+        handelFileParser.validateHandelFile(handelFile, serviceDeployers);
 
-    //Check current credentials against the accountConfig
-    return util.validateCredentials(accountConfig).then( () => {
-      let envDeployPromises = [];
-      for (let environmentToDeploy of environmentsToDeploy) {
-        let environmentContext = util.createEnvironmentContext(handelFile, handelFileParser, environmentToDeploy, deployVersion);
-        envDeployPromises.push(deployEnvironment(accountConfig, serviceDeployers, environmentContext));
-      }
-      return Promise.all(envDeployPromises);
+        //Check current credentials against the accountConfig
+        let envDeployPromises = [];
+        for (let environmentToDeploy of environmentsToDeploy) {
+            let environmentContext = util.createEnvironmentContext(handelFile, handelFileParser, environmentToDeploy, deployVersion);
+            envDeployPromises.push(deployEnvironment(accountConfig, serviceDeployers, environmentContext));
+        }
+        return Promise.all(envDeployPromises);
     });
-  });
 }

--- a/lib/phases/bind.js
+++ b/lib/phases/bind.js
@@ -52,7 +52,7 @@ exports.bindServicesInLevel = function (serviceDeployers, environmentContext, pr
 
             //Run bind on the service combination
             let bindContextName = util.getBindContextName(toBindServiceName, dependentOfServiceName)
-            winston.info(`Binding service ${bindContextName}`);
+            winston.debug(`Binding service ${bindContextName}`);
             let bindPromise = serviceDeployer.bind(toBindServiceContext, toBindPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext)
                 .then(bindContext => {
                     if (!(bindContext instanceof BindContext)) {

--- a/lib/phases/consume-events.js
+++ b/lib/phases/consume-events.js
@@ -26,8 +26,6 @@ exports.consumeEvents = function (serviceDeployers, environmentContext, deployCo
     let consumeEventActions = [];
     let consumeEventsContexts = {};
 
-    winston.info(`Consuming internal events (if any) for services`);
-
     _.forEach(environmentContext.serviceContexts, function (producerServiceContext, producerServiceName) {
         if (producerServiceContext.params.event_consumers) { //Only look at those services producing events
             _.forEach(producerServiceContext.params.event_consumers, function (consumerService) {
@@ -47,7 +45,7 @@ exports.consumeEvents = function (serviceDeployers, environmentContext, deployCo
 
     return Promise.mapSeries(consumeEventActions, action => {
         let consumeEventsContextName = util.getConsumeEventsContextName(action.consumerServiceContext.serviceName, action.producerServiceContext.serviceName);
-        winston.info(`Consuming events from internal service ${consumeEventsContextName}`);
+        winston.debug(`Consuming events from service ${consumeEventsContextName}`);
         return action.consumerServiceDeployer.consumeEvents(action.consumerServiceContext, action.consumerDeployContext, action.producerServiceContext, action.producerDeployContext)
             .then(consumeEventsContext => {
                 if (!(consumeEventsContext instanceof ConsumeEventsContext)) {

--- a/lib/phases/deploy.js
+++ b/lib/phases/deploy.js
@@ -50,7 +50,7 @@ exports.deployServicesInLevel = function (serviceDeployers, environmentContext, 
 
         //Get all the DeployContexts for services that this service being deployed depends on
         let dependenciesDeployContexts = getDependencyDeployContexts(toDeployServiceContext, toDeployPreDeployContext, environmentContext, deployContexts, serviceDeployers)
-        winston.info(`Deploying service ${toDeployServiceName}`);
+        winston.debug(`Deploying service ${toDeployServiceName}`);
         let serviceDeployPromise = serviceDeployer.deploy(toDeployServiceContext, toDeployPreDeployContext, dependenciesDeployContexts)
             .then(deployContext => {
                 if (!(deployContext instanceof DeployContext)) {

--- a/lib/phases/pre-deploy.js
+++ b/lib/phases/pre-deploy.js
@@ -19,12 +19,12 @@ const _ = require('lodash');
 const PreDeployContext = require('../datatypes/pre-deploy-context');
 
 exports.preDeployServices = function (serviceDeployers, environmentContext) {
-    winston.info(`Executing pre-deploy on services in environment ${environmentContext.environmentName}`);
+    winston.info(`Executing pre-deploy phase on services in environment ${environmentContext.environmentName}`);
     let preDeployPromises = [];
     let preDeployContexts = {};
 
     _.forEach(environmentContext.serviceContexts, function (serviceContext) {
-        winston.info(`Executing pre-deploy on service ${serviceContext.serviceName}`);
+        winston.debug(`Executing pre-deploy on service ${serviceContext.serviceName}`);
         let serviceDeployer = serviceDeployers[serviceContext.serviceType];
         let preDeployPromise = serviceDeployer.preDeploy(serviceContext)
             .then(preDeployContext => {

--- a/lib/phases/produce-events.js
+++ b/lib/phases/produce-events.js
@@ -21,7 +21,7 @@ const util = require('../common/util');
 const Promise = require('bluebird');
 
 let produceEvent = function (consumerServiceContext, consumerDeployContext, producerServiceContext, producerDeployContext, producerServiceDeployer) {
-    winston.info(`Producing events from ${producerServiceContext.serviceName} for service ${consumerServiceContext.serviceName}`);
+    winston.debug(`Producing events from ${producerServiceContext.serviceName} for service ${consumerServiceContext.serviceName}`);
     return producerServiceDeployer.produceEvents(producerServiceContext, producerDeployContext, consumerServiceContext, consumerDeployContext)
         .then(produceEventsContext => {
             if (!(produceEventsContext instanceof ProduceEventsContext)) {

--- a/lib/phases/un-bind.js
+++ b/lib/phases/un-bind.js
@@ -28,8 +28,7 @@ exports.unBindServicesInLevel = function (serviceDeployers, environmentContext, 
         let toUnBindServiceContext = environmentContext.serviceContexts[toUnBindServiceName];
         let serviceDeployer = serviceDeployers[toUnBindServiceContext.serviceType];
 
-        winston.info(`UnBinding service ${toUnBindServiceName}`);
-
+        winston.debug(`UnBinding service ${toUnBindServiceName}`);
         let unBindPromise = serviceDeployer.unBind(toUnBindServiceContext)
             .then(unBindContext => {
                 if (!(unBindContext instanceof UnBindContext)) {

--- a/lib/phases/un-deploy.js
+++ b/lib/phases/un-deploy.js
@@ -29,7 +29,7 @@ exports.unDeployServicesInLevel = function (serviceDeployers, environmentContext
 
         let serviceDeployer = serviceDeployers[toUnDeployServiceContext.serviceType];
 
-        winston.info(`UnDeploying service ${toUnDeployServiceName}`);
+        winston.debug(`UnDeploying service ${toUnDeployServiceName}`);
         let serviceUndeployPromise = serviceDeployer.unDeploy(toUnDeployServiceContext)
             .then(unDeployContext => {
                 if (!(unDeployContext instanceof UnDeployContext)) {

--- a/lib/phases/un-pre-deploy.js
+++ b/lib/phases/un-pre-deploy.js
@@ -24,7 +24,7 @@ exports.unPreDeployServices = function (serviceDeployers, environmentContext) {
 
     for (let serviceName in environmentContext.serviceContexts) {
         let serviceContext = environmentContext.serviceContexts[serviceName];
-        winston.info(`Executing UnPreDeploy on service ${serviceName}`);
+        winston.debug(`Executing UnPreDeploy on service ${serviceName}`);
         let serviceDeployer = serviceDeployers[serviceContext.serviceType];
         let unPreDeployPromise = serviceDeployer.unPreDeploy(serviceContext)
             .then(unPreDeployContext => {

--- a/lib/services/alexaskillkit/index.js
+++ b/lib/services/alexaskillkit/index.js
@@ -64,7 +64,7 @@ exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServ
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext) {
-    winston.info(`${SERVICE_NAME} - Deploy not currently required for the Alexa Skill Kit service`);
+    winston.debug(`${SERVICE_NAME} - Deploy not currently required for the Alexa Skill Kit service`);
     return Promise.resolve(getDeployContext(ownServiceContext));
 }
 

--- a/lib/services/apiaccess/index.js
+++ b/lib/services/apiaccess/index.js
@@ -82,7 +82,6 @@ exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServ
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
     let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
     winston.info(`${SERVICE_NAME} - Deploying ${SERVICE_NAME} '${stackName}'`);
-
     return Promise.resolve(getDeployContext(ownServiceContext))
 }
 

--- a/lib/services/apigateway/index.js
+++ b/lib/services/apigateway/index.js
@@ -146,7 +146,7 @@ exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServ
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
     let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
-    winston.info(`${SERVICE_NAME} - Deploying service ${stackName}`);
+    winston.info(`${SERVICE_NAME} - Deploying API Gateway service '${stackName}'`);
 
     return uploadDeployableArtifactToS3(ownServiceContext)
         .then(s3ObjectInfo => {
@@ -158,7 +158,7 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
         })
         .then(deployedStack => {
             let restApiUrl = getRestApiUrl(deployedStack, ownServiceContext);
-            winston.info(`${SERVICE_NAME} - Deployed service is available at ${restApiUrl}`);
+            winston.info(`${SERVICE_NAME} - Finished deploying API Gateway service. The service is available at ${restApiUrl}`);
             return getDeployContext(ownServiceContext);
         });
 }

--- a/lib/services/beanstalk/index.js
+++ b/lib/services/beanstalk/index.js
@@ -290,7 +290,7 @@ exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServ
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
     let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
-    winston.info(`${SERVICE_NAME} - Executing Deploy on ${stackName}`);
+    winston.info(`${SERVICE_NAME} - Deploying Beanstalk application '${stackName}'`);
 
     return deployPhaseCommon.createCustomRole('elasticbeanstalk.amazonaws.com', 'HandelBeanstalkServiceRole', getPolicyStatementsForServiceRole())
         .then(serviceRole => {
@@ -307,7 +307,7 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
             return deployPhaseCommon.deployCloudFormationStack(stackName, compiledBeanstalkTemplate, [], true, SERVICE_NAME, stackTags);
         })
         .then(deployedStack => {
-            winston.info(`${SERVICE_NAME} - Finished deploying '${stackName}'`);
+            winston.info(`${SERVICE_NAME} - Finished deploying Beanstalk application '${stackName}'`);
             return getDeployContext(ownServiceContext, deployedStack);
         });
 }

--- a/lib/services/ecs/index.js
+++ b/lib/services/ecs/index.js
@@ -135,7 +135,7 @@ exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServ
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
     let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
-    winston.info(`${SERVICE_NAME} - Deploying Cluster and Service ${stackName}`);
+    winston.info(`${SERVICE_NAME} - Deploying service '${stackName}'`);
 
     let clusterName = getShortenedClusterName(ownServiceContext);
     return clusterAutoScalingSection.createAutoScalingLambdaIfNotExists()
@@ -153,7 +153,7 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
             return deployPhaseCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, SERVICE_NAME, stackTags);
         })
         .then(() => {
-            winston.info(`${SERVICE_NAME} - Finished Deploying Cluster and Serivce ${stackName}`);
+            winston.info(`${SERVICE_NAME} - Finished deploying service '${stackName}'`);
             let deployContext = new DeployContext(ownServiceContext);
             return deployContext;
         });

--- a/lib/services/efs/index.js
+++ b/lib/services/efs/index.js
@@ -126,7 +126,7 @@ exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServ
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
     let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
-    winston.info(`${SERVICE_NAME} - Executing Deploy on ${stackName}`);
+    winston.info(`${SERVICE_NAME} - Deploying EFS mount '${stackName}'`);
 
     return getCompiledEfsTemplate(stackName, ownServiceContext, ownPreDeployContext)
         .then(compiledTemplate => {
@@ -134,7 +134,7 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
             return deployPhaseCommon.deployCloudFormationStack(stackName, compiledTemplate, [], false, SERVICE_NAME, stackTags);
         })
         .then(deployedStack => {
-            winston.info(`${SERVICE_NAME} - Finished deploy for '${stackName}'`)
+            winston.info(`${SERVICE_NAME} - Finished deploying EFS mount '${stackName}'`)
             let fileSystemId = getFileSystemIdFromStack(deployedStack);
             return getDeployContext(ownServiceContext, fileSystemId, accountConfig['region'], stackName);
         });

--- a/lib/services/iot/index.js
+++ b/lib/services/iot/index.js
@@ -109,7 +109,7 @@ exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServ
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
-    winston.info(`${SERVICE_NAME} - Deploy not currently required for the IoT service`);
+    winston.debug(`${SERVICE_NAME} - Deploy not currently required for the IoT service`);
     let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
     return Promise.resolve(getDeployContext(stackName, ownServiceContext)); //Empty deploy
 }
@@ -150,6 +150,7 @@ exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerS
                 return deployPhaseCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, SERVICE_NAME, stackTags)
             })
             .then(deployedStack => {
+                winston.info(`${SERVICE_NAME} - Finished producing events from '${ownServiceContext.serviceName}' for consumer '${consumerServiceContext.serviceName}'`);
                 return resolve(new ProduceEventsContext(ownServiceContext, consumerServiceContext));
             })
     });
@@ -164,6 +165,7 @@ exports.unBind = function (ownServiceContext) {
 }
 
 exports.unDeploy = function (ownServiceContext) {
+    winston.info(`${SERVICE_NAME} - Undeploying events production from '${ownServiceContext.serviceName}'`);
     let deletePromises = [];
 
     //Delete all topic rules created by produce events
@@ -178,6 +180,7 @@ exports.unDeploy = function (ownServiceContext) {
 
     return Promise.all(deletePromises)
         .then(() => {
+            winston.info(`${SERVICE_NAME} - Finished undeploying events production from '${ownServiceContext.serviceName}'`);
             return new UnDeployContext(ownServiceContext);
         });
 }

--- a/lib/services/memcached/index.js
+++ b/lib/services/memcached/index.js
@@ -109,7 +109,7 @@ exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServ
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
     let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
-    winston.info(`${SERVICE_NAME} - Executing Deploy on '${stackName}'`);
+    winston.info(`${SERVICE_NAME} - Deploying cluster '${stackName}'`);
 
     return getCompiledMemcachedTemplate(stackName, ownServiceContext, ownPreDeployContext)
         .then(compiledTemplate => {
@@ -117,7 +117,7 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
             return deployPhaseCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, SERVICE_NAME, stackTags);
         })
         .then(deployedStack => {
-            winston.info(`${SERVICE_NAME} - Finished Deploy on '${stackName}'`);
+            winston.info(`${SERVICE_NAME} - Finished deploying cluster '${stackName}'`);
             return getDeployContext(ownServiceContext, deployedStack)
         });
 }

--- a/lib/services/mysql/index.js
+++ b/lib/services/mysql/index.js
@@ -111,7 +111,7 @@ exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServ
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
     let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
-    winston.info(`${SERVICE_NAME} - Executing Deploy on ${stackName}`);
+    winston.info(`${SERVICE_NAME} - Deploying database '${stackName}'`);
 
     return getCompiledMysqlTemplate(stackName, ownServiceContext, ownPreDeployContext)
         .then(compiledTemplate => {
@@ -123,9 +123,10 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
                             DBPassword: dbPassword
                         }
                         let stackTags = deployPhaseCommon.getTags(ownServiceContext);
-                        winston.info(`${SERVICE_NAME} - Creating RDS instances '${stackName}'`);
+                        winston.debug(`${SERVICE_NAME} - Creating CloudFormation stack '${stackName}'`);
                         return cloudFormationCalls.createStack(stackName, compiledTemplate, cloudFormationCalls.getCfStyleStackParameters(cfParameters), stackTags)
                             .then(deployedStack => {
+                                winston.debug(`${SERVICE_NAME} - Finished creating CloudFormation stack '${stackName}`);
                                 return rdsDeployersCommon.addDbCredentialToParameterStore(ownServiceContext, dbPassword, deployedStack);
                             });
                     }
@@ -136,7 +137,7 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
                 });
         })
         .then(deployedStack => {
-            winston.info(`${SERVICE_NAME} - Finished deploying RDS instance '${stackName}'`)
+            winston.info(`${SERVICE_NAME} - Finished deploying database '${stackName}'`)
             return rdsDeployersCommon.getDeployContext(ownServiceContext, deployedStack);
         });
 }

--- a/lib/services/postgresql/index.js
+++ b/lib/services/postgresql/index.js
@@ -114,7 +114,7 @@ exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServ
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
     let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
-    winston.info(`${SERVICE_NAME} - Executing Deploy on ${stackName}`);
+    winston.info(`${SERVICE_NAME} - Deploying database '${stackName}'`);
 
     return getCompiledPostgresTemplate(stackName, ownServiceContext, ownPreDeployContext)
         .then(compiledTemplate => {
@@ -126,9 +126,10 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
                             DBPassword: dbPassword
                         }
                         let stackTags = deployPhaseCommon.getTags(ownServiceContext);
-                        winston.info(`${SERVICE_NAME} - Creating RDS instances '${stackName}'`);
+                        winston.debug(`${SERVICE_NAME} - Creating CloudFormation stack '${stackName}'`);
                         return cloudFormationCalls.createStack(stackName, compiledTemplate, cloudFormationCalls.getCfStyleStackParameters(cfParameters), stackTags)
                             .then(deployedStack => {
+                                winston.debug(`${SERVICE_NAME} - Finished creating CloudFormation stack '${stackName}'`);
                                 return rdsDeployersCommon.addDbCredentialToParameterStore(ownServiceContext, dbPassword, deployedStack);
                             });
                     }
@@ -139,7 +140,7 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
                 });
         })
         .then(deployedStack => {
-            winston.info(`${SERVICE_NAME} - Finished deploying RDS instance '${stackName}'`)
+            winston.info(`${SERVICE_NAME} - Finished deploying database '${stackName}'`)
             return rdsDeployersCommon.getDeployContext(ownServiceContext, deployedStack);
         });
 }

--- a/lib/services/redis/index.js
+++ b/lib/services/redis/index.js
@@ -163,7 +163,7 @@ exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServ
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
     let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
-    winston.info(`${SERVICE_NAME} - Executing Deploy on '${stackName}'`);
+    winston.info(`${SERVICE_NAME} - Deploying cluster '${stackName}'`);
 
     return getCompiledRedisTemplate(stackName, ownServiceContext, ownPreDeployContext)
         .then(compiledTemplate => {
@@ -171,7 +171,7 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
             return deployPhaseCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, SERVICE_NAME, stackTags);
         })
         .then(deployedStack => {
-            winston.info(`${SERVICE_NAME} - Finished Deploy on '${stackName}'`);
+            winston.info(`${SERVICE_NAME} - Finished deploying cluster '${stackName}'`);
             return getDeployContext(ownServiceContext, deployedStack)
         });
 }

--- a/lib/services/s3/index.js
+++ b/lib/services/s3/index.js
@@ -125,7 +125,7 @@ exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServ
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
     let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
-    winston.info(`${SERVICE_NAME} - Deploying S3 bucket ${stackName}`);
+    winston.info(`${SERVICE_NAME} - Deploying bucket '${stackName}'`);
 
     return s3DeployersCommon.createLoggingBucketIfNotExists()
         .then(loggingBucketName => {
@@ -136,7 +136,7 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
             return deployPhaseCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, SERVICE_NAME, stackTags);
         })
         .then(createdOrUpdatedStack => {
-            winston.info(`${SERVICE_NAME} - Finished deploying S3 bucket ${stackName}`);
+            winston.info(`${SERVICE_NAME} - Finished deploying bucket '${stackName}'`);
             return getDeployContext(ownServiceContext, createdOrUpdatedStack);
         });
 }

--- a/lib/services/s3staticsite/index.js
+++ b/lib/services/s3staticsite/index.js
@@ -80,7 +80,7 @@ exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServ
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
     let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
-    winston.info(`${SERVICE_NAME} - Deploying S3 static website '${stackName}'`);
+    winston.info(`${SERVICE_NAME} - Deploying static website '${stackName}'`);
 
     return s3DeployersCommon.createLoggingBucketIfNotExists()
         .then(loggingBucketName => {
@@ -101,7 +101,7 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
                 });
         })
         .then(createdOrUpdatedStack => {
-            winston.info(`${SERVICE_NAME} - Finished deploying S3 static site '${stackName}'`);
+            winston.info(`${SERVICE_NAME} - Finished deploying static site '${stackName}'`);
             return new DeployContext(ownServiceContext);
         });
 }

--- a/lib/services/sns/index.js
+++ b/lib/services/sns/index.js
@@ -111,7 +111,7 @@ exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServ
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
     let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
-    winston.info(`${SERVICE_NAME} - Executing Deploy on ${stackName}`);
+    winston.info(`${SERVICE_NAME} - Deploying topic '${stackName}'`);
 
     return getCompiledSnsTemplate(stackName, ownServiceContext)
         .then(compiledSnsTemplate => {
@@ -119,7 +119,7 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
             return deployPhaseCommon.deployCloudFormationStack(stackName, compiledSnsTemplate, [], true, SERVICE_NAME, stackTags);
         })
         .then(deployedStack => {
-            winston.info(`${SERVICE_NAME} - Finished deploying SNS topic ${stackName}`);
+            winston.info(`${SERVICE_NAME} - Finished deploying topic '${stackName}'`);
             return getDeployContext(ownServiceContext, deployedStack);
         });
 }
@@ -130,7 +130,7 @@ exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerS
 
 exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext) {
     return new Promise((resolve, reject) => {
-        winston.info(`${SERVICE_NAME} - Producing events from ${ownServiceContext.serviceName} for consumer ${consumerServiceContext.serviceName}`);
+        winston.info(`${SERVICE_NAME} - Producing events from '${ownServiceContext.serviceName}' for consumer '${consumerServiceContext.serviceName}'`);
         //Add subscription to sns service
         let topicArn = ownDeployContext.eventOutputs.topicArn;
         let consumerServiceType = consumerServiceContext.serviceType;
@@ -150,7 +150,7 @@ exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerS
 
         return snsCalls.subscribeToTopic(topicArn, protocol, endpoint)
             .then(subscriptionArn => {
-                winston.info(`${SERVICE_NAME} - Configured production of events from ${ownServiceContext.serviceName} for consumer ${consumerServiceContext.serviceName}`);
+                winston.info(`${SERVICE_NAME} - Configured production of events from '${ownServiceContext.serviceName}' for consumer '${consumerServiceContext.serviceName}'`);
                 return resolve(new ProduceEventsContext(ownServiceContext, consumerServiceContext));
             });
     });

--- a/lib/services/sqs/index.js
+++ b/lib/services/sqs/index.js
@@ -208,7 +208,7 @@ exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServ
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
     let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
-    winston.info(`${SERVICE_NAME} - Executing Deploy on ${stackName}`);
+    winston.info(`${SERVICE_NAME} - Deploying queue '${stackName}'`);
 
     return getCompiledSqsTemplate(stackName, ownServiceContext)
         .then(sqsTemplate => {
@@ -216,7 +216,7 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
             return deployPhaseCommon.deployCloudFormationStack(stackName, sqsTemplate, [], true, SERVICE_NAME, stackTags);
         })
         .then(deployedStack => {
-            winston.info(`${SERVICE_NAME} - Finished deploying SQS queue ${stackName}`);
+            winston.info(`${SERVICE_NAME} - Finished deploying queue '${stackName}'`);
             return getDeployContext(ownServiceContext, deployedStack);
         });
 }

--- a/test/aws/iam-calls-test.js
+++ b/test/aws/iam-calls-test.js
@@ -252,7 +252,7 @@ describe('iam calls', function () {
 
             return iamCalls.showAccount()
                 .then(response => {
-                    expect(response).to.equal(`${accountConfig.account_id}`);
+                    expect(response).to.equal(accountConfig.account_id);
                 });
         });
     });

--- a/test/common/util-test.js
+++ b/test/common/util-test.js
@@ -81,28 +81,7 @@ describe('util module', function () {
                 });
         });
     });
-
-    describe('validateCredentials', function () {
-        it('should not throw an Error if credentials are valid and match the account id', function () {
-            let validateCredentialsStub = sandbox.stub(iamCalls, 'showAccount').returns(Promise.resolve(accountConfig.account_id));
-            return util.validateCredentials(accountConfig)
-              .then(result => {
-                expect(result).to.be.undefined;
-              });
-        })
-
-        it('should return a rejected promise on error', function () {
-            let validateCredentialsStub = sandbox.stub(iamCalls, 'showAccount').returns(Promise.resolve(''));
-            return util.validateCredentials(accountConfig)
-                .then(result => {
-                    expect(true).to.be.false; //Should not get here
-                })
-                .catch(err => {
-                    expect(err.name).to.equal('HandelAcct');
-                });
-        });
-    });
-
+    
     describe('zipDirectoryToFile', function () {
         let zippedPath = `${__dirname}/zipped-test-file.zip`;
 


### PR DESCRIPTION
This commit streamlines the logging from the library, moving a lot
of info-level statements to verbose-level. It also starts using
three levels, the lowest being "debug", which is where all the
really high amounts of log statements like AWS SDK calls should go.

Resolve #235 