### PR TITLE
Depending on route53zone fails

### DIFF
--- a/lib/services/route53zone/route53zone-template.yml
+++ b/lib/services/route53zone/route53zone-template.yml
@@ -34,3 +34,6 @@ Outputs:
       Fn::Join:
         - ","
         - !GetAtt Zone.NameServers
+  ZoneName:
+    Description: Zone Name
+    Value: {{name}}


### PR DESCRIPTION
The route53zone service wasn't setting it's output environment variables properly, and thus you would get an error like this when depending on one:

```
Error during environment deploy: [/Resources/TaskDefinition/Type/ContainerDefinitions/0/Environment/0/Value] 'null' values are not allowed in templates
```