### PR TITLE
Support fronting S3 Static Sites with CloudFront

### DIFF
--- a/docs/supported-services/route53zone.rst
+++ b/docs/supported-services/route53zone.rst
@@ -115,8 +115,11 @@ Certain supported services can create an alias record in this zone.  The current
 
 * Beanstalk
 * ECS
+* S3 Static Site
 
-Each service can support multiple DNS entries. See the individual service documentation for how to define the DNS names.
+Beanstalk and ECS can support multiple DNS entries.
+
+See the individual service documentation for how to define the DNS names.
 
 The DNS name must either match or be a subdomain of an existing Route 53 hosted zone name. If the hosted zone is configured
 in the same Handel environment, you must declare it as a dependency of the service consuming it, so that Handel can make

--- a/docs/supported-services/s3staticsite.rst
+++ b/docs/supported-services/s3staticsite.rst
@@ -63,6 +63,11 @@ This service takes the following parameters:
      - No 
      - error.html
      - The name of the file in S3 to serve as the error document.
+   * - cloudfront
+     - enabled|disabled
+     - No
+     - enabled
+     - Whether or not to set up a Cloudfront distribution. Features such as custom DNS names and HTTPS support require CloudFront.
    * - https_certificate
      - string
      - No

--- a/docs/supported-services/s3staticsite.rst
+++ b/docs/supported-services/s3staticsite.rst
@@ -63,11 +63,82 @@ This service takes the following parameters:
      - No 
      - error.html
      - The name of the file in S3 to serve as the error document.
+   * - cdn
+     - :ref:`s3staticsite-cdn`
+     - No
+     -
+     - The configuration of the CloudFront CDN for this site.
    * - tags
      - :ref:`s3staticsite-tags`
      - No
      -
      - Any tags you want to apply to your S3 bucket
+
+
+.. _s3staticsite-cdn:
+
+CDN Configuration
+~~~~~~~~~~~~~~~~~
+The CloudFront CDN configuration is defined by the following schema:
+
+.. code-block:: yaml
+
+   cdn:
+     price_class: <price class> #defaults to 100
+     logging: <enabled|disabled> #defaults to enabled
+     min_ttl: <ttl time> #defaults to 0
+     max_ttl: <ttl time> #defaults to 1 year
+     default_ttl: <ttl time> #defaults to 1 day
+     https_certificate: <string> # Required to use HTTPs. The ID of the ACM certificate to use on the CloudFront distribution.
+     dns_names: #Optional
+       - <DNS Name>
+
+
+.. _s3staticsite-cdn-price-class:
+
+Price Classes
+`````````````
+
+Valid price class values are `100`, `200`, and `all`. For more information on what each value means, see
+`CloudFront Pricing <https://aws.amazon.com/cloudfront/pricing/>`_
+
+
+.. _s3staticsite-cdn-times:
+
+TTL Values
+``````````
+
+`min_ttl`, `max_ttl`, and `default_ttl` control how often CloudFront will check the origin for updated objects.
+They are specified in seconds. In the interest of readability, Handel also offers some duration shortcuts:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Alias
+     - Duration in seconds
+   * - second(s)
+     - 1
+   * - minute(s)
+     - 60
+   * - hour(s)
+     - 3600
+   * - day(s)
+     - 86400
+   * - year
+     - 31536000
+
+So, writing this:
+
+
+.. code-block:: yaml
+
+    max_ttl: 2 days
+
+is equivalent to:
+
+.. code-block:: yaml
+
+    max_ttl: 172800
 
 .. _s3staticsite-tags:
 
@@ -102,6 +173,9 @@ This Handel file shows an S3 Static Site service being configured:
           versioning: enabled
           index_document: index.html
           error_document: error.html
+          cdn:
+            price_class: all
+            https_certificate: 6afbc85f-de0c-4ee9-b7d7-28b961eca135
           tags:
             mytag: myvalue
 

--- a/docs/supported-services/s3staticsite.rst
+++ b/docs/supported-services/s3staticsite.rst
@@ -2,7 +2,7 @@
 
 S3 Static Site
 ==============
-This document contains information about the S3 Static Site service supported in Handel. This Handel service sets up an S3 bucket for your static website.
+This document contains information about the S3 Static Site service supported in Handel. This Handel service sets up an S3 bucket and CloudFront distribution for your static website.
 
 .. ATTENTION::
 
@@ -63,11 +63,46 @@ This service takes the following parameters:
      - No 
      - error.html
      - The name of the file in S3 to serve as the error document.
-   * - cdn
-     - :ref:`s3staticsite-cdn`
+   * - https_certificate
+     - string
      - No
      -
-     - The configuration of the CloudFront CDN for this site.
+     - The ID of an Amazon Certificate Manager certificate to use for this site
+   * - dns_name
+     - string
+     - No
+     -
+     - The DNS name to use for the CloudFront distribution. See :ref:`route53zone-records`.
+   * - cloudfront_price_class
+     - string
+     - No
+     - all
+     - one of `100`, `200`, or `all`. See `CloudFront Pricing <https://aws.amazon.com/cloudfront/pricing/>`_.
+   * - cloudfront_logging
+     - enabled|disabled
+     - No
+     - enabled
+     - Whether or not to log all calls to Cloudfront.
+   * - cloudfront_min_ttl
+     - :ref:`s3staticsite-ttl`
+     - No
+     - 0
+     - Minimum time to cache objects in CloudFront
+   * - cloudfront_max_ttl
+     - :ref:`s3staticsite-ttl`
+     - No
+     - 1 year
+     - Maximum time to cache objects in CloudFront
+   * - cloudfront_default_ttl
+     - :ref:`s3staticsite-ttl`
+     - No
+     - 1 day
+     - Default time to cache objects in CloudFront
+   * - https_certificate
+     - string
+     - No
+     -
+     - The ID of an Amazon Certificate Manager certificate to use for this site
    * - tags
      - :ref:`s3staticsite-tags`
      - No
@@ -75,41 +110,14 @@ This service takes the following parameters:
      - Any tags you want to apply to your S3 bucket
 
 
-.. _s3staticsite-cdn:
-
-CDN Configuration
-~~~~~~~~~~~~~~~~~
-The CloudFront CDN configuration is defined by the following schema:
-
-.. code-block:: yaml
-
-   cdn:
-     price_class: <price class> #defaults to 100
-     logging: <enabled|disabled> #defaults to enabled
-     min_ttl: <ttl time> #defaults to 0
-     max_ttl: <ttl time> #defaults to 1 year
-     default_ttl: <ttl time> #defaults to 1 day
-     https_certificate: <string> # Required to use HTTPs. The ID of the ACM certificate to use on the CloudFront distribution.
-     dns_names: #Optional
-       - <DNS Name>
-
-
-.. _s3staticsite-cdn-price-class:
-
-Price Classes
-`````````````
-
-Valid price class values are `100`, `200`, and `all`. For more information on what each value means, see
-`CloudFront Pricing <https://aws.amazon.com/cloudfront/pricing/>`_
-
-
-.. _s3staticsite-cdn-times:
+.. _s3staticsite-ttl:
 
 TTL Values
-``````````
+~~~~~~~~~~
 
-`min_ttl`, `max_ttl`, and `default_ttl` control how often CloudFront will check the origin for updated objects.
-They are specified in seconds. In the interest of readability, Handel also offers some duration shortcuts:
+`cloudfront_min_ttl`, `cloudfront_max_ttl`, and `cloudfront_default_ttl` control how often CloudFront will check the
+source bucket for updated objects. They are specified in seconds.
+In the interest of readability, Handel also offers some duration shortcuts:
 
 .. list-table::
    :header-rows: 1
@@ -132,13 +140,13 @@ So, writing this:
 
 .. code-block:: yaml
 
