### PR TITLE
Better env vars

### DIFF
--- a/docs/handel-basics/consuming-service-dependencies.rst
+++ b/docs/handel-basics/consuming-service-dependencies.rst
@@ -31,10 +31,10 @@ The following Handel file defines a Beanstalk service that depends on an SQS que
 
 Handel will inject environment variables in the Beanstalk application for the SQS queue, such as the queue's ARN, name, and URL. You can read these environment variables when you are writing code to communicate with the queue.
 
-.. _environment-variable-prefix:
+.. _environment-variable-names:
 
-Environment Variable Name
--------------------------
+Environment Variable Names
+--------------------------
 Every environment variable injected by Handel for service dependencies has a common structure.
 
 This environment variable name consists of the dependency's name (as defined in the Handel file), followed by the name of the value being injected.

--- a/docs/handel-basics/consuming-service-dependencies.rst
+++ b/docs/handel-basics/consuming-service-dependencies.rst
@@ -25,44 +25,33 @@ The following Handel file defines a Beanstalk service that depends on an SQS que
           min_instances: 1
           max_instances: 1
           dependencies:
-          - queue
-        queue:
+          - my-queue
+        my-queue:
           type: sqs
 
 Handel will inject environment variables in the Beanstalk application for the SQS queue, such as the queue's ARN, name, and URL. You can read these environment variables when you are writing code to communicate with the queue.
 
 .. _environment-variable-prefix:
 
-Environment Variable Prefix
----------------------------
-Every environment variable injected by Handel for service dependencies has a common prefix in the environment variable name. 
+Environment Variable Name
+-------------------------
+Every environment variable injected by Handel for service dependencies has a common structure.
 
-This environment variable prefix is defined with the following structure:
+This environment variable name consists of the dependency's name (as defined in the Handel file), followed by the name of the value being injected.
+
+.. code-block:: none
+
+   <SERVICE_NAME>_<VALUE_NAME>
+
+In the above example, the referencing Beanstalk application would need to use the following name to get the URL of the SQS Queue:
 
 .. code-block:: none
 
-   <SERVICE_TYPE>_<APP_NAME>_<ENVIRONMENT_NAME>_<SERVICE_NAME>
-
-These values come from the service dependency in your Handel file. In the above example, the referencing Beanstalk application would need to use the following values in that prefix:
-
-.. code-block:: none
-   
-    service_type = "sqs"
-    app_name = "beanstalk-example"
-    environment_name = "dev"
-    service_name = "queue"
-
-You can use the :ref:`consuming-service-dependencies-common-vars` to dynamically obtain values such as *environment_name* that will be different depending on which environment your code is currently running in.
+    MY_QUEUE_QUEUE_URL
 
 .. NOTE::
-   All Handel injected environment variables will be all upper-cased, with dashes converted to underscores. In the above example, the Beanstalk application would need to use the following prefix for the SQS queue: 
+   All Handel injected environment variables will be all upper-cased, with dashes converted to underscores.
    
-   .. code-block:: none
-
-      SQS_BEANSTALK_EXAMPLE_DEV_QUEUE
-
-   Note that everything in the above prefix is upper-cased, and the app name "beanstalk-example" has been converted to to use underscores instead of dashes
-
 .. _parameter-store-prefix:
 
 Parameter Store Prefix
@@ -75,15 +64,7 @@ Each parameter Handel puts in the parameter store has a common prefix, which is 
 
     <app_name>.<environment_name>.<service_name>
 
-These values come from the service dependency in your Handel file. In the above example, the referencing Beanstalk application would need to use the following values in that prefix:
-
-.. code-block:: none
-   
-    app_name = "beanstalk-example"
-    environment_name = "dev"
-    service_name = "queue"
-
-You can use the :ref:`consuming-service-dependencies-common-vars` to dynamically obtain values such as *environment_name* that will be different depending on which environment your code is currently running in.
+You can use the :ref:`consuming-service-dependencies-common-vars` to obtain the value of this prefix.
 
 .. _consuming-service-dependencies-common-vars:
 
@@ -104,3 +85,5 @@ In addition to environment variables injected by services your applications cons
      - This is the value of the *\<service_name>* field from your Handel file. It is the name of the currently deployed service.
    * - HANDEL_SERVICE_VERSION
      - This is the value of the version of the application being deployed. It is set to whatever the *-v* parameter was when Handel last deployed your application.
+   * - HANDEL_PARAMETER_STORE_PREFIX
+     - This is the prefix used for secrets stored in Parameter Store.

--- a/docs/supported-services/dynamodb.rst
+++ b/docs/supported-services/dynamodb.rst
@@ -189,12 +189,12 @@ The DynamoDB service outputs the following environment variables:
 
    * - Environment Variable
      - Description
-   * - <ENV_PREFIX>_TABLE_NAME
+   * - <SERVICE_NAME>_TABLE_NAME
      - The name of the created DynamoDB table
-   * - <ENV_PREFIX>_TABLE_ARN
+   * - <SERVICE_NAME>_TABLE_ARN
      - The ARN of the created DynamoDB table
 
-The <ENV_PREFIX> is a consistent prefix applied to all information injected for service dependencies.  See :ref:`environment-variable-prefix` for information about the structure of this prefix.
+See :ref:`environment-variable-names` for information about how the service name is included in the environment variable name.
 
 DynamoDB Streams
 -------------------------------

--- a/docs/supported-services/efs.rst
+++ b/docs/supported-services/efs.rst
@@ -71,10 +71,10 @@ The EFS service outputs the following environment variables:
 
    * - Environment Variable
      - Description
-   * - <ENV_PREFIX>_MOUNT_DIR
+   * - <SERVICE_NAME>_MOUNT_DIR
      - The directory on the host where the EFS volume was mounted.
 
-The <ENV_PREFIX> is a consistent prefix applied to all information injected for service dependencies.  See :ref:`environment-variable-prefix` for information about the structure of this prefix.
+See :ref:`environment-variable-names` for information about how the service name is included in the environment variable name.
 
 Events produced by this service
 -------------------------------

