### PR TITLE
Ecs bug fix

### DIFF
--- a/lib/services/ecs/index.js
+++ b/lib/services/ecs/index.js
@@ -173,6 +173,7 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
         .then(
           dat=>
           {
+            if(!dat) return lstOrig;
             let lstOrig=dat;
             //winston.debug(`cluster list:\n${JSON.stringify(lstASGec2,null,2)}`);
 


### PR DESCRIPTION
fix null ec2 list when trying to decide if cluster needs a restart after an update when the cluster hasn't been created.