### PR TITLE
Add support for HTTP passthrough URLs in Swagger documents

### DIFF
--- a/docs/supported-services/apigateway.rst
+++ b/docs/supported-services/apigateway.rst
@@ -96,36 +96,14 @@ The Swagger section is defined by the following schema:
 
     swagger: <string> # The path to the Swagger file in your repository
 
-Handel Swagger Extensions
+Lambda Swagger Extensions
 *************************
 For the most part, the Swagger document you provide in the *swagger* section is just a regular Swagger document, 
-specifying the API paths you want your app to use. Handel makes use of certain Swagger extensions in your Swagger document 
-to know which Lambdas to create, and how to wire them to your API.
+specifying the API paths you want your app to use. If you're using Lambdas to service your API Gateway resources, 
+Handel makes use of certain Swagger extensions in your Swagger document so that it can create and wire your Lambdas
+for your.
 
-Consider the following vanilla Swagger document:
-
-.. code-block:: json
-
-    {
-      "swagger": "2.0",
-      "info": {
-        "title": "my-cool-app",
-        "description": "Test Swagger API",
-        "version:": "1.0"
-      },
-      "paths": {
-        "/": {
-          "get": {
-            "responses": {
-              "200": {}
-            }
-          }
-        }
-      }
-    }
-
-This simple Swagger defines a single path "/" that will make up the API. In order for Handel to be able to create the API,
-you need to add some custom extensions to your Handel file, telling how to create the Lambdas and wire them:
+Consider the following Swagger document:
 
 .. code-block:: json
 
@@ -156,7 +134,8 @@ you need to add some custom extensions to your Handel file, telling how to creat
       }
     }
 
-Notice that the Swagger document now contains an *x-lambda-functions* section. This section contains a list of elements that define Lambda configurations. 
+Notice that this is just a vanilla Swagger document for the most part. It does have some Handel-provided extensions, however. Notice that the Swagger 
+document contains an *x-lambda-functions* section. This section contains a list of elements that define Lambda configurations. 
 For each item in this list, Handel will create a Lambda function for you. These objects are defined by the following schema:
 
 .. code-block:: none
@@ -173,6 +152,35 @@ For each item in this list, Handel will create a Lambda function for you. These 
     }
 
 Also notice that the paths in your document have an *x-lambda-function* element. This element tells Handel which Lambda function from the *x-lambda-functions* section you want that API path to be serviced by.
+
+HTTP Passthrough Swagger Extensions
+***********************************
+In addition to servicing your API methods with Lambdas, you can configure API Gateway to just do an HTTP passthrough to some other HTTP endpoint, be it an AWS EC2 server or something else outside of AWS entirely.
+
+Handel supports this with another swagger extension, called *x-http-passthrough-url* that you configure on your resource methods. Here's an example:
+
+.. code-block:: json
+
+    {
+      "swagger": "2.0",
+      "info": {
+        "title": "my-cool-app",
+        "description": "Test Swagger API",
+        "version:": "1.0"
+      },
+      "paths": {
+        "/": {
+          "get": {
+            "responses": {
+              "200": {}
+            },
+            "x-http-passthrough-url": "https://my.cool.fake.url.com"
+          }
+        }
+      }
+    }
+
+The above Swagger document will route GET on the "/" path to "https://my.cool.fake.url.com". All request headers, parameters, and body will be passed through directly to the given URL, and the response from the URL will be passed through API Gateway without modification.
 
 .. _apigateway-tags:
 

--- a/lib/services/apigateway/swagger/swagger-deploy-type.js
+++ b/lib/services/apigateway/swagger/swagger-deploy-type.js
@@ -119,6 +119,7 @@ function enrichSwagger(stackName, originalSwagger, accountConfig) {
         for (let methodName in path) {
             let method = path[methodName];
             let requestedFunction = method['x-lambda-function'];
+            let httpPassthroughUrl = method['x-http-passthrough-url'];
             if (requestedFunction) { //Replace reference with Lambda info
                 let functionConfig = enrichedSwagger['x-lambda-functions'][requestedFunction];
                 if (!functionConfig) {
@@ -132,6 +133,14 @@ function enrichSwagger(stackName, originalSwagger, accountConfig) {
                     passthroughBehavior: 'when_no_match',
                     httpMethod: 'POST',
                     type: 'aws_proxy'
+                }
+            }
+            else if(httpPassthroughUrl) {
+                method['x-amazon-apigateway-integration'] = {
+                    uri: httpPassthroughUrl,
+                    passthroughBehavior: 'when_no_match',
+                    httpMethod: methodName.toUpperCase(),
+                    type: 'http_proxy'
                 }
             }
         }

--- a/test/services/apigateway/swagger/test-swagger.json
+++ b/test/services/apigateway/swagger/test-swagger.json
@@ -21,6 +21,22 @@
                 },
                 "x-lambda-function": "my-function-2"
             }
+        },
+        "/test3": {
+            "get": {
+                "responses": {
+                    "200": {}
+                },
+                "x-http-passthrough-url": "https://my.fake.url.com"
+            }
+        },
+        "/test4": {
+            "put": {
+                "responses": {
+                    "200": {}
+                },
+                "x-http-passthrough-url": "https://my.other.fake.url.com"
+            }
         }
     },
     "x-lambda-functions": {


### PR DESCRIPTION
API Gateway supports HTTP passthrough as a choice for handling API gateway resource methods, and this change adds support in Handel to use them. You can mix and match these HTTP passthrough methods and Lambda functions in your Swagger file.