--- a/docs/supported-services/kms.rst
+++ b/docs/supported-services/kms.rst
@@ -66,16 +66,16 @@ This service outputs the following environment variables:
 
    * - Environment Variable
      - Description
-   * - <ENV_PREFIX>_KEY_ID
+   * - <SERVICE_NAME>_KEY_ID
      - The id of the created key
-   * - <ENV_PREFIX>_KEY_ARN
+   * - <SERVICE_NAME>_KEY_ARN
      - The ARN of the created key
-   * - <ENV_PREFIX>_ALIAS_NAME
+   * - <SERVICE_NAME>_ALIAS_NAME
      - The name of the created alias
-   * - <ENV_PREFIX>_ALIAS_ARN
+   * - <SERVICE_NAME>_ALIAS_ARN
      - The ARN of the created alias
 
-The <ENV_PREFIX> is a consistent prefix applied to all information injected for service dependencies.  See :ref:`environment-variable-prefix` for information about the structure of this prefix.
+See :ref:`environment-variable-names` for information about how the service name is included in the environment variable name.
 
 Events produced by this service
 -------------------------------

--- a/docs/supported-services/memcached.rst
+++ b/docs/supported-services/memcached.rst
@@ -121,12 +121,12 @@ The Memcached service outputs the following environment variables:
 
    * - Environment Variable
      - Description
-   * - <ENV_PREFIX>_ADDRESS
+   * - <SERVICE_NAME>_ADDRESS
      - The DNS name of the Memcached configuration endpoint address.
-   * - <ENV_PREFIX>_PORT
+   * - <SERVICE_NAME>_PORT
      - The port on which the Memcached cluster is listening.
 
-The <ENV_PREFIX> is a consistent prefix applied to all information injected for service dependencies.  See :ref:`environment-variable-prefix` for information about the structure of this prefix.
+See :ref:`environment-variable-names` for information about how the service name is included in the environment variable name.
 
 Events produced by this service
 -------------------------------

--- a/docs/supported-services/mysql.rst
+++ b/docs/supported-services/mysql.rst
@@ -136,16 +136,16 @@ The MySQL service outputs the following environment variables:
 
    * - Environment Variable
      - Description
-   * - <ENV_PREFIX>_ADDRESS
+   * - <SERVICE_NAME>_ADDRESS
      - The DNS name of the MySQL database address.
-   * - <ENV_PREFIX>_PORT
+   * - <SERVICE_NAME>_PORT
      - The port on which the MySQL instance is listening.
-   * - <ENV_PREFIX>_USERNAME
+   * - <SERVICE_NAME>_USERNAME
      - The username you can use to access the database.
-   * - <ENV_PREFIX>_DATABASE_NAME
+   * - <SERVICE_NAME>_DATABASE_NAME
      - The name of the database in your MySQL instance.
 
-The <ENV_PREFIX> is a consistent prefix applied to all information injected for service dependencies.  See :ref:`environment-variable-prefix` for information about the structure of this prefix.
+See :ref:`environment-variable-names` for information about how the service name is included in the environment variable name.
 
 In addition, the MySQL service puts the following credentials into the EC2 parameter store:
 

--- a/docs/supported-services/postgresql.rst
+++ b/docs/supported-services/postgresql.rst
@@ -135,16 +135,16 @@ The PostgreSQL service outputs the following environment variables:
 
    * - Environment Variable
      - Description
-   * - <ENV_PREFIX>_ADDRESS
+   * - <SERVICE_NAME>_ADDRESS
      - The DNS name of the PostgreSQL database address.
-   * - <ENV_PREFIX>_PORT
+   * - <SERVICE_NAME>_PORT
      - The port on which the PostgreSQL instance is listening.
-   * - <ENV_PREFIX>_USERNAME
+   * - <SERVICE_NAME>_USERNAME
      - The username you can use to access the database.
-   * - <ENV_PREFIX>_DATABASE_NAME
+   * - <SERVICE_NAME>_DATABASE_NAME
      - The name of the database in your PostgreSQL instance.
 
-The <ENV_PREFIX> is a consistent prefix applied to all information injected for service dependencies.  See :ref:`environment-variable-prefix` for information about the structure of this prefix.
+See :ref:`environment-variable-names` for information about how the service name is included in the environment variable name.
 
 In addition, the PostgreSQL service puts the following credentials into the EC2 parameter store:
 

--- a/docs/supported-services/redis.rst
+++ b/docs/supported-services/redis.rst
@@ -127,12 +127,12 @@ The Redis service outputs the following environment variables:
 
    * - Environment Variable
      - Description
-   * - <ENV_PREFIX>_ADDRESS
+   * - <SERVICE_NAME>_ADDRESS
      - The DNS name of the primary Redis node
-   * - <ENV_PREFIX>_PORT
+   * - <SERVICE_NAME>_PORT
      - The port on which the primary Redis node is listening.
 
-The <ENV_PREFIX> is a consistent prefix applied to all information injected for service dependencies.  See :ref:`environment-variable-prefix` for information about the structure of this prefix.
+See :ref:`environment-variable-names` for information about how the service name is included in the environment variable name.
 
 Events produced by this service
 -------------------------------

--- a/docs/supported-services/route53zone.rst
+++ b/docs/supported-services/route53zone.rst
@@ -95,15 +95,15 @@ This service outputs the following environment variables:
 
    * - Environment Variable
      - Description
-   * - <ENV_PREFIX>_ZONE_NAME
+   * - <SERVICE_NAME>_ZONE_NAME
      - The DNS name of hosted zone.
-   * - <ENV_PREFIX>_ZONE_ID
+   * - <SERVICE_NAME>_ZONE_ID
      - The id of the hosted zone
-   * - <ENV_PREFIX>_ZONE_NAME_SERVERS
+   * - <SERVICE_NAME>_ZONE_NAME_SERVERS
      - A comma-delimited list of the name servers for this hosted zone. For example: ns1.example.com,ns2.example.co.uk
 
 
