### PR TITLE
Add support for KMS

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,6 +41,7 @@ Handel is a library that orchestrates your AWS deployments so you don't have to.
    supported-services/ecs
    supported-services/efs
    supported-services/iot
+   supported-services/kms
    supported-services/lambda
    supported-services/memcached
    supported-services/mysql

--- a/docs/supported-services/kms.rst
+++ b/docs/supported-services/kms.rst
@@ -1,0 +1,86 @@
+.. _kms:
+
+KMS (Key Management Service)
+============================
+This document contains information about the KMS service supported in Handel. This Handel service provisions a KMS key and alias for use by your applications.
+
+Service Limitations
+-------------------
+This service currently does not allow creating disabled keys. It also uses IAM instead of custom Key Policies to control
+access to the key, as key policies can easily make keys unmanageable.
+
+While the AWS API allows for multiple aliases to point to a single key, this service matches the AWS Console in enforcing
+a one-to-one relationship between keys.
+
+Parameters
+----------
+This service takes the following parameters:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Parameter
+     - Type
+     - Required
+     - Default
+     - Description
+   * - type
+     - string
+     - Yes
+     - 
+     - This must always be *kms* for this service type.
+   * - alias
+     - string
+     - No
+     - <appName>/<environmentName>/<serviceName>
+     - The name of the alias to create. This name must be unique across the account and region in which the key is deployed.
+   * - auto_rotate
+     - boolean
+     - No
+     - true
+     - Whether to allow AWS to auto-rotate the underlying Master Key.
+
+Example Handel File
+-------------------
+This Handel file shows a KMS key being configured:
+
+.. code-block:: yaml
+
+    version: 1
+
+    name: my-app
+
+    environments:
+      dev:
+        mykey:
+          type: kms
+          # because we don't specify an alias, the alias will be my-app/dev/mykey (see above)
+          auto_rotate: true
+
+Depending on this service
+-------------------------
+This service outputs the following environment variables:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Environment Variable
+     - Description
+   * - <ENV_PREFIX>_KEY_ID
+     - The id of the created key
+   * - <ENV_PREFIX>_KEY_ARN
+     - The ARN of the created key
+   * - <ENV_PREFIX>_ALIAS_NAME
+     - The name of the created alias
+   * - <ENV_PREFIX>_ALIAS_ARN
+     - The ARN of the created alias
+
+The <ENV_PREFIX> is a consistent prefix applied to all information injected for service dependencies.  See :ref:`environment-variable-prefix` for information about the structure of this prefix.
+
+Events produced by this service
+-------------------------------
+The KMS service does not currently produce events for other Handel services. Support for producing events upon key rotation is planned for the future.
+
+Events consumed by this service
+-------------------------------
+The KMS service does not consume events from other Handel services.

--- a/lib/services/kms/index.js
+++ b/lib/services/kms/index.js
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const winston = require('winston');
+const DeployContext = require('../../datatypes/deploy-context');
+const cloudFormationCalls = require('../../aws/cloudformation-calls');
+const deployPhaseCommon = require('../../common/deploy-phase-common');
+const deletePhasesCommon = require('../../common/delete-phases-common');
+const handlebarsUtils = require('../../common/handlebars-utils');
+
+const SERVICE_NAME = "KMS";
+
+function getDeployContext(serviceContext, cfStack) {
+    let keyId = cloudFormationCalls.getOutput('KeyId', cfStack);
+    let keyArn = cloudFormationCalls.getOutput('KeyArn', cfStack);
+    let aliasName = cloudFormationCalls.getOutput('AliasName', cfStack);
+    let aliasArn = cloudFormationCalls.getOutput('AliasArn', cfStack);
+
+    let deployContext = new DeployContext(serviceContext);
+
+    //Env variables to inject into consuming services
+    let keyIdEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'KEY_ID');
+    deployContext.environmentVariables[keyIdEnv] = keyId;
+
+    let keyArnEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'KEY_ARN');
+    deployContext.environmentVariables[keyArnEnv] = keyArn;
+
+    let aliasNameEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'ALIAS_NAME');
+    deployContext.environmentVariables[aliasNameEnv] = aliasName;
+
+    let aliasArnEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'ALIAS_ARN');
+    deployContext.environmentVariables[aliasArnEnv] = aliasArn;
+
+    //Set up key use policies
+    deployContext.policies.push({
+        "Effect": "Allow",
+        "Action": [
+            "kms:DescribeKey",
+            "kms:Encrypt",
+            "kms:Decrypt",
+            "kms:GenerateDataKey",
+            "kms:GenerateDataKeyWithoutPlaintext",
+            "kms:ReEncryptFrom",
+            "kms:ReEncryptTo",
+        ],
+        "Resource": [
+            keyArn
+        ]
+    });
+
+    return deployContext;
+}
+
+
+function getCompiledTemplate(ownServiceContext) {
+    let serviceParams = ownServiceContext.params;
+
+    let handlebarsParams = {
+        autoRotate: !!serviceParams.auto_rotate,
+        alias: serviceParams.alias || getDefaultAlias(ownServiceContext)
+    };
+
+    return handlebarsUtils.compileTemplate(`${__dirname}/kms-template.yml`, handlebarsParams)
+}
+
+function getDefaultAlias(context) {
+    return `${context.appName}/${context.environmentName}/${context.serviceName}`;
+}
+
+/**
+ * Service Deployer Contract Methods
+ * See https://github.com/byu-oit-appdev/handel/wiki/Creating-a-New-Service-Deployer#service-deployer-contract
+ *   for contract method documentation
+ */
+
+exports.check = function (serviceContext, dependenciesServiceContexts) {
+    let errors = [];
+
+    let params = serviceContext.params;
+
+    if (params.alias) {
+        let alias = params.alias;
+        if (alias.startsWith('AWS')) {
+            errors.push("'alias' parameter must not begin with 'AWS'")
+        }
+        if (!alias.match(/^[-\/_a-z0-9]+$/i)) {
+            errors.push("'alias' parameter must only contain alphanumeric characters, dashes ('-'), underscores ('_'), or slashes ('/')");
+        }
+    }
+
+    return errors.map(it => `${SERVICE_NAME} - ${it}`);
+}
+
+exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
+    let stackName = deployPhaseCommon.getResourceName(ownServiceContext);
+    winston.info(`${SERVICE_NAME} - Deploying KMS Key ${stackName}`);
+
+    return getCompiledTemplate(ownServiceContext)
+        .then(compiledTemplate => {
+            let stackTags = deployPhaseCommon.getTags(ownServiceContext);
+            return deployPhaseCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, SERVICE_NAME, stackTags);
+        })
+        .then(createdOrUpdatedStack => {
+            winston.info(`${SERVICE_NAME} - Finished deploying KMS Key ${stackName}`);
+            return getDeployContext(ownServiceContext, createdOrUpdatedStack);
+        });
+}
+
+exports.unDeploy = function (ownServiceContext) {
+    return deletePhasesCommon.unDeployService(ownServiceContext, SERVICE_NAME);
+}
+
+exports.producedEventsSupportedServices = [];
+
+exports.producedDeployOutputTypes = [
+    'environmentVariables',
+    'policies'
+];
+
+exports.consumedDeployOutputTypes = [];