-    max_ttl: 2 days
+    cloudfront_max_ttl: 2 days
 
 is equivalent to:
 
 .. code-block:: yaml
 
-    max_ttl: 172800
+    cloudfront_max_ttl: 172800
 
 .. _s3staticsite-tags:
 

--- a/docs/supported-services/s3staticsite.rst
+++ b/docs/supported-services/s3staticsite.rst
@@ -64,63 +64,74 @@ This service takes the following parameters:
      - error.html
      - The name of the file in S3 to serve as the error document.
    * - cloudfront
-     - enabled|disabled
-     - No
-     - enabled
-     - Whether or not to set up a Cloudfront distribution. Features such as custom DNS names and HTTPS support require CloudFront.
-   * - https_certificate
-     - string
+     - :ref:`s3staticsite-cloudfront`
      - No
      -
-     - The ID of an Amazon Certificate Manager certificate to use for this site
-   * - dns_name
-     - string
-     - No
-     -
-     - The DNS name to use for the CloudFront distribution. See :ref:`route53zone-records`.
-   * - cloudfront_price_class
-     - string
-     - No
-     - all
-     - one of `100`, `200`, or `all`. See `CloudFront Pricing <https://aws.amazon.com/cloudfront/pricing/>`_.
-   * - cloudfront_logging
-     - enabled|disabled
-     - No
-     - enabled
-     - Whether or not to log all calls to Cloudfront.
-   * - cloudfront_min_ttl
-     - :ref:`s3staticsite-ttl`
-     - No
-     - 0
-     - Minimum time to cache objects in CloudFront
-   * - cloudfront_max_ttl
-     - :ref:`s3staticsite-ttl`
-     - No
-     - 1 year
-     - Maximum time to cache objects in CloudFront
-   * - cloudfront_default_ttl
-     - :ref:`s3staticsite-ttl`
-     - No
-     - 1 day
-     - Default time to cache objects in CloudFront
-   * - https_certificate
-     - string
-     - No
-     -
-     - The ID of an Amazon Certificate Manager certificate to use for this site
+     - Configuration for CloudFront. If not specified, CloudFront is not enabled.
    * - tags
      - :ref:`s3staticsite-tags`
      - No
      -
      - Any tags you want to apply to your S3 bucket
 
+.. _s3staticsite-cloudfront:
 
-.. _s3staticsite-ttl:
+CloudFront Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The `cloudfront` section is defined by the following schema:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Parameter
+     - Type
+     - Required
+     - Default
+     - Description
+   * - https_certificate
+     - string
+     - No
+     -
+     - The ID of an Amazon Certificate Manager certificate to use for this site
+   * - dns_names
+     - List<string>
+     - No
+     -
+     - The DNS names to use for the CloudFront distribution. See :ref:`route53zone-records`.
+   * - price_class
+     - string
+     - No
+     - all
+     - one of `100`, `200`, or `all`. See `CloudFront Pricing <https://aws.amazon.com/cloudfront/pricing/>`_.
+   * - logging
+     - enabled|disabled
+     - No
+     - enabled
+     - Whether or not to log all calls to Cloudfront.
+   * - min_ttl
+     - :ref:`s3staticsite-cloudfront-ttl`
+     - No
+     - 0
+     - Minimum time to cache objects in CloudFront
+   * - max_ttl
+     - :ref:`s3staticsite-cloudfront-ttl`
+     - No
+     - 1 year
+     - Maximum time to cache objects in CloudFront
+   * - default_ttl
+     - :ref:`s3staticsite-cloudfront-ttl`
+     - No
+     - 1 day
+     - Default time to cache objects in CloudFront
+
+
+.. _s3staticsite-cloudfront-ttl:
 
 TTL Values
-~~~~~~~~~~
+``````````
 
-`cloudfront_min_ttl`, `cloudfront_max_ttl`, and `cloudfront_default_ttl` control how often CloudFront will check the
+`min_ttl`, `max_ttl`, and `default_ttl` control how often CloudFront will check the
 source bucket for updated objects. They are specified in seconds.
 In the interest of readability, Handel also offers some duration shortcuts:
 

--- a/lib/services/s3staticsite/index.js
+++ b/lib/services/s3staticsite/index.js
@@ -207,7 +207,6 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
             return getCompiledS3Template(ownServiceContext, stackName, loggingBucketName)
         })
         .then(compiledTemplate => {
-            console.log(compiledTemplate);
             let stackTags = deployPhaseCommon.getTags(ownServiceContext);
             return deployPhaseCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, SERVICE_NAME, stackTags);
         })

--- a/lib/services/s3staticsite/index.js
+++ b/lib/services/s3staticsite/index.js
@@ -28,7 +28,7 @@ const SERVICE_NAME = "S3 Static Site";
 const VERSIONING_PARAM_MAPPING = {
     enabled: 'Enabled',
     disabled: 'Suspended'
-}
+};
 
 const TTL_UNITS = {
     second: 1,
@@ -59,6 +59,7 @@ function getCompiledS3Template(ownServiceContext, stackName, loggingBucketName) 
         errorDocument,
         tags: deployPhaseCommon.getTags(ownServiceContext),
         cloudfront: !serviceParams.cloudfront || serviceParams.cloudfront === 'enabled',
+        cfLogging: !serviceParams.cloudfront_logging || serviceParams.cloudfront_logging === 'enabled',
         cfMinTTL: computeTTL(serviceParams.cloudfront_min_ttl, 0),
         cfMaxTTL: computeTTL(serviceParams.cloudfront_max_ttl, TTL_UNITS.year),
         cfDefaultTTL: computeTTL(serviceParams.cloudfront_default_ttl, TTL_UNITS.day),
@@ -103,10 +104,7 @@ function computePriceClass(priceClass, defaultValue) {
     }
 }
 