-The <ENV_PREFIX> is a consistent prefix applied to all information injected for service dependencies.  See :ref:`environment-variable-prefix` for information about the structure of this prefix.
+See :ref:`environment-variable-names` for information about how the service name is included in the environment variable name.
 
 
 .. _route53zone-records:

--- a/docs/supported-services/s3.rst
+++ b/docs/supported-services/s3.rst
@@ -169,14 +169,14 @@ This service outputs the following environment variables:
 
    * - Environment Variable
      - Description
-   * - <ENV_PREFIX>_BUCKET_NAME
+   * - <SERVICE_NAME>_BUCKET_NAME
      - The name of the created bucket
-   * - <ENV_PREFIX>_BUCKET_URL
+   * - <SERVICE_NAME>_BUCKET_URL
      - The HTTPS URL of the created bucket
-   * - <ENV_PREFIX>_REGION_ENDPOINT
+   * - <SERVICE_NAME>_REGION_ENDPOINT
      - The domain of the S3 region endpoint, which you can use when configuring your AWS SDK
 
-The <ENV_PREFIX> is a consistent prefix applied to all information injected for service dependencies.  See :ref:`environment-variable-prefix` for information about the structure of this prefix.
+See :ref:`environment-variable-names` for information about how the service name is included in the environment variable name.
 
 Events produced by this service
 -------------------------------

--- a/docs/supported-services/sns.rst
+++ b/docs/supported-services/sns.rst
@@ -70,12 +70,12 @@ This service outputs the following environment variables:
 
    * - Environment Variable
      - Description
-   * - <ENV_PREFIX>_TOPIC_ARN
+   * - <SERVICE_NAME>_TOPIC_ARN
      - The AWS ARN of the created topic
-   * - <ENV_PREFIX>_TOPIC_NAME
+   * - <SERVICE_NAME>_TOPIC_NAME
      - The name of the created topic
 
-The <ENV_PREFIX> is a consistent prefix applied to all information injected for service dependencies.  See :ref:`environment-variable-prefix` for information about the structure of this prefix.
+See :ref:`environment-variable-names` for information about how the service name is included in the environment variable name.
 
 Events produced by this service
 -------------------------------

--- a/docs/supported-services/sqs.rst
+++ b/docs/supported-services/sqs.rst
@@ -145,11 +145,11 @@ The SQS service outputs the following environment variables:
 
    * - Environment Variable
      - Description
-   * - <ENV_PREFIX>_QUEUE_NAME
+   * - <SERVICE_NAME>_QUEUE_NAME
      - The name of the created queue
-   * - <ENV_PREFIX>_QUEUE_URL
+   * - <SERVICE_NAME>_QUEUE_URL
      - The HTTPS URL of the created queue
-   * - <ENV_PREFIX>_QUEUE_ARN
+   * - <SERVICE_NAME>_QUEUE_ARN
      - The AWS ARN of the created queue
 
 If you have a Dead-Letter Queue, the SQS service also outputs the following environment variables:
@@ -159,14 +159,14 @@ If you have a Dead-Letter Queue, the SQS service also outputs the following envi
 
     * - Environment Variable
       - Description
-    * - <ENV_PREFIX>_DEAD_LETTER_QUEUE_NAME
+    * - <SERVICE_NAME>_DEAD_LETTER_QUEUE_NAME
       - The name of the created dead-letter queue
-    * - <ENV_PREFIX>_DEAD_LETTER_QUEUE_URL
+    * - <SERVICE_NAME>_DEAD_LETTER_QUEUE_URL
       - The HTTPS URL of the created dead-letter queue
-    * - <ENV_PREFIX>_DEAD_LETTER_QUEUE_ARN
+    * - <SERVICE_NAME>_DEAD_LETTER_QUEUE_ARN
       - The AWS ARN of the created dead-letter queue
 
-The <ENV_PREFIX> is a consistent prefix applied to all information injected for service dependencies.  See :ref:`environment-variable-prefix` for information about the structure of this prefix.
+See :ref:`environment-variable-names` for information about how the service name is included in the environment variable name.
 
 Events produced by this service
 -------------------------------

