### PR TITLE
Fix delete flags

### DIFF
--- a/bin/handel
+++ b/bin/handel
@@ -43,6 +43,7 @@ Options:
 -c [required] -- Path to account config or base64 encoded JSON string of config
 -e [required] -- A comma-separated list of environments from your handel file to deploy
 -d -- If this flag is set, verbose debug output will be enabled
+-y -- If this flag is set, you will *not* be asked to confirm the delete action
 
 Errors:
   ${errors.join('\n  ')}`;

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -288,7 +288,7 @@ exports.deleteAction = function (handelFile, argv) {
     let environmentToDelete = argv.e;
     validateCredentials(accountConfig)
         .then(() => {
-            return confirmDelete(environmentToDelete, argv.d);
+            return confirmDelete(environmentToDelete, argv.y);
         })
         .then(confirmDelete => {
             if (confirmDelete) {


### PR DESCRIPTION
This adds a '-y' option to the delete action to skip the delete confirmation. This also handles the '-d' debug level debugging option correctly.