### PR TITLE
Fix parameter store prefix to correct value (no service name)

### DIFF
--- a/lib/common/deploy-phase-common.js
+++ b/lib/common/deploy-phase-common.js
@@ -48,7 +48,7 @@ function legacyEnvVarName(serviceContext, name) {
 }
 
 function ssmParamPrefix(serviceContext) {
-    return `${serviceContext.appName}.${serviceContext.environmentName}.${serviceContext.serviceName}`;
+    return `${serviceContext.appName}.${serviceContext.environmentName}`;
 }
 
 exports.getSsmParamName = function (serviceContext, suffix) {

--- a/test/common/deploy-phase-common-test.js
+++ b/test/common/deploy-phase-common-test.js
@@ -59,7 +59,7 @@ describe('Deploy phase common module', function () {
     describe('getSsmParamName', function() {
         it('should return a consistent name for SSM params', function() {
             let paramName = deployPhaseCommon.getSsmParamName(serviceContext, 'myparamname');
-            expect(paramName).to.equal("FakeApp.FakeEnv.FakeService.myparamname");
+            expect(paramName).to.equal("FakeApp.FakeEnv.myparamname");
         });
     });
 


### PR DESCRIPTION
This fixes the parameter store prefix to use the correct value of appName.envName instead of appName.envName.serviceName