--- a/lib/common/deploy-phase-common.js
+++ b/lib/common/deploy-phase-common.js
@@ -31,7 +31,20 @@ const os = require('os');
  * @returns {String} - The environment variable prefix string constructed from the service context
  */
 exports.getInjectedEnvVarName = function (serviceContext, suffix) {
-    return `${serviceContext.serviceType}_${serviceContext.appName}_${serviceContext.environmentName}_${serviceContext.serviceName}_${suffix}`.toUpperCase().replace(/-/g, "_");
+    return `${serviceContext.serviceName}_${suffix}`.toUpperCase().replace(/-/g, "_");
+}
+
+exports.getInjectedEnvVarsFor = function(serviceContext, outputs) {
+    return Object.keys(outputs).reduce((obj, name) => {
+        let value = outputs[name];
+        obj[exports.getInjectedEnvVarName(serviceContext, name)] = value;
+        obj[legacyEnvVarName(serviceContext, name)] = value;
+        return obj;
+    }, {});
+};
+
+function legacyEnvVarName(serviceContext, name) {
+    return `${serviceContext.serviceType}_${serviceContext.appName}_${serviceContext.environmentName}_${serviceContext.serviceName}_${name}`.toUpperCase().replace(/-/g, "_");
 }
 
 function ssmParamPrefix(serviceContext) {

--- a/lib/common/deploy-phase-common.js
+++ b/lib/common/deploy-phase-common.js
@@ -34,8 +34,12 @@ exports.getInjectedEnvVarName = function (serviceContext, suffix) {
     return `${serviceContext.serviceType}_${serviceContext.appName}_${serviceContext.environmentName}_${serviceContext.serviceName}_${suffix}`.toUpperCase().replace(/-/g, "_");
 }
 
+function ssmParamPrefix(serviceContext) {
+    return `${serviceContext.appName}.${serviceContext.environmentName}.${serviceContext.serviceName}`;
+}
+
 exports.getSsmParamName = function (serviceContext, suffix) {
-    return `${serviceContext.appName}.${serviceContext.environmentName}.${serviceContext.serviceName}.${suffix}`;
+    return `${ssmParamPrefix(serviceContext)}.${suffix}`;
 }
 
 exports.getEnvVarsFromServiceContext = function (serviceContext) {
@@ -44,6 +48,7 @@ exports.getEnvVarsFromServiceContext = function (serviceContext) {
     envVars['HANDEL_ENVIRONMENT_NAME'] = serviceContext.environmentName;
     envVars['HANDEL_SERVICE_NAME'] = serviceContext.serviceName;
     envVars['HANDEL_SERVICE_VERSION'] = serviceContext.deployVersion;
+    envVars['HANDEL_PARAMETER_STORE_PREFIX'] = ssmParamPrefix(serviceContext);
     return envVars;
 }
 

--- a/lib/common/rds-deployers-common.js
+++ b/lib/common/rds-deployers-common.js
@@ -23,18 +23,19 @@ exports.getDeployContext = function (serviceContext, rdsCfStack) {
     let deployContext = new DeployContext(serviceContext);
 
     //Inject ENV variables to talk to this database
-    let portEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'ADDRESS');
-    let port = cloudFormationCalls.getOutput('DatabaseAddress', rdsCfStack);
-    deployContext.environmentVariables[portEnv] = port;
-    let addressEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'PORT');
-    let address = cloudFormationCalls.getOutput('DatabasePort', rdsCfStack);
-    deployContext.environmentVariables[addressEnv] = address;
-    let usernameEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'USERNAME');
+    let address = cloudFormationCalls.getOutput('DatabaseAddress', rdsCfStack);
+    let port = cloudFormationCalls.getOutput('DatabasePort', rdsCfStack);
     let username = cloudFormationCalls.getOutput('DatabaseUsername', rdsCfStack);
-    deployContext.environmentVariables[usernameEnv] = username;
-    let dbNameEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'DATABASE_NAME');
     let dbName = cloudFormationCalls.getOutput('DatabaseName', rdsCfStack);
-    deployContext.environmentVariables[dbNameEnv] = dbName;
+
+    deployContext.addEnvironmentVariables(
+        deployPhaseCommon.getInjectedEnvVarsFor(serviceContext, {
+            ADDRESS: address,
+            PORT: port,
+            USERNAME: username,
+            DATABASE_NAME: dbName
+        })
+    );
 
     return deployContext;
 }

--- a/lib/datatypes/deploy-context.js
+++ b/lib/datatypes/deploy-context.js
@@ -26,6 +26,10 @@ class DeployContext {
         this.environmentVariables = {}; //Items intended to be injected as environment variables into the consuming service
         this.scripts = []; //Scripts intended to be run on startup by the consuming resource. Some services like EFS require running commands on the host to connect them in
     }
+
+    addEnvironmentVariables(vars) {
+        Object.assign(this.environmentVariables, vars);
+    }
 }
 
 module.exports = exports = DeployContext;

--- a/lib/services/dynamodb/index.js
+++ b/lib/services/dynamodb/index.js
@@ -87,8 +87,9 @@ function getDeployContext(serviceContext, cfStack) {
     }
 
     //Inject env vars
-    let tableNameEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'TABLE_NAME');
-    deployContext.environmentVariables[tableNameEnv] = tableName;
+    deployContext.addEnvironmentVariables(deployPhaseCommon.getInjectedEnvVarsFor(serviceContext, {
+        TABLE_NAME: tableName
+    }));
 
     return deployContext;
 }

--- a/lib/services/efs/index.js
+++ b/lib/services/efs/index.js
@@ -49,8 +49,9 @@ function getDeployContext(serviceContext, fileSystemId, region, fileSystemName) 
     let mountDir = `/mnt/share/${fileSystemName}`
     return getMountScript(fileSystemId, region, mountDir)
         .then(mountScript => {
-            let mountDirEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'MOUNT_DIR');
-            deployContext.environmentVariables[mountDirEnv] = mountDir
+            deployContext.addEnvironmentVariables(deployPhaseCommon.getInjectedEnvVarsFor(serviceContext, {
+                'MOUNT_DIR': mountDir
+            }));
             deployContext.scripts.push(mountScript);
             return deployContext;
         });

--- a/lib/services/kms/index.js
+++ b/lib/services/kms/index.js
@@ -31,18 +31,12 @@ function getDeployContext(serviceContext, cfStack) {
 
     let deployContext = new DeployContext(serviceContext);
 
-    //Env variables to inject into consuming services
-    let keyIdEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'KEY_ID');
-    deployContext.environmentVariables[keyIdEnv] = keyId;
-
-    let keyArnEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'KEY_ARN');
-    deployContext.environmentVariables[keyArnEnv] = keyArn;
-
-    let aliasNameEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'ALIAS_NAME');
-    deployContext.environmentVariables[aliasNameEnv] = aliasName;
-
-    let aliasArnEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'ALIAS_ARN');
-    deployContext.environmentVariables[aliasArnEnv] = aliasArn;
+    deployContext.addEnvironmentVariables(deployPhaseCommon.getInjectedEnvVarsFor(serviceContext, {
+        'KEY_ID': keyId,
+        'KEY_ARN': keyArn,
+        'ALIAS_NAME': aliasName,
+        'ALIAS_ARN': aliasArn
+    }));
 
     //Set up key use policies
     deployContext.policies.push({

--- a/lib/services/memcached/index.js
+++ b/lib/services/memcached/index.js
@@ -32,12 +32,14 @@ function getDeployContext(serviceContext, cfStack) {
     let deployContext = new DeployContext(serviceContext);
 
     // Set port and address environment variables
-    let portEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'PORT');
     let port = cloudFormationCalls.getOutput('CachePort', cfStack);
-    deployContext.environmentVariables[portEnv] = port;
-    let addressEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'ADDRESS');
     let address = cloudFormationCalls.getOutput('CacheAddress', cfStack);
-    deployContext.environmentVariables[addressEnv] = address;
+
+    deployContext.addEnvironmentVariables(deployPhaseCommon.getInjectedEnvVarsFor(serviceContext, {
+        PORT: port,
+        ADDRESS: address
+    }));
+
     return deployContext;
 }
 