--- a/lib/services/kms/kms-template.yml
+++ b/lib/services/kms/kms-template.yml
@@ -9,6 +9,16 @@ Resources:
       Description: Handel-generated key
       Enabled: true
       EnableKeyRotation: {{autoRotate}}
+      KeyPolicy:
+        Version: "2017-10-17"
+        Id: "key-default-1"
+        Statement:
+          - "Sid": "Enable IAM User Permissions",
+            "Effect": "Allow",
+            "Principal":
+              "AWS": !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            "Action": "kms:*",
+            "Resource": "*"
 
   Alias:
     Type: "AWS::KMS::Alias"

--- a/lib/services/kms/kms-template.yml
+++ b/lib/services/kms/kms-template.yml
@@ -10,15 +10,15 @@ Resources:
       Enabled: true
       EnableKeyRotation: {{autoRotate}}
       KeyPolicy:
-        Version: "2017-10-17"
-        Id: "key-default-1"
+        Version: "2012-10-17"
         Statement:
-          - "Sid": "Enable IAM User Permissions",
-            "Effect": "Allow",
-            "Principal":
-              "AWS": !Sub "arn:aws:iam::${AWS::AccountId}:root"
-            "Action": "kms:*",
-            "Resource": "*"
+          - Sid: "Enable IAM User Permissions"
+            Effect: "Allow"
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action:
+              - "kms:*"
+            Resource: "*"
 
   Alias:
     Type: "AWS::KMS::Alias"

--- a/lib/services/kms/kms-template.yml
+++ b/lib/services/kms/kms-template.yml
@@ -1,0 +1,31 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Handel-created KMS Key
+
+Resources:
+  Key:
+    Type: "AWS::KMS::Key"
+    Properties:
+      Description: Handel-generated key
+      Enabled: true
+      EnableKeyRotation: {{autoRotate}}
+
+  Alias:
+    Type: "AWS::KMS::Alias"
+    Properties:
+      AliasName: alias/{{alias}}
+      TargetKeyId: !Ref Key
+
+Outputs:
+  KeyId:
+    Description: The ID of the key
+    Value: !Ref Key
+  KeyArn:
+    Description: ARN of the key
+    Value: !GetAtt Key.Arn
+  AliasName:
+    Description: Alias Name
+    Value: !Ref Alias
+  AliasArn:
+    Description: Alias Arn
+    Value: !Sub "arn:aws:kms:${AWS::Region}:${AWS::AccountId}:${Alias}"


### PR DESCRIPTION
This adds support for creating and depending on KMS keys.

By default, it creates an alias for the key, named `alias/<appName>/<envName>/<serviceName>`.

**Future Enhancements:**

- Add support for publishing events whenever the key is rotated.  I'll probably tackle this as part of my work on Payment Manager v2.