-function isValidTTL(ttl, defaultValue) {
-    if (!ttl) {
-        return defaultValue;
-    }
+function isValidTTL(ttl) {
     return TTL_REGEX.test(ttl);
 }
 

--- a/lib/services/s3staticsite/index.js
+++ b/lib/services/s3staticsite/index.js
@@ -30,14 +30,14 @@ const VERSIONING_PARAM_MAPPING = {
     disabled: 'Suspended'
 }
 
-const TTL_ALIASES = {
+const TTL_UNITS = {
     second: 1,
     minute: 60,
     hour: 3600,
     day: 86400,
     year: 31536000,
 };
-const TTL_REGEX = new RegExp(`^(\\d+)(?:(?: )*(${Object.keys(TTL_ALIASES).join('|')})(?:s)?)?$`);
+const TTL_REGEX = new RegExp(`^(\\d+)(?:(?: )*(${Object.keys(TTL_UNITS).join('|')})(?:s)?)?$`);
 
 function getCompiledS3Template(ownServiceContext, stackName, loggingBucketName) {
     let serviceParams = ownServiceContext.params;
@@ -48,6 +48,8 @@ function getCompiledS3Template(ownServiceContext, stackName, loggingBucketName) 
     let indexDocument = serviceParams.index_document || 'index.html';
     let errorDocument = serviceParams.error_document || 'error.html';
 
+    let dnsName = serviceParams.dns_name;
+
     let handlebarsParams = {
         bucketName,
         versioningStatus,
@@ -55,11 +57,71 @@ function getCompiledS3Template(ownServiceContext, stackName, loggingBucketName) 
         logFilePrefix,
         indexDocument,
         errorDocument,
-        tags: deployPhaseCommon.getTags(ownServiceContext)
+        tags: deployPhaseCommon.getTags(ownServiceContext),
+        cloudfront: !serviceParams.cloudfront || serviceParams.cloudfront === 'enabled',
+        cfMinTTL: computeTTL(serviceParams.cloudfront_min_ttl, 0),
+        cfMaxTTL: computeTTL(serviceParams.cloudfront_max_ttl, TTL_UNITS.year),
+        cfDefaultTTL: computeTTL(serviceParams.cloudfront_default_ttl, TTL_UNITS.day),
+        cfPriceClass: computePriceClass(serviceParams.cloudfront_price_class, 'all'),
+        httpsCertificateId: serviceParams.https_certificate,
+        dnsName
     };
 
-    return handlebarsUtils.compileTemplate(`${__dirname}/s3-static-site-template.yml`, handlebarsParams)
+    let dnsHostedZoneId;
+    if (dnsName) {
+        dnsHostedZoneId = route53Calls.listHostedZones()
+            .then(zones => {
+                let zone = route53Calls.getBestMatchingHostedZone(dnsName, zones);
+                if (!zone) {
+                    throw `No Route53 hosted zone found matching '${dnsName}'`
+                }
+                return zone.Id;
+            });
+    } else {
+        dnsHostedZoneId = Promise.resolve();
+    }
+
+    return dnsHostedZoneId.then(zoneId => {
+        handlebarsParams.dnsHostedZoneId = zoneId;
+        return handlebarsUtils.compileTemplate(`${__dirname}/s3-static-site-template.yml`, handlebarsParams);
+    })
 }
+
+function computePriceClass(priceClass, defaultValue) {
+    let value = priceClass || defaultValue;
+    switch (value) {
+        case 100:
+        case '100':
+            return 'PriceClass_100';
+        case 200:
+        case '200':
+            return 'PriceClass_200';
+        case 'all':
+            return 'PriceClass_All';
+        default:
+            throw 'Invalid cloudfront_price_class: ' + value;
+    }
+}
+
+function isValidTTL(ttl, defaultValue) {
+    if (!ttl) {
+        return defaultValue;
+    }
+    return TTL_REGEX.test(ttl);
+}
+
+function computeTTL(ttl, defaultValue) {
+    if (!ttl) {
+        return defaultValue;
+    }
+    let [, num, unit] = TTL_REGEX.exec(ttl);
+    if (!unit) {
+        return num;
+    }
+    let multiplier = TTL_UNITS[unit];
+    return multiplier * num;
+}
+
 
 /**
  * Service Deployer Contract Methods
@@ -78,36 +140,73 @@ exports.check = function (serviceContext, dependenciesServiceContexts) {
     if (versioning && versioning !== 'enabled' && versioning !== 'disabled') {
         errors.push(`${SERVICE_NAME} - The 'versioning' parameter must be either 'enabled' or 'disabled'`);
     }
+    let cloudfront = serviceParams.cloudfront;
+    if (cloudfront && cloudfront !== 'enabled' && cloudfront !== 'disabled') {
+        errors.push(`${SERVICE_NAME} - The 'cloudfront' parameter must be either 'enabled' or 'disabled'`);
+    }
+
+    let cloudfrontDisabled = cloudfront && cloudfront === 'disabled';
+
     let cfLogging = serviceParams.cloudfront_logging;
-    if (cfLogging && cfLogging !== 'enabled' && cfLogging !== 'disabled') {
-        errors.push(`${SERVICE_NAME} - The 'cloudfront_logging' parameter must be either 'enabled' or 'disabled'`);
+    if (cfLogging) {
+        if (cloudfrontDisabled) {
+            errors.push(`${SERVICE_NAME} - The 'cloudfront_logging' parameter cannot be specified if 'cloudfront' is set to 'disabled'`);
+        }
+        if (cfLogging !== 'enabled' && cfLogging !== 'disabled') {
+            errors.push(`${SERVICE_NAME} - The 'cloudfront_logging' parameter must be either 'enabled' or 'disabled'`);
+        }
     }
     let cfPrice = serviceParams.cloudfront_price_class;
-    if (cfPrice && cfPrice !== '100' && cfPrice !== '200' && cfPrice !== 'all') {
-        errors.push(`${SERVICE_NAME} - the 'cloudfront_price_class' parameter must be one of '100', '200', or 'all'`)
+    if (cfPrice) {
+        if (cloudfrontDisabled) {
+            errors.push(`${SERVICE_NAME} - The 'cloudfront_price_class' parameter cannot be specified if 'cloudfront' is set to 'disabled'`);
+        }
+
+        let priceString = String(cfPrice);
+        if (priceString !== '100' && priceString !== '200' && priceString !== 'all') {
+            errors.push(`${SERVICE_NAME} - the 'cloudfront_price_class' parameter must be one of '100', '200', or 'all'`)
+        }
     }
-    if (!isValidTTL(serviceParams.cloudfront_min_ttl)) {
-        errors.push(`${SERVICE_NAME} - The 'cloudfront_min_ttl' parameter must be a valid TTL value`);
+    if (serviceParams.https_certificate && cloudfrontDisabled) {
+        errors.push(`${SERVICE_NAME} - The 'https_certificate' parameter cannot be specified if 'cloudfront' is set to 'disabled'`);
     }
-    if (!isValidTTL(serviceParams.cloudfront_max_ttl)) {
-        errors.push(`${SERVICE_NAME} - The 'cloudfront_max_ttl' parameter must be a valid TTL value`);
+    let minTTL = serviceParams.cloudfront_min_ttl;
+    if (minTTL) {
+        if (cloudfrontDisabled) {
+            errors.push(`${SERVICE_NAME} - The 'cloudfront_min_ttl' parameter cannot be specified if 'cloudfront' is set to 'disabled'`);
+        }
+        if (!isValidTTL(minTTL)) {
+            errors.push(`${SERVICE_NAME} - The 'cloudfront_min_ttl' parameter must be a valid TTL value`);
+        }
     }
-    if (!isValidTTL(serviceParams.cloudfront_default_ttl)) {
-        errors.push(`${SERVICE_NAME} - The 'cloudfront_default_ttl' parameter must be a valid TTL value`);
+    let maxTTL = serviceParams.cloudfront_max_ttl;
+    if (maxTTL) {
+        if (cloudfrontDisabled) {
+            errors.push(`${SERVICE_NAME} - The 'cloudfront_max_ttl' parameter cannot be specified if 'cloudfront' is set to 'disabled'`);
+        }
+        if (!isValidTTL(maxTTL)) {
+            errors.push(`${SERVICE_NAME} - The 'cloudfront_max_ttl' parameter must be a valid TTL value`);
+        }
     }
-    if (serviceParams.dns_name && !route53Calls.isValidHostname(serviceParams.dns_name)) {
-        errors.push(`${SERVICE_NAME} - The 'dns_name' parameter must be a valid DNS hostname`);
+    let defaultTTL = serviceParams.cloudfront_default_ttl;
+    if (defaultTTL) {
+        if (cloudfrontDisabled) {
+            errors.push(`${SERVICE_NAME} - The 'cloudfront_default_ttl' parameter cannot be specified if 'cloudfront' is set to 'disabled'`);
+        }
+        if (!isValidTTL(defaultTTL)) {
+            errors.push(`${SERVICE_NAME} - The 'cloudfront_default_ttl' parameter must be a valid TTL value`);
+        }
+    }
+    if (serviceParams.dns_name) {
+        if (cloudfrontDisabled) {
+            errors.push(`${SERVICE_NAME} - The 'dns_name' parameter cannot be specified if 'cloudfront' is set to 'disabled'`);
+        }
+        if (!route53Calls.isValidHostname(serviceParams.dns_name)) {
+            errors.push(`${SERVICE_NAME} - The 'dns_name' parameter must be a valid DNS hostname`);
+        }
     }
 
     return errors;
-}
-
-
-function isValidTTL(ttl) {
-    if (!ttl) {
-        return true;
-    }
-    return TTL_REGEX.test(ttl);
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {

--- a/lib/services/s3staticsite/index.js
+++ b/lib/services/s3staticsite/index.js
@@ -23,6 +23,7 @@ const deployPhaseCommon = require('../../common/deploy-phase-common');
 const deletePhasesCommon = require('../../common/delete-phases-common');
 const s3DeployersCommon = require('../../common/s3-deployers-common');
 const handlebarsUtils = require('../../common/handlebars-utils');
+const fs = require('fs-extra');
 
 const SERVICE_NAME = "S3 Static Site";
 const VERSIONING_PARAM_MAPPING = {
@@ -40,52 +41,55 @@ const TTL_UNITS = {
 const TTL_REGEX = new RegExp(`^(\\d+)(?:(?: )*(${Object.keys(TTL_UNITS).join('|')})(?:s)?)?$`);
 
 function getCompiledS3Template(ownServiceContext, stackName, loggingBucketName) {
-    let serviceParams = ownServiceContext.params;
+    return fs.readFile(`${__dirname}/set-ipv6.js`, 'utf-8').then(setIPV6FunctionBody => {
+        let serviceParams = ownServiceContext.params;
 
-    let bucketName = serviceParams.bucket_name || stackName;
-    let versioningStatus = VERSIONING_PARAM_MAPPING[serviceParams.versioning] || 'Suspended';
-    let logFilePrefix = s3DeployersCommon.getLogFilePrefix(ownServiceContext);
-    let indexDocument = serviceParams.index_document || 'index.html';
-    let errorDocument = serviceParams.error_document || 'error.html';
+        let bucketName = serviceParams.bucket_name || stackName;
+        let versioningStatus = VERSIONING_PARAM_MAPPING[serviceParams.versioning] || 'Suspended';
+        let logFilePrefix = s3DeployersCommon.getLogFilePrefix(ownServiceContext);
+        let indexDocument = serviceParams.index_document || 'index.html';
+        let errorDocument = serviceParams.error_document || 'error.html';
 
-    let dnsName = serviceParams.dns_name;
+        let dnsName = serviceParams.dns_name;
 
-    let handlebarsParams = {
-        bucketName,
-        versioningStatus,
-        loggingBucketName,
-        logFilePrefix,
-        indexDocument,
-        errorDocument,
-        tags: deployPhaseCommon.getTags(ownServiceContext),
-        cloudfront: !serviceParams.cloudfront || serviceParams.cloudfront === 'enabled',
-        cfLogging: !serviceParams.cloudfront_logging || serviceParams.cloudfront_logging === 'enabled',
-        cfMinTTL: computeTTL(serviceParams.cloudfront_min_ttl, 0),
-        cfMaxTTL: computeTTL(serviceParams.cloudfront_max_ttl, TTL_UNITS.year),
-        cfDefaultTTL: computeTTL(serviceParams.cloudfront_default_ttl, TTL_UNITS.day),
-        cfPriceClass: computePriceClass(serviceParams.cloudfront_price_class, 'all'),
-        httpsCertificateId: serviceParams.https_certificate,
-        dnsName
-    };
+        let handlebarsParams = {
+            bucketName,
+            versioningStatus,
+            loggingBucketName,
+            logFilePrefix,
+            indexDocument,
+            errorDocument,
+            tags: deployPhaseCommon.getTags(ownServiceContext),
+            cloudfront: !serviceParams.cloudfront || serviceParams.cloudfront === 'enabled',
+            cfLogging: !serviceParams.cloudfront_logging || serviceParams.cloudfront_logging === 'enabled',
+            cfMinTTL: computeTTL(serviceParams.cloudfront_min_ttl, 0),
+            cfMaxTTL: computeTTL(serviceParams.cloudfront_max_ttl, TTL_UNITS.year),
+            cfDefaultTTL: computeTTL(serviceParams.cloudfront_default_ttl, TTL_UNITS.day),
+            cfPriceClass: computePriceClass(serviceParams.cloudfront_price_class, 'all'),
+            httpsCertificateId: serviceParams.https_certificate,
+            dnsName,
+            setIPV6FunctionBody: JSON.stringify(setIPV6FunctionBody),
+        };
 
-    let dnsHostedZoneId;
-    if (dnsName) {
-        dnsHostedZoneId = route53Calls.listHostedZones()
-            .then(zones => {
-                let zone = route53Calls.getBestMatchingHostedZone(dnsName, zones);
-                if (!zone) {
-                    throw `No Route53 hosted zone found matching '${dnsName}'`
-                }
-                return zone.Id;
-            });
-    } else {
-        dnsHostedZoneId = Promise.resolve();
-    }
+        let dnsHostedZoneId;
+        if (dnsName) {
+            dnsHostedZoneId = route53Calls.listHostedZones()
+                .then(zones => {
+                    let zone = route53Calls.getBestMatchingHostedZone(dnsName, zones);
+                    if (!zone) {
+                        throw `No Route53 hosted zone found matching '${dnsName}'`
+                    }
+                    return zone.Id;
+                });
+        } else {
+            dnsHostedZoneId = Promise.resolve();
+        }
 
-    return dnsHostedZoneId.then(zoneId => {
-        handlebarsParams.dnsHostedZoneId = zoneId;
-        return handlebarsUtils.compileTemplate(`${__dirname}/s3-static-site-template.yml`, handlebarsParams);
-    })
+        return dnsHostedZoneId.then(zoneId => {
+            handlebarsParams.dnsHostedZoneId = zoneId;
+            return handlebarsUtils.compileTemplate(`${__dirname}/s3-static-site-template.yml`, handlebarsParams);
+        });
+    });
 }
 
 function computePriceClass(priceClass, defaultValue) {

--- a/lib/services/s3staticsite/index.js
+++ b/lib/services/s3staticsite/index.js
@@ -41,7 +41,6 @@ const TTL_UNITS = {
 const TTL_REGEX = new RegExp(`^(\\d+)(?:(?: )*(${Object.keys(TTL_UNITS).join('|')})(?:s)?)?$`);
 
 function getCompiledS3Template(ownServiceContext, stackName, loggingBucketName) {
-    return fs.readFile(`${__dirname}/set-ipv6.js`, 'utf-8').then(setIPV6FunctionBody => {
         let serviceParams = ownServiceContext.params;
 
         let bucketName = serviceParams.bucket_name || stackName;
@@ -49,8 +48,6 @@ function getCompiledS3Template(ownServiceContext, stackName, loggingBucketName) 
         let logFilePrefix = s3DeployersCommon.getLogFilePrefix(ownServiceContext);
         let indexDocument = serviceParams.index_document || 'index.html';
         let errorDocument = serviceParams.error_document || 'error.html';
-
-        let dnsName = serviceParams.dns_name;
 
         let handlebarsParams = {
             bucketName,
@@ -60,35 +57,50 @@ function getCompiledS3Template(ownServiceContext, stackName, loggingBucketName) 
             indexDocument,
             errorDocument,
             tags: deployPhaseCommon.getTags(ownServiceContext),
-            cloudfront: !serviceParams.cloudfront || serviceParams.cloudfront === 'enabled',
-            cfLogging: !serviceParams.cloudfront_logging || serviceParams.cloudfront_logging === 'enabled',
-            cfMinTTL: computeTTL(serviceParams.cloudfront_min_ttl, 0),
-            cfMaxTTL: computeTTL(serviceParams.cloudfront_max_ttl, TTL_UNITS.year),
-            cfDefaultTTL: computeTTL(serviceParams.cloudfront_default_ttl, TTL_UNITS.day),
-            cfPriceClass: computePriceClass(serviceParams.cloudfront_price_class, 'all'),
-            httpsCertificateId: serviceParams.https_certificate,
-            dnsName,
-            setIPV6FunctionBody: JSON.stringify(setIPV6FunctionBody),
+
         };
 
-        let dnsHostedZoneId;
-        if (dnsName) {
-            dnsHostedZoneId = route53Calls.listHostedZones()
-                .then(zones => {
-                    let zone = route53Calls.getBestMatchingHostedZone(dnsName, zones);
-                    if (!zone) {
-                        throw `No Route53 hosted zone found matching '${dnsName}'`
-                    }
-                    return zone.Id;
-                });
-        } else {
-            dnsHostedZoneId = Promise.resolve();
-        }
-
-        return dnsHostedZoneId.then(zoneId => {
-            handlebarsParams.dnsHostedZoneId = zoneId;
+        return getCloudfrontTemplateParameters(ownServiceContext).then(cfParameters => {
+            handlebarsParams.cloudfront = cfParameters;
             return handlebarsUtils.compileTemplate(`${__dirname}/s3-static-site-template.yml`, handlebarsParams);
         });
+}
+
+function getCloudfrontTemplateParameters(ownServiceContext) {
+    let cf = ownServiceContext.params.cloudfront;
+    if (!cf) {
+        return Promise.resolve(null);
+    }
+
+    let getIpv6Function = fs.readFile(`${__dirname}/set-ipv6.js`, 'utf-8').then(code => JSON.stringify(code));
+    let getHostedZones = route53Calls.listHostedZones();
+
+    return Promise.all([getIpv6Function, getHostedZones]).then(results => {
+        let [ipV6FunctionBody, hostedZones] = results;
+        let handlebarsParams = {
+            logging: !cf.logging || cf.logging === 'enabled',
+            minTTL: computeTTL(cf.min_ttl, 0),
+            maxTTL: computeTTL(cf.max_ttl, TTL_UNITS.year),
+            defaultTTL: computeTTL(cf.default_ttl, TTL_UNITS.day),
+            priceClass: computePriceClass(cf.price_class, 'all'),
+            httpsCertificateId: cf.https_certificate,
+            setIPV6FunctionBody: ipV6FunctionBody
+        };
+
+        let dnsNames = cf.dns_names;
+        if (dnsNames) {
+            handlebarsParams.dnsNames = dnsNames.map(dnsName => {
+                let zone = route53Calls.getBestMatchingHostedZone(dnsName, hostedZones);
+                if (!zone) {
+                    throw `No Route53 hosted zone found matching '${dnsName}'`;
+                }
+                return {
+                    name: dnsName,
+                    zoneId: zone.Id
+                }
+            });
+        }
+        return handlebarsParams;
     });
 }
 
@@ -124,6 +136,41 @@ function computeTTL(ttl, defaultValue) {
     return multiplier * num;
 }
 
+function checkCloudfront(cloudfront) {
+    let errors = [];
+
+    let logging = cloudfront.logging;
+    if (logging && logging !== 'enabled' && logging !== 'disabled') {
+        errors.push(`${SERVICE_NAME} - 'cloudfront' -  The 'logging' parameter must be either 'enabled' or 'disabled'`);
+    }
+    let priceClass = cloudfront.price_class;
+    if (priceClass) {
+        let priceString = String(priceClass);
+        if (priceString !== '100' && priceString !== '200' && priceString !== 'all') {
+            errors.push(`${SERVICE_NAME} - 'cloudfront' - the 'price_class' parameter must be one of '100', '200', or 'all'`);
+        }
+    }
+    if (cloudfront.min_ttl && !isValidTTL(cloudfront.min_ttl)) {
+        errors.push(`${SERVICE_NAME} - 'cloudfront' - The 'min_ttl' parameter must be a valid TTL value`);
+    }
+    if (cloudfront.max_ttl && !isValidTTL(cloudfront.max_ttl)) {
+        errors.push(`${SERVICE_NAME} - 'cloudfront' - The 'max_ttl' parameter must be a valid TTL value`);
+    }
+    if (cloudfront.default_ttl && !isValidTTL(cloudfront.default_ttl)) {
+        errors.push(`${SERVICE_NAME} - 'cloudfront' - The 'default_ttl' parameter must be a valid TTL value`);
+    }
+
+    if (cloudfront.dns_names) {
+        let badName = cloudfront.dns_names.some(name => !route53Calls.isValidHostname(name));
+
+        if (badName) {
+            errors.push(`${SERVICE_NAME} - 'cloudfront' - The 'dns_name' parameter must be a valid DNS hostname`);
+        }
+    }
+
+    return errors;
+}
+
 
 /**
  * Service Deployer Contract Methods
@@ -142,70 +189,10 @@ exports.check = function (serviceContext, dependenciesServiceContexts) {
     if (versioning && versioning !== 'enabled' && versioning !== 'disabled') {
         errors.push(`${SERVICE_NAME} - The 'versioning' parameter must be either 'enabled' or 'disabled'`);
     }
-    let cloudfront = serviceParams.cloudfront;
-    if (cloudfront && cloudfront !== 'enabled' && cloudfront !== 'disabled') {
-        errors.push(`${SERVICE_NAME} - The 'cloudfront' parameter must be either 'enabled' or 'disabled'`);
-    }
 
-    let cloudfrontDisabled = cloudfront && cloudfront === 'disabled';
-
-    let cfLogging = serviceParams.cloudfront_logging;
-    if (cfLogging) {
-        if (cloudfrontDisabled) {
-            errors.push(`${SERVICE_NAME} - The 'cloudfront_logging' parameter cannot be specified if 'cloudfront' is set to 'disabled'`);
-        }
-        if (cfLogging !== 'enabled' && cfLogging !== 'disabled') {
-            errors.push(`${SERVICE_NAME} - The 'cloudfront_logging' parameter must be either 'enabled' or 'disabled'`);
-        }
-    }
-    let cfPrice = serviceParams.cloudfront_price_class;
-    if (cfPrice) {
-        if (cloudfrontDisabled) {
-            errors.push(`${SERVICE_NAME} - The 'cloudfront_price_class' parameter cannot be specified if 'cloudfront' is set to 'disabled'`);
-        }
-
-        let priceString = String(cfPrice);
-        if (priceString !== '100' && priceString !== '200' && priceString !== 'all') {
-            errors.push(`${SERVICE_NAME} - the 'cloudfront_price_class' parameter must be one of '100', '200', or 'all'`)
-        }
-    }
-    if (serviceParams.https_certificate && cloudfrontDisabled) {
-        errors.push(`${SERVICE_NAME} - The 'https_certificate' parameter cannot be specified if 'cloudfront' is set to 'disabled'`);
-    }
-    let minTTL = serviceParams.cloudfront_min_ttl;
-    if (minTTL) {
-        if (cloudfrontDisabled) {
-            errors.push(`${SERVICE_NAME} - The 'cloudfront_min_ttl' parameter cannot be specified if 'cloudfront' is set to 'disabled'`);
-        }
-        if (!isValidTTL(minTTL)) {
-            errors.push(`${SERVICE_NAME} - The 'cloudfront_min_ttl' parameter must be a valid TTL value`);
-        }
-    }
-    let maxTTL = serviceParams.cloudfront_max_ttl;
-    if (maxTTL) {
-        if (cloudfrontDisabled) {
-            errors.push(`${SERVICE_NAME} - The 'cloudfront_max_ttl' parameter cannot be specified if 'cloudfront' is set to 'disabled'`);
-        }
-        if (!isValidTTL(maxTTL)) {
-            errors.push(`${SERVICE_NAME} - The 'cloudfront_max_ttl' parameter must be a valid TTL value`);
-        }
-    }
-    let defaultTTL = serviceParams.cloudfront_default_ttl;
-    if (defaultTTL) {
-        if (cloudfrontDisabled) {
-            errors.push(`${SERVICE_NAME} - The 'cloudfront_default_ttl' parameter cannot be specified if 'cloudfront' is set to 'disabled'`);
-        }
-        if (!isValidTTL(defaultTTL)) {
-            errors.push(`${SERVICE_NAME} - The 'cloudfront_default_ttl' parameter must be a valid TTL value`);
-        }
-    }
-    if (serviceParams.dns_name) {
-        if (cloudfrontDisabled) {
-            errors.push(`${SERVICE_NAME} - The 'dns_name' parameter cannot be specified if 'cloudfront' is set to 'disabled'`);
-        }
-        if (!route53Calls.isValidHostname(serviceParams.dns_name)) {
-            errors.push(`${SERVICE_NAME} - The 'dns_name' parameter must be a valid DNS hostname`);
-        }
+    if (serviceParams.cloudfront) {
+        let cfErrors = checkCloudfront(serviceParams.cloudfront);
+        errors.push(...cfErrors);
     }
 
     return errors;
@@ -220,6 +207,7 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
             return getCompiledS3Template(ownServiceContext, stackName, loggingBucketName)
         })
         .then(compiledTemplate => {
+            console.log(compiledTemplate);
             let stackTags = deployPhaseCommon.getTags(ownServiceContext);
             return deployPhaseCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, SERVICE_NAME, stackTags);
         })

--- a/lib/services/s3staticsite/index.js
+++ b/lib/services/s3staticsite/index.js
@@ -16,6 +16,7 @@
  */
 const winston = require('winston');
 const s3Calls = require('../../aws/s3-calls');
+const route53Calls = require('../../aws/route53-calls');
 const DeployContext = require('../../datatypes/deploy-context');
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
 const deployPhaseCommon = require('../../common/deploy-phase-common');
@@ -28,6 +29,15 @@ const VERSIONING_PARAM_MAPPING = {
     enabled: 'Enabled',
     disabled: 'Suspended'
 }
+
+const TTL_ALIASES = {
+    second: 1,
+    minute: 60,
+    hour: 3600,
+    day: 86400,
+    year: 31536000,
+};
+const TTL_REGEX = new RegExp(`^(\\d+)(?:(?: )*(${Object.keys(TTL_ALIASES).join('|')})(?:s)?)?$`);
 
 function getCompiledS3Template(ownServiceContext, stackName, loggingBucketName) {
     let serviceParams = ownServiceContext.params;
@@ -64,8 +74,40 @@ exports.check = function (serviceContext, dependenciesServiceContexts) {
     if (!serviceParams.path_to_code) {
         errors.push(`${SERVICE_NAME} - The 'path_to_code' parameter is required`);
     }
+    let versioning = serviceParams.versioning;
+    if (versioning && versioning !== 'enabled' && versioning !== 'disabled') {
+        errors.push(`${SERVICE_NAME} - The 'versioning' parameter must be either 'enabled' or 'disabled'`);
+    }
+    let cfLogging = serviceParams.cloudfront_logging;
+    if (cfLogging && cfLogging !== 'enabled' && cfLogging !== 'disabled') {
+        errors.push(`${SERVICE_NAME} - The 'cloudfront_logging' parameter must be either 'enabled' or 'disabled'`);
+    }
+    let cfPrice = serviceParams.cloudfront_price_class;
+    if (cfPrice && cfPrice !== '100' && cfPrice !== '200' && cfPrice !== 'all') {
+        errors.push(`${SERVICE_NAME} - the 'cloudfront_price_class' parameter must be one of '100', '200', or 'all'`)
+    }
+    if (!isValidTTL(serviceParams.cloudfront_min_ttl)) {
+        errors.push(`${SERVICE_NAME} - The 'cloudfront_min_ttl' parameter must be a valid TTL value`);
+    }
+    if (!isValidTTL(serviceParams.cloudfront_max_ttl)) {
+        errors.push(`${SERVICE_NAME} - The 'cloudfront_max_ttl' parameter must be a valid TTL value`);
+    }
+    if (!isValidTTL(serviceParams.cloudfront_default_ttl)) {
+        errors.push(`${SERVICE_NAME} - The 'cloudfront_default_ttl' parameter must be a valid TTL value`);
+    }
+    if (serviceParams.dns_name && !route53Calls.isValidHostname(serviceParams.dns_name)) {
+        errors.push(`${SERVICE_NAME} - The 'dns_name' parameter must be a valid DNS hostname`);
+    }
 
     return errors;
+}
+
+
+function isValidTTL(ttl) {
+    if (!ttl) {
+        return true;
+    }
+    return TTL_REGEX.test(ttl);
 }
 
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {

--- a/lib/services/s3staticsite/s3-static-site-template.yml
+++ b/lib/services/s3staticsite/s3-static-site-template.yml
@@ -37,8 +37,79 @@ Resources:
           Resource:
           - 'arn:aws:s3:::{{bucketName}}/*'
 
+  {{#if cloudfront}}
+  Cloudfront:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Comment: CDN for {{bucketName}}
+        {{#if dnsName}}
+        Aliases:
+         - {{dnsName}}
+        {{/if}}
+        Enabled: 'true'
+        HttpVersion: http2
+        {{#if httpsCertificateId}}
+        ViewerCertificate:
+          AcmCertificateArn: !Sub "arn:aws:acm:us-east-1:${AWS::AccountId}:certificate/{{httpsCertificateId}}"
+          SslSupportMethod: sni-only
+        {{/if}}
+        DefaultCacheBehavior:
+          AllowedMethods: [GET, HEAD, OPTIONS]
+          Compress: true
+          MinTTL: {{cfMinTTL}}
+          MaxTTL: {{cfMaxTTL}}
+          DefaultTTL: {{cfDefaultTTL}}
+          TargetOriginId: only-origin
+          ForwardedValues:
+            QueryString: true
+          {{#if httpsCertificateId}}
+          ViewerProtocolPolicy: redirect-to-https
+          {{else}}
+          ViewerProtocolPolicy: allow-all
+          {{/if}}
+        DefaultRootObject: {{indexDocument}}
+        PriceClass: {{cfPriceClass}}
+        Origins:
+        # We're using a custom origin instead of an S3 origin to allow for future support of redirects, etc.
+        - Id: only-origin
+          DomainName: !Select [ 1, !Split [ "://", !GetAtt Bucket.WebsiteURL ] ]
+          CustomOriginConfig:
+            HTTPPort: 80
+            HTTPSPort: 443
+            OriginProtocolPolicy: http-only
+
+  {{#if dnsName}}
+  DNS:
+    Type: AWS::Route53::RecordSetGroup
+    Properties:
+      HostedZoneId: {{dnsHostedZoneId}}
+      Comment: DNS for CDN
+      RecordSets:
+        - Name: {{dnsName}}
+          Type: A
+          AliasTarget:
+            HostedZoneId: Z2FDTNDATAQYW2
+            DNSName: !GetAtt Cloudfront.DomainName
+# TODO: Add IPV6 support to CloudFront distro. It'll require a custom resource, since Cloudformation still doesn't support it.
+#        - Name: {{dnsName}}
+#          Type: AAAA
+#          AliasTarget:
+#            HostedZoneId: Z2FDTNDATAQYW2
+#            DNSName: !GetAtt Cloudfront.DomainName
+  {{/if}}
+  {{/if}}
+
 Outputs:
   BucketName:
     Description: The name of the bucket
     Value: 
       Ref: Bucket
+  {{#if cloudfront}}
+  CloudfrontDistribution:
+    Description: The Cloudfront Distribution ID
+    Value: !Ref Cloudfront
+  CloudfrontUrl:
+    Description: The Cloudfront domain name
+    Value: !GetAtt Cloudfront.DomainName
+  {{/if}}

--- a/lib/services/s3staticsite/s3-static-site-template.yml
+++ b/lib/services/s3staticsite/s3-static-site-template.yml
@@ -96,13 +96,61 @@ Resources:
           AliasTarget:
             HostedZoneId: Z2FDTNDATAQYW2
             DNSName: !GetAtt Cloudfront.DomainName
-# TODO: Add IPV6 support to CloudFront distro. It'll require a custom resource, since Cloudformation still doesn't support it.
-#        - Name: {{dnsName}}
-#          Type: AAAA
-#          AliasTarget:
-#            HostedZoneId: Z2FDTNDATAQYW2
-#            DNSName: !GetAtt Cloudfront.DomainName
+        - Name: {{dnsName}}
+          Type: AAAA
+          AliasTarget:
+            HostedZoneId: Z2FDTNDATAQYW2
+            DNSName: !GetAtt Cloudfront.DomainName
+    DependsOn: SetIPV6
   {{/if}}
+
+  SetIPV6:
+    Type: Custom::SetIPV6
+    Properties:
+      ServiceToken: !GetAtt SetIPV6Function.Arn
+      DistributionId: !Ref Cloudfront
+
+  SetIPV6Function:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        ZipFile: {{{setIPV6FunctionBody}}}
+      Handler: "index.handler"
+      Runtime: nodejs6.10
+      Timeout: 30
+      Role: !GetAtt SetIPV6FunctionRole.Arn
+
+  SetIPV6FunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+            - lambda.amazonaws.com
+          Action:
+          - sts:AssumeRole
+      Path: "/"
+      Policies:
+      - PolicyName: root
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - logs:CreateLogGroup
+            - logs:CreateLogStream
+            - logs:PutLogEvents
+            Resource: arn:aws:logs:*:*:*
+          - Effect: Allow
+            Action:
+            - cloudfront:GetDistribution
+            - cloudfront:GetDistributionConfig
+            - cloudfront:UpdateDistribution
+            #Uggh. Cloudfront requires these to be granted on everything.
+            Resource: "*"
   {{/if}}
 
 Outputs:

--- a/lib/services/s3staticsite/s3-static-site-template.yml
+++ b/lib/services/s3staticsite/s3-static-site-template.yml
@@ -49,6 +49,11 @@ Resources:
         {{/if}}
         Enabled: 'true'
         HttpVersion: http2
+        {{#if cfLogging}}
+        Logging:
+          Bucket: {{loggingBucketName}}.s3.amazonaws.com
+          Prefix: {{logFilePrefix}}cloudfront/
+        {{/if}}
         {{#if httpsCertificateId}}
         ViewerCertificate:
           AcmCertificateArn: !Sub "arn:aws:acm:us-east-1:${AWS::AccountId}:certificate/{{httpsCertificateId}}"

--- a/lib/services/s3staticsite/s3-static-site-template.yml
+++ b/lib/services/s3staticsite/s3-static-site-template.yml
@@ -43,38 +43,40 @@ Resources:
     Properties:
       DistributionConfig:
         Comment: CDN for {{bucketName}}
-        {{#if dnsName}}
+        {{#if cloudfront.dnsNames}}
         Aliases:
-         - {{dnsName}}
+        {{#each cloudfront.dnsNames}}
+         - {{name}}
+        {{/each}}
         {{/if}}
         Enabled: 'true'
         HttpVersion: http2
-        {{#if cfLogging}}
+        {{#if cloudformation.logging}}
         Logging:
           Bucket: {{loggingBucketName}}.s3.amazonaws.com
           Prefix: {{logFilePrefix}}cloudfront/
         {{/if}}
-        {{#if httpsCertificateId}}
+        {{#if cloudfront.httpsCertificateId}}
         ViewerCertificate:
-          AcmCertificateArn: !Sub "arn:aws:acm:us-east-1:${AWS::AccountId}:certificate/{{httpsCertificateId}}"
+          AcmCertificateArn: !Sub "arn:aws:acm:us-east-1:${AWS::AccountId}:certificate/{{cloudfront.httpsCertificateId}}"
           SslSupportMethod: sni-only
         {{/if}}
         DefaultCacheBehavior:
           AllowedMethods: [GET, HEAD, OPTIONS]
           Compress: true
-          MinTTL: {{cfMinTTL}}
-          MaxTTL: {{cfMaxTTL}}
-          DefaultTTL: {{cfDefaultTTL}}
+          MinTTL: {{cloudfront.minTTL}}
+          MaxTTL: {{cloudfront.maxTTL}}
+          DefaultTTL: {{cloudfront.defaultTTL}}
           TargetOriginId: only-origin
           ForwardedValues:
             QueryString: true
-          {{#if httpsCertificateId}}
+          {{#if cloudfront.httpsCertificateId}}
           ViewerProtocolPolicy: redirect-to-https
           {{else}}
           ViewerProtocolPolicy: allow-all
           {{/if}}
         DefaultRootObject: {{indexDocument}}
-        PriceClass: {{cfPriceClass}}
+        PriceClass: {{cloudfront.priceClass}}
         Origins:
         # We're using a custom origin instead of an S3 origin to allow for future support of redirects, etc.
         - Id: only-origin
@@ -84,24 +86,26 @@ Resources:
             HTTPSPort: 443
             OriginProtocolPolicy: http-only
 
-  {{#if dnsName}}
-  DNS:
+  {{#if cloudfront.dnsNames}}
+  {{#each cloudfront.dnsNames}}
+  DNS{{logicalId name}}:
     Type: AWS::Route53::RecordSetGroup
     Properties:
-      HostedZoneId: {{dnsHostedZoneId}}
-      Comment: DNS for CDN
+      HostedZoneId: {{zoneId}}
+      Comment: DNS for S3 Static Site {{bucketName}}
       RecordSets:
-        - Name: {{dnsName}}
+        - Name: {{name}}
           Type: A
           AliasTarget:
             HostedZoneId: Z2FDTNDATAQYW2
             DNSName: !GetAtt Cloudfront.DomainName
-        - Name: {{dnsName}}
+        - Name: {{name}}
           Type: AAAA
           AliasTarget:
             HostedZoneId: Z2FDTNDATAQYW2
             DNSName: !GetAtt Cloudfront.DomainName
     DependsOn: SetIPV6
+  {{/each}}
   {{/if}}
 
   SetIPV6:
@@ -114,7 +118,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Code:
-        ZipFile: {{{setIPV6FunctionBody}}}
+        ZipFile: {{{cloudfront.setIPV6FunctionBody}}}
       Handler: "index.handler"
       Runtime: nodejs6.10
       Timeout: 30

--- a/lib/services/s3staticsite/set-ipv6.js
+++ b/lib/services/s3staticsite/set-ipv6.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+"use strict";
+
+/*
+ * This file is intended for use inside a lambda function to set IsIPV6Enabled on a Cloudfront Distribution.
+ * TODO: Get rid of this once Cloudformation supports setting this value natively.
+ */
+
+const AWS = require('aws-sdk');
+const response = require('cfn-response');
+
+exports.handler = function handler(event, context, callback) {
+    let cloudfront = new AWS.CloudFront({apiVersion: '2017-03-25'});
+    let distroId = event.ResourceProperties.DistributionId;
+    console.log(`--- got request to update distribution ${distroId} ---`);
+    cloudfront.getDistributionConfig({
+        Id: distroId
+    }).promise().then(data => {
+        let config = data.DistributionConfig;
+        if (config.IsIPV6Enabled) {
+            console.log(`--- distribution ${distroId} already had IsIPV6Enabled = true---`);
+            response.send(event, context, response.SUCCESS, {});
+            return;
+        } else {
+            config.IsIPV6Enabled = true;
+            let update = {
+                Id: distroId,
+                IfMatch: data.ETag,
+                DistributionConfig: config,
+            };
+            return cloudfront.updateDistribution(update).promise().then(data => {
+                console.log(`--- updated distribution ${distroId} ---`);
+                response.send(event, context, response.SUCCESS, {});
+            });
+        }
+    }).catch(error => {
+            console.log(`--- error updating distribution ${distroId} ---`, error);
+            response.send(event, context, response.FAILED, {});
+        }
+    );
+};

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "archiver": "^1.3.0",
     "aws-sdk": "^2.9.0",
     "bluebird": "^3.5.0",
+    "fs-extra": "^4.0.2",
     "handlebars": "^4.0.6",
     "inquirer": "^3.0.6",
     "js-yaml": "3.7.0",

--- a/test/services/s3staticsite/s3staticsite-test.js
+++ b/test/services/s3staticsite/s3staticsite-test.js
@@ -33,8 +33,8 @@ describe('s3staticsite deployer', function () {
 
     beforeEach(function () {
         let serviceParams = {
-            path_to_code: "."
-        }
+            path_to_code: ".",
+        };
         ownServiceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "s3staticsite", "1", serviceParams, accountConfig);
         sandbox = sinon.sandbox.create();
     });
@@ -73,80 +73,63 @@ describe('s3staticsite deployer', function () {
                 expect(errors[0]).to.include("'versioning' parameter must be either 'enabled' or 'disabled'")
             });
         });
-        describe('cloudfront', function () {
+        describe('cloudfront.logging', function () {
             const valid = ['enabled', 'disabled'];
             for (let validValue of valid) {
                 it(`should allow '${validValue}'`, function () {
-                    ownServiceContext.params.cloudfront = validValue;
+                    ownServiceContext.params.cloudfront = {logging: validValue};
 
                     let errors = s3StaticSite.check(ownServiceContext);
                     expect(errors).to.be.empty;
                 });
             }
             it("should reject invalid values", function () {
-                ownServiceContext.params.cloudfront = 'off';
+                ownServiceContext.params.cloudfront = {logging: 'off'};
                 let errors = s3StaticSite.check(ownServiceContext);
                 expect(errors).to.have.lengthOf(1);
-                expect(errors[0]).to.include("'cloudfront' parameter must be either 'enabled' or 'disabled'")
+                expect(errors[0]).to.include("'logging' parameter must be either 'enabled' or 'disabled'")
             });
         });
-        describe('cloudfront_logging', function () {
-            const valid = ['enabled', 'disabled'];
-            for (let validValue of valid) {
-                it(`should allow '${validValue}'`, function () {
-                    ownServiceContext.params.cloudfront_logging = validValue;
-
-                    let errors = s3StaticSite.check(ownServiceContext);
-                    expect(errors).to.be.empty;
-                });
-            }
-            it("should reject invalid values", function () {
-                ownServiceContext.params.cloudfront_logging = 'off';
-                let errors = s3StaticSite.check(ownServiceContext);
-                expect(errors).to.have.lengthOf(1);
-                expect(errors[0]).to.include("'cloudfront_logging' parameter must be either 'enabled' or 'disabled'")
-            });
-        });
-        describe('cloudfront_price_class', function () {
+        describe('cloudfront.price_class', function () {
             const valid = ['100', '200', 'all'];
             for (let validValue of valid) {
                 it(`should allow '${validValue}'`, function () {
-                    ownServiceContext.params.cloudfront_price_class = validValue;
+                    ownServiceContext.params.cloudfront = {price_class: validValue};
 
                     let errors = s3StaticSite.check(ownServiceContext);
                     expect(errors).to.be.empty;
                 });
             }
             it("should reject invalid values", function () {
-                ownServiceContext.params.cloudfront_price_class = 'off';
+                ownServiceContext.params.cloudfront = {price_class: 'off'};
                 let errors = s3StaticSite.check(ownServiceContext);
                 expect(errors).to.have.lengthOf(1);
-                expect(errors[0]).to.include("'cloudfront_price_class' parameter must be one of '100', '200', or 'all'");
+                expect(errors[0]).to.include("'price_class' parameter must be one of '100', '200', or 'all'");
             });
         });
-        describe('TTLs', function () {
+        describe('cloudfront TTLs', function () {
             const ttlFields = ['min', 'max', 'default'];
             const aliases = ['second', 'minute', 'hour', 'day', 'year'];
-            for (let field of ttlFields.map(it => `cloudfront_${it}_ttl`)) {
+            for (let field of ttlFields.map(it => `${it}_ttl`)) {
                 it(`should allow numbers in '${field}`, function() {
-                    ownServiceContext.params[field] = 100;
+                    ownServiceContext.params.cloudfront = {[field]: 100};
                     let errors = s3StaticSite.check(ownServiceContext);
                     expect(errors).to.be.empty;
                 });
                 for (let alias of aliases) {
                     it(`should allow ${alias} aliases in '${field}`, function() {
-                        ownServiceContext.params[field] = `2 ${alias}`;
+                        ownServiceContext.params.cloudfront = {[field]: `2 ${alias}`};
                         let errors = s3StaticSite.check(ownServiceContext);
                         expect(errors).to.be.empty;
 
                         //plural
-                        ownServiceContext.params[field] = `2 ${alias}s`;
+                        ownServiceContext.params.cloudfront = {[field]: `2 ${alias}s`};
                         errors = s3StaticSite.check(ownServiceContext);
                         expect(errors).to.be.empty;
                     });
                 }
                 it(`should reject invalid values in '${field}`, function() {
-                    ownServiceContext.params[field] = 'foobar';
+                    ownServiceContext.params.cloudfront = {[field]: 'foobar'};
 
                     let errors = s3StaticSite.check(ownServiceContext);
                     expect(errors).to.have.lengthOf(1);
@@ -154,15 +137,15 @@ describe('s3staticsite deployer', function () {
                 });
             }
         });
-        describe('dns_name', function () {
+        describe('cloudfront.dns_name', function () {
             it('should allow valid hostnames', function() {
-                ownServiceContext.params.dns_name = 'valid.dns.name.com';
+                ownServiceContext.params.cloudfront = {dns_names: ['valid.dns.name.com']};
 
                 let errors = s3StaticSite.check(ownServiceContext);
                 expect(errors).to.be.empty;
             });
             it("should reject invalid values", function() {
-                ownServiceContext.params.dns_name = 'invalid hostname';
+                ownServiceContext.params.cloudfront = {dns_names: ['invalid hostname', 'valid.dns.name.com']};
 
                 let errors = s3StaticSite.check(ownServiceContext);
                 expect(errors).to.have.lengthOf(1);

--- a/test/services/s3staticsite/s3staticsite-test.js
+++ b/test/services/s3staticsite/s3staticsite-test.js
@@ -73,6 +73,23 @@ describe('s3staticsite deployer', function () {
                 expect(errors[0]).to.include("'versioning' parameter must be either 'enabled' or 'disabled'")
             });
         });
+        describe('cloudfront', function () {
+            const valid = ['enabled', 'disabled'];
+            for (let validValue of valid) {
+                it(`should allow '${validValue}'`, function () {
+                    ownServiceContext.params.cloudfront = validValue;
+
+                    let errors = s3StaticSite.check(ownServiceContext);
+                    expect(errors).to.be.empty;
+                });
+            }
+            it("should reject invalid values", function () {
+                ownServiceContext.params.cloudfront = 'off';
+                let errors = s3StaticSite.check(ownServiceContext);
+                expect(errors).to.have.lengthOf(1);
+                expect(errors[0]).to.include("'cloudfront' parameter must be either 'enabled' or 'disabled'")
+            });
+        });
         describe('cloudfront_logging', function () {
             const valid = ['enabled', 'disabled'];
             for (let validValue of valid) {


### PR DESCRIPTION
By adding CloudFront support, we can now support DNS names and HTTPS certificates on S3 Static Sites.

Fixes #183. Fixes #190.

**Future Work:**
Add a `cloudfront` service type, and support pointing at an s3 static site to allow for more complex configuration.