--- a/lib/services/redis/index.js
+++ b/lib/services/redis/index.js
@@ -32,12 +32,13 @@ function getDeployContext(serviceContext, cfStack) {
     let deployContext = new DeployContext(serviceContext);
 
     // Set port and address environment variables
-    let portEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'PORT');
     let port = cloudFormationCalls.getOutput('CachePort', cfStack);
-    deployContext.environmentVariables[portEnv] = port;
-    let addressEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'ADDRESS');
     let address = cloudFormationCalls.getOutput('CacheAddress', cfStack);
-    deployContext.environmentVariables[addressEnv] = address;
+
+    deployContext.addEnvironmentVariables(deployPhaseCommon.getInjectedEnvVarsFor(serviceContext, {
+        PORT: port,
+        ADDRESS: address
+    }));
     return deployContext;
 }
 

--- a/lib/services/route53zone/index.js
+++ b/lib/services/route53zone/index.js
@@ -32,12 +32,11 @@ function getDeployContext(serviceContext, cfStack) {
     let deployContext = new DeployContext(serviceContext);
 
     //Env variables to inject into consuming services
-    let zoneNameEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'ZONE_NAME');
-    deployContext.environmentVariables[zoneNameEnv] = name;
-    let zoneIdEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, "ZONE_ID");
-    deployContext.environmentVariables[zoneIdEnv] = id;
-    let zoneNameServersEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, "ZONE_NAME_SERVERS");
-    deployContext.environmentVariables[zoneNameServersEnv] = nameServers;
+    deployContext.addEnvironmentVariables(deployPhaseCommon.getInjectedEnvVarsFor(serviceContext, {
+        ZONE_NAME: name,
+        ZONE_ID: id,
+        ZONE_NAME_SERVERS: nameServers,
+    }));
 
     return deployContext;
 }

--- a/lib/services/s3/index.js
+++ b/lib/services/s3/index.js
@@ -36,12 +36,11 @@ function getDeployContext(serviceContext, cfStack) {
     let deployContext = new DeployContext(serviceContext);
 
     //Env variables to inject into consuming services
-    let bucketNameEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'BUCKET_NAME');
-    deployContext.environmentVariables[bucketNameEnv] = bucketName;
-    let bucketUrlEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, "BUCKET_URL");
-    deployContext.environmentVariables[bucketUrlEnv] = `https://${bucketName}.s3.amazonaws.com/`
-    let regionEndpointEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, "REGION_ENDPOINT");
-    deployContext.environmentVariables[regionEndpointEnv] = `s3-${accountConfig.region}.amazonaws.com`;
+    deployContext.addEnvironmentVariables(deployPhaseCommon.getInjectedEnvVarsFor(serviceContext, {
+        BUCKET_NAME: bucketName,
+        BUCKET_URL: `https://${bucketName}.s3.amazonaws.com/`,
+        REGION_ENDPOINT: `s3-${accountConfig.region}.amazonaws.com`
+    }));
 
     //Need two policies for accessing S3. The first allows you to list the contents of the bucket,
     // and the second allows you to modify objects in that bucket

--- a/lib/services/sns/index.js
+++ b/lib/services/sns/index.js
@@ -43,10 +43,10 @@ function getDeployContext(serviceContext, cfStack) {
     deployContext.eventOutputs.principal = "sns.amazonaws.com";
 
     //Env variables to inject into consuming services
-    let topicArnEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'TOPIC_ARN');
-    deployContext.environmentVariables[topicArnEnv] = topicArn;
-    let topicNameEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, "TOPIC_NAME");
-    deployContext.environmentVariables[topicNameEnv] = topicName;
+    deployContext.addEnvironmentVariables(deployPhaseCommon.getInjectedEnvVarsFor(serviceContext, {
+        TOPIC_ARN: topicArn,
+        TOPIC_NAME: topicName
+    }));
 
     //Policy to talk to this queue
     deployContext.policies.push({

--- a/lib/services/sqs/index.js
+++ b/lib/services/sqs/index.js
@@ -113,12 +113,11 @@ function getDeployContext(serviceContext, cfStack) {
     let deployContext = new DeployContext(serviceContext);
 
     //Env variables to inject into consuming services
-    let queueNameEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'QUEUE_NAME');
-    deployContext.environmentVariables[queueNameEnv] = queueName;
-    let queueArnEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, "QUEUE_ARN");
-    deployContext.environmentVariables[queueArnEnv] = queueArn;
-    let queueUrlEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, "QUEUE_URL");
-    deployContext.environmentVariables[queueUrlEnv] = queueUrl;
+    deployContext.addEnvironmentVariables(deployPhaseCommon.getInjectedEnvVarsFor(serviceContext, {
+        QUEUE_NAME: queueName,
+        QUEUE_ARN: queueArn,
+        QUEUE_URL: queueUrl
+    }));
 
     //Add event outputs for event consumption
     deployContext.eventOutputs.queueUrl = queueUrl;
