### PR TITLE
Fix issue with using DNS in Beanstalk

### DIFF
--- a/lib/services/beanstalk/dns-names-ebextension-template.yml
+++ b/lib/services/beanstalk/dns-names-ebextension-template.yml
@@ -9,11 +9,15 @@ Resources:
         - Name: {{name}}
           Type: A
           AliasTarget:
-            DNSName: !GetAtt AWSEBV2LoadBalancer.DNSName
-            HostedZoneId: !GetAtt AWSEBV2LoadBalancer.CanonicalHostedZoneID
+            DNSName:
+              Fn::GetAtt: [ AWSEBV2LoadBalancer, DNSName ]
+            HostedZoneId:
+              Fn::GetAtt: [ AWSEBV2LoadBalancer, CanonicalHostedZoneID ]
         - Name: {{name}}
           Type: AAAA
           AliasTarget:
-            DNSName: !GetAtt AWSEBV2LoadBalancer.DNSName
-            HostedZoneId: !GetAtt AWSEBV2LoadBalancer.CanonicalHostedZoneID
+            DNSName:
+              Fn::GetAtt: [ AWSEBV2LoadBalancer, DNSName ]
+            HostedZoneId:
+              Fn::GetAtt: [ AWSEBV2LoadBalancer, CanonicalHostedZoneID ]
   {{/each}}


### PR DESCRIPTION
Fixed function calls, since ebextensions don't support the ! shorthand.