### PR TITLE
Use a spread placement strategy for ecs clusters

### DIFF
--- a/lib/services/ecs/ecs-service-template.yml
+++ b/lib/services/ecs/ecs-service-template.yml
@@ -197,6 +197,9 @@ Resources:
       {{/if}}
       TaskDefinition:
         Ref: TaskDefinition
+      PlacementStrategies:
+        - Type: spread
+          Field: instanceId
   TaskDefinition:
     Type: AWS::ECS::TaskDefinition
     Properties:


### PR DESCRIPTION
This change will allow us to spread the ec2 utilization between cluster members