@@ -148,16 +147,15 @@ function getDeployContext(serviceContext, cfStack) {
 
     //Add exports if a dead letter queue was specified
     if (deadLetterQueueName) {
-        let deadLetterQueueNameEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, 'DEAD_LETTER_QUEUE_NAME');
-        deployContext.environmentVariables[deadLetterQueueNameEnv] = deadLetterQueueName;
-        let deadLetterQueueArnEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, "DEAD_LETTER_QUEUE_ARN");
-        deployContext.environmentVariables[deadLetterQueueArnEnv] = deadLetterQueueArn;
-        let deadLetterQueueUrlEnv = deployPhaseCommon.getInjectedEnvVarName(serviceContext, "DEAD_LETTER_QUEUE_URL");
-        deployContext.environmentVariables[deadLetterQueueUrlEnv] = deadLetterQueueUrl;
+        deployContext.addEnvironmentVariables(deployPhaseCommon.getInjectedEnvVarsFor(serviceContext, {
+            DEAD_LETTER_QUEUE_NAME:deadLetterQueueName,
+            DEAD_LETTER_QUEUE_ARN: deadLetterQueueArn,
+            DEAD_LETTER_QUEUE_URL: deadLetterQueueUrl
+        }));
 
         deployContext.eventOutputs.deadLetterQueueUrl = deadLetterQueueUrl;
         deployContext.eventOutputs.deadLetterQueueArn = deadLetterQueueArn;
-        
+
         deployContext.policies[0].Resource.push(deadLetterQueueArn);
     }
 

--- a/test/common/deploy-phase-common-test.js
+++ b/test/common/deploy-phase-common-test.js
@@ -44,10 +44,15 @@ describe('Deploy phase common module', function () {
         sandbox.restore();
     });
 
-    describe('getInjectedEnvVarName', function () {
-        it('should return the environment variable name from the given ServiceContext and suffix', function () {
-            let envVarName = deployPhaseCommon.getInjectedEnvVarName(serviceContext, "SOME_INFO");
-            expect(envVarName).to.equal("FAKETYPE_FAKEAPP_FAKEENV_FAKESERVICE_SOME_INFO");
+    describe('getInjectedEnvVarsFor', function() {
+        it('should return environment variables with the service name', function() {
+            let vars = deployPhaseCommon.getInjectedEnvVarsFor(serviceContext, {FOO: 'bar'});
+            expect(vars).to.have.property('FAKESERVICE_FOO', 'bar');
+        });
+
+        it('should return environment variables with the legacy format', function() {
+            let vars = deployPhaseCommon.getInjectedEnvVarsFor(serviceContext, {FOO: 'bar'});
+            expect(vars).to.have.property('FAKETYPE_FAKEAPP_FAKEENV_FAKESERVICE_FOO', 'bar');
         });
     });
 

--- a/test/common/rds-deployers-common-test.js
+++ b/test/common/rds-deployers-common-test.js
@@ -63,11 +63,10 @@ describe('RDS deployers common module', function () {
             }
 
             let deployContext = rdsDeployersCommon.getDeployContext(serviceContext, rdsCfStack);
-            console.log(deployContext.environmentVariables);
-            expect(deployContext.environmentVariables['FAKETYPE_FAKEAPP_FAKEENV_FAKESERVICE_ADDRESS']).to.equal(dbAddress);
-            expect(deployContext.environmentVariables['FAKETYPE_FAKEAPP_FAKEENV_FAKESERVICE_PORT']).to.equal(dbPort);
-            expect(deployContext.environmentVariables['FAKETYPE_FAKEAPP_FAKEENV_FAKESERVICE_USERNAME']).to.equal(dbUsername);
-            expect(deployContext.environmentVariables['FAKETYPE_FAKEAPP_FAKEENV_FAKESERVICE_DATABASE_NAME']).to.equal(dbName);
+            expect(deployContext.environmentVariables['FAKESERVICE_ADDRESS']).to.equal(dbAddress);
+            expect(deployContext.environmentVariables['FAKESERVICE_PORT']).to.equal(dbPort);
+            expect(deployContext.environmentVariables['FAKESERVICE_USERNAME']).to.equal(dbUsername);
+            expect(deployContext.environmentVariables['FAKESERVICE_DATABASE_NAME']).to.equal(dbName);
         });
     });
 

--- a/test/services/dynamodb/dynamodb-test.js
+++ b/test/services/dynamodb/dynamodb-test.js
@@ -203,8 +203,7 @@ describe('dynamodb deployer', function () {
                     expect(deployContext).to.be.instanceof(DeployContext);
                     expect(deployContext.policies.length).to.equal(1);
                     expect(deployContext.policies[0].Resource[0]).to.equal(tableArn);
-                    let tableNameVar = `${serviceType}_${appName}_${envName}_${serviceName}_TABLE_NAME`.toUpperCase();
-                    expect(deployContext.environmentVariables[tableNameVar]).to.equal(tableName);
+                    expect(deployContext.environmentVariables[`${serviceName}_TABLE_NAME`.toUpperCase()]).to.equal(tableName);
                 });
         });
     });

--- a/test/services/kms/kms-test.js
+++ b/test/services/kms/kms-test.js
@@ -115,10 +115,10 @@ describe('kms deployer', function () {
                     expect(deployStackStub.callCount).to.equal(1);
                     expect(deployContext).to.be.instanceof(DeployContext);
                     expect(deployContext.policies).to.have.lengthOf(1);
-                    expect(deployContext.environmentVariables["KMS_FAKEAPP_FAKEENV_FAKESERVICE_KEY_ID"]).to.equal(keyId);
-                    expect(deployContext.environmentVariables["KMS_FAKEAPP_FAKEENV_FAKESERVICE_KEY_ARN"]).to.equal(keyArn);
-                    expect(deployContext.environmentVariables["KMS_FAKEAPP_FAKEENV_FAKESERVICE_ALIAS_NAME"]).to.equal('alias/' + alias);
-                    expect(deployContext.environmentVariables["KMS_FAKEAPP_FAKEENV_FAKESERVICE_ALIAS_ARN"]).to.equal('arn:aws:kms:us-west-2:000000000:alias/' + alias);
+                    expect(deployContext.environmentVariables["FAKESERVICE_KEY_ID"]).to.equal(keyId);
+                    expect(deployContext.environmentVariables["FAKESERVICE_KEY_ARN"]).to.equal(keyArn);
+                    expect(deployContext.environmentVariables["FAKESERVICE_ALIAS_NAME"]).to.equal('alias/' + alias);
+                    expect(deployContext.environmentVariables["FAKESERVICE_ALIAS_ARN"]).to.equal('arn:aws:kms:us-west-2:000000000:alias/' + alias);
                 });
         });
 
