### PR TITLE
Remove outdated DNS docs

### DIFF
--- a/docs/supported-services/ecs.rst
+++ b/docs/supported-services/ecs.rst
@@ -53,11 +53,6 @@ Parameters
      - No
      - 
      - If your task needs routing from a load balancer, this section can be used to configure the load balancer's options.
-   * - dns
-     - List<:ref:`route53zone-records`>
-     - No
-     -
-     - DNS records to create and associate with the load balancer for this task.
    * - tags
      - :ref:`ecs-tags`
      - No


### PR DESCRIPTION
The ECS docs still had the docs for the old proposal for how to do DNS config.