@@ -152,8 +152,8 @@ describe('kms deployer', function () {
 
                     expect(deployContext).to.be.instanceof(DeployContext);
                     expect(deployContext.policies).to.have.lengthOf(1);
-                    expect(deployContext.environmentVariables["KMS_FAKEAPP_FAKEENV_FAKESERVICE_ALIAS_NAME"]).to.equal(alias);
-                    expect(deployContext.environmentVariables["KMS_FAKEAPP_FAKEENV_FAKESERVICE_ALIAS_ARN"]).to.equal(aliasArn);
+                    expect(deployContext.environmentVariables["FAKESERVICE_ALIAS_NAME"]).to.equal(alias);
+                    expect(deployContext.environmentVariables["FAKESERVICE_ALIAS_ARN"]).to.equal(aliasArn);
                 });
         });
 

--- a/test/services/memcached/memcached-test.js
+++ b/test/services/memcached/memcached-test.js
@@ -112,7 +112,7 @@ describe('memcached deployer', function () {
         let dependenciesDeployContexts;
         let cacheAddress = "fakeaddress.byu.edu";
         let cachePort = 11211;
-        let envPrefix = `MEMCACHED_${appName}_${envName}_FAKESERVICE`.toUpperCase();
+        let envPrefix = 'FAKESERVICE';
 
         beforeEach(function() {
             serviceContext.params = {

--- a/test/services/mysql/mysql-test.js
+++ b/test/services/mysql/mysql-test.js
@@ -96,7 +96,7 @@ describe('mysql deployer', function () {
     });
 
     describe('deploy', function () {
-        let envPrefix = `MYSQL_${appName}_${envName}_FAKESERVICE`.toUpperCase();
+        let envPrefix = 'FAKESERVICE';
         let databaseAddress = "fakeaddress.amazonaws.com";
         let databasePort = 3306;
         let databaseUsername = "handel";

--- a/test/services/postgresql/postgresql-test.js
+++ b/test/services/postgresql/postgresql-test.js
@@ -96,7 +96,7 @@ describe('postgresql deployer', function () {
 
     describe('deploy', function () {
         let ownPreDeployContext;
-        let envPrefix;
+        let envPrefix = 'FAKESERVICE';
         let dependenciesDeployContexts;
         let databaseAddress = "fakeaddress.amazonaws.com";
         let databasePort = 3306;
@@ -134,8 +134,6 @@ describe('postgresql deployer', function () {
             });
             
             dependenciesDeployContexts = [];
-            
-            envPrefix = `POSTGRESQL_${appName}_${envName}_FAKESERVICE`.toUpperCase();
         });
 
 

--- a/test/services/redis/redis-test.js
+++ b/test/services/redis/redis-test.js
@@ -143,7 +143,7 @@ describe('redis deployer', function () {
     
             let cacheAddress = "fakeaddress.byu.edu";
             let cachePort = 6379;
-            let envPrefix = `REDIS_${appName}_${envName}_FAKESERVICE`.toUpperCase();
+            let envPrefix = 'FAKESERVICE';
 
             let deployStackStub = sandbox.stub(deployPhaseCommon, 'deployCloudFormationStack').returns(Promise.resolve({
                 Outputs: [

--- a/test/services/route53zone/route53zone-test.js
+++ b/test/services/route53zone/route53zone-test.js
@@ -130,9 +130,9 @@ describe('route53zone deployer', function () {
                     expect(deployStackStub.callCount).to.equal(1);
                     expect(deployContext).to.be.instanceof(DeployContext);
                     expect(deployContext.policies).to.be.empty;
-                    expect(deployContext.environmentVariables["ROUTE53_FAKEAPP_FAKEENV_FAKESERVICE_ZONE_NAME"]).to.equal(dnsName);
-                    expect(deployContext.environmentVariables["ROUTE53_FAKEAPP_FAKEENV_FAKESERVICE_ZONE_ID"]).to.equal(zoneId);
-                    expect(deployContext.environmentVariables["ROUTE53_FAKEAPP_FAKEENV_FAKESERVICE_ZONE_NAME_SERVERS"]).to.equal(zoneNameServers);
+                    expect(deployContext.environmentVariables["FAKESERVICE_ZONE_NAME"]).to.equal(dnsName);
+                    expect(deployContext.environmentVariables["FAKESERVICE_ZONE_ID"]).to.equal(zoneId);
+                    expect(deployContext.environmentVariables["FAKESERVICE_ZONE_NAME_SERVERS"]).to.equal(zoneNameServers);
                 });
         });
 
@@ -165,9 +165,9 @@ describe('route53zone deployer', function () {
           VPCRegion: ${serviceContext.accountConfig.region}`);
                     expect(deployContext).to.be.instanceof(DeployContext);
                     expect(deployContext.policies).to.be.empty;
-                    expect(deployContext.environmentVariables["ROUTE53_FAKEAPP_FAKEENV_FAKESERVICE_ZONE_NAME"]).to.equal(dnsName);
-                    expect(deployContext.environmentVariables["ROUTE53_FAKEAPP_FAKEENV_FAKESERVICE_ZONE_ID"]).to.equal(zoneId);
-                    expect(deployContext.environmentVariables["ROUTE53_FAKEAPP_FAKEENV_FAKESERVICE_ZONE_NAME_SERVERS"]).to.equal(zoneNameServers);
+                    expect(deployContext.environmentVariables["FAKESERVICE_ZONE_NAME"]).to.equal(dnsName);
+                    expect(deployContext.environmentVariables["FAKESERVICE_ZONE_ID"]).to.equal(zoneId);
+                    expect(deployContext.environmentVariables["FAKESERVICE_ZONE_NAME_SERVERS"]).to.equal(zoneNameServers);
                 });
         });
     });

--- a/test/services/s3/s3-test.js
+++ b/test/services/s3/s3-test.js
@@ -96,9 +96,9 @@ describe('s3 deployer', function () {
                         expect(deployStackStub.callCount).to.equal(2);
                         expect(deployContext).to.be.instanceof(DeployContext);
                         expect(deployContext.policies.length).to.equal(2);
-                        expect(deployContext.environmentVariables["S3_FAKEAPP_FAKEENV_FAKESERVICE_BUCKET_NAME"]).to.equal(bucketName);
-                        expect(deployContext.environmentVariables["S3_FAKEAPP_FAKEENV_FAKESERVICE_BUCKET_URL"]).to.contain(bucketName);
-                        expect(deployContext.environmentVariables["S3_FAKEAPP_FAKEENV_FAKESERVICE_REGION_ENDPOINT"]).to.exist;
+                        expect(deployContext.environmentVariables["FAKESERVICE_BUCKET_NAME"]).to.equal(bucketName);
+                        expect(deployContext.environmentVariables["FAKESERVICE_BUCKET_URL"]).to.contain(bucketName);
+                        expect(deployContext.environmentVariables["FAKESERVICE_REGION_ENDPOINT"]).to.exist;
                     });
             });
         });

--- a/test/services/sns/sns-test.js
+++ b/test/services/sns/sns-test.js
@@ -113,11 +113,11 @@ describe('sns deployer', function () {
                     expect(deployStackStub.calledOnce).to.be.true;
                     expect(deployContext).to.be.instanceof(DeployContext);
 
+                    let envPrefix = serviceName.toUpperCase();
+
                     //Should have exported 2 env vars
-                    let topicNameEnv = `${serviceType}_${appName}_${envName}_${serviceName}_TOPIC_NAME`.toUpperCase()
-                    expect(deployContext.environmentVariables[topicNameEnv]).to.equal(topicName);
-                    let topicArnEnv = `${serviceType}_${appName}_${envName}_${serviceName}_TOPIC_ARN`.toUpperCase()
-                    expect(deployContext.environmentVariables[topicArnEnv]).to.equal(topicArn);
+                    expect(deployContext.environmentVariables).to.have.property(`${envPrefix}_TOPIC_NAME`, topicName);
+                    expect(deployContext.environmentVariables).to.have.property(`${envPrefix}_TOPIC_ARN`, topicArn);
 
                     //Should have exported 1 policy
                     expect(deployContext.policies.length).to.equal(1); //Should have exported one policy

--- a/test/services/sqs/sqs-test.js
+++ b/test/services/sqs/sqs-test.js
@@ -115,20 +115,16 @@ describe('sqs deployer', function () {
 
                     expect(deployContext).to.be.instanceof(DeployContext);
 
-                    //Should have exported 3 env vars
-                    let queueNameEnv = `${serviceType}_${appName}_${envName}_${serviceName}_QUEUE_NAME`.toUpperCase()
-                    expect(deployContext.environmentVariables[queueNameEnv]).to.equal(queueName);
-                    let queueUrlEnv = `${serviceType}_${appName}_${envName}_${serviceName}_QUEUE_URL`.toUpperCase()
-                    expect(deployContext.environmentVariables[queueUrlEnv]).to.equal(queueUrl);
-                    let queueArnEnv = `${serviceType}_${appName}_${envName}_${serviceName}_QUEUE_ARN`.toUpperCase()
-                    expect(deployContext.environmentVariables[queueArnEnv]).to.equal(queueArn);
+                    let envPrefix = serviceName.toUpperCase();
 
-                    let deadLetterQueueNameEnv = `${serviceType}_${appName}_${envName}_${serviceName}_DEAD_LETTER_QUEUE_NAME`.toUpperCase()
-                    expect(deployContext.environmentVariables[deadLetterQueueNameEnv]).to.equal(deadLetterQueueName);
-                    let deadLetterQueueUrlEnv = `${serviceType}_${appName}_${envName}_${serviceName}_DEAD_LETTER_QUEUE_URL`.toUpperCase()
-                    expect(deployContext.environmentVariables[deadLetterQueueUrlEnv]).to.equal(deadLetterQueueUrl);
-                    let deadLetterQueueArnEnv = `${serviceType}_${appName}_${envName}_${serviceName}_DEAD_LETTER_QUEUE_ARN`.toUpperCase()
-                    expect(deployContext.environmentVariables[deadLetterQueueArnEnv]).to.equal(deadLetterQueueArn);
+                    //Should have exported 3 env vars
+                    expect(deployContext.environmentVariables).to.have.property(`${envPrefix}_QUEUE_NAME`, queueName);
+                    expect(deployContext.environmentVariables).to.have.property(`${envPrefix}_QUEUE_URL`, queueUrl);
+                    expect(deployContext.environmentVariables).to.have.property(`${envPrefix}_QUEUE_ARN`, queueArn);
+
+                    expect(deployContext.environmentVariables).to.have.property(`${envPrefix}_DEAD_LETTER_QUEUE_NAME`,deadLetterQueueName);
+                    expect(deployContext.environmentVariables).to.have.property(`${envPrefix}_DEAD_LETTER_QUEUE_URL`, deadLetterQueueUrl);
+                    expect(deployContext.environmentVariables).to.have.property(`${envPrefix}_DEAD_LETTER_QUEUE_ARN`, deadLetterQueueArn);
 
                     //Should have exported 1 policy
                     expect(deployContext.policies.length).to.equal(1); //Should have exported one policy


### PR DESCRIPTION
Resolves #270 .

Adds `HANDEL_PARAMETER_STORE_PREFIX`, with the computed prefix for parameter store values.

Changes injected environment variables to drop the service type, app name, and env name.  Environment variables now look like `<SERVICE_NAME>_<VARIABLE_NAME>`.

For compatibility, the old variable names are still included.  They will be removed pre-1.0 release.

Question to consider: do we want to prefix the environment variables with something like `HANDEL_`? I personally don't think it's necessary, but I can see how we might want the extra namespacing.