### PR TITLE
SES

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -79,5 +79,6 @@ including taking care of all the tricky security bits wiring services together.
    supported-services/route53zone
    supported-services/s3
    supported-services/s3staticsite
+   supported-services/ses
    supported-services/sns
    supported-services/sqs

--- a/docs/supported-services/ses.rst
+++ b/docs/supported-services/ses.rst
@@ -31,6 +31,10 @@ Parameters
 
     Handel does not support verification of entire domains at this time.
 
+.. WARNING::
+
+    To allow multiple applications to share an email address, Handel does not delete an SES identity upon deletion of the Handel SES service.
+
 Example Handel File
 -------------------
 This Handel file shows an SQS service being configured:

--- a/docs/supported-services/ses.rst
+++ b/docs/supported-services/ses.rst
@@ -1,0 +1,72 @@
+.. _ses:
+
+SES (Simple Email Service)
+=================================
+This document contains information about the SES service supported in Handel. This Handel service verifies an email address for use by your applications.
+
+Parameters
+----------
+.. list-table::
+   :header-rows: 1
+
+   * - Parameter
+     - Type
+     - Required
+     - Default
+     - Description
+   * - type
+     - string
+     - Yes
+     - 
+     - This must always be *ses* for this service type.
+   * - address
+     - string
+     - Yes
+     -
+     - The email address your applications will use.
+
+.. NOTE::
+
+    When Handel attempts to verify an email address through SES, AWS will send an email to the address with a link to verify the address. Handel will not attempt to re-verify email addresses that have already been verified in the same AWS account or are in a pending state (SES allows 24 hours before a verification fails). It will still wire up the appropriate permissions to allow other Handel services to use successfully verified addresses.
+
+    Handel does not support verification of entire domains at this time.
+
+Example Handel File
+-------------------
+This Handel file shows an SQS service being configured:
+
+.. code-block:: yaml
+
+    version: 1
+
+    name: my-email-address
+
+    environments:
+      dev:
+        email:
+          type: ses
+          address: user@example.com
+
+Depending on this service
+-------------------------
+This service outputs the following environment variables:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Environment Variable
+     - Description
+   * - <SERVICE_NAME>_EMAIL_ADDRESS
+     - The email address available through SES
+   * - <SERVICE_NAME>_IDENTITY_ARN
+     - The AWS ARN of the email identity
+
+See :ref:`environment-variable-names` for information about how the service name is included in the environment variable name.
+
+Events produced by this service
+-------------------------------
+The SES service does not currently produce events for other Handel services.
+
+Events consumed by this service
+-------------------------------
+The SES service does not currently consume events from other Handel services.

--- a/lib/aws/ses-calls.js
+++ b/lib/aws/ses-calls.js
@@ -23,7 +23,7 @@ function verifyEmailAddress(address) {
     return ses.getIdentityVerificationAttributes({Identities: [address]}).promise()
         .then(response => {
             const address_verified = address in response.VerificationAttributes
-                && response.VerficationAttributes[address].VerificationStatus != 'Failed';
+                && response.VerificationAttributes[address].VerificationStatus != 'Failed';
             if (!address_verified) {
                 winston.verbose(`Requested verification for ${address}`);
                 return ses.verifyEmailAddress({EmailAddress: address}).promise();
@@ -31,3 +31,5 @@ function verifyEmailAddress(address) {
             winston.verbose(`${address} is already verified`);
         });
 }
+
+exports.verifyEmailAddress = verifyEmailAddress;

--- a/lib/aws/ses-calls.js
+++ b/lib/aws/ses-calls.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const AWS = require('aws-sdk');
+const winston = require('winston');
+
+function verifyEmailAddress(address) {
+    const ses = new AWS.SES({apiVersion: '2010-12-01'});
+    winston.verbose(`Verifying ${address} if needed`);
+    return ses.getIdentityVerificationAttributes({Identities: [address]}).promise()
+        .then(response => {
+            const address_verified = address in response.VerificationAttributes
+                && response.VerficationAttributes[address].VerificationStatus != 'Failed';
+            if (!address_verified) {
+                winston.verbose(`Requested verification for ${address}`);
+                return ses.verifyEmailAddress({EmailAddress: address}).promise();
+            }
+            winston.verbose(`${address} is already verified`);
+        });
+}

--- a/lib/services/ses/index.js
+++ b/lib/services/ses/index.js
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const winston = require('winston');
+const DeployContext = require('../../datatypes/deploy-context');
+const sesCalls = require('../../aws/ses-calls');
+const deployPhaseCommon = require('../../common/deploy-phase-common');
+
+const EMAIL_ADDRESS = /^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
+const SERVICE_NAME = "SES";
+
+function getDeployContext(serviceContext) {
+    const deployContext = new DeployContext(serviceContext);
+
+    const account = serviceContext.accountConfig.account_id;
+    const address = serviceContext.params.address;
+    const region = serviceContext.accountConfig.region;
+    const identityArn = `arn:aws:ses:${region}:${account}:identity/${address}`
+
+    // Env variables to inject into consuming services
+    deployContext.addEnvironmentVariables(deployPhaseCommon.getInjectedEnvVarsFor(serviceContext, {
+        EMAIL_ADDRESS: address,
+        IDENTITY_ARN: identityArn
+    }));
+
+    //Policy to talk to this queue
+    deployContext.policies.push({
+        "Effect": "Allow",
+        "Action": [
+            "ses:SendEmail"
+        ],
+        "Resource": [
+            identityArn
+        ]
+    })
+
+    return deployContext;
+}
+
+
+/**
+ * Service Deployer Contract Methods
+ * See https://github.com/byu-oit-appdev/handel/wiki/Creating-a-New-Service-Deployer#service-deployer-contract
+ *   for contract method documentation
+ */
+
+exports.check = function (serviceContext, dependenciesServiceContexts) {
+    let errors = [];
+
+    if (!EMAIL_ADDRESS.test(serviceContext.params.address))
+        errors.push(`${SERVICE_NAME} - An address must be a valid email address`);
+
+    return errors;
+}
+
+exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
+    const address = ownServiceContext.params.address;
+    winston.info(`${SERVICE_NAME} - Deploying email address ${address}`);
+
+    return sesCalls.verifyEmailAddress(address)
+        .then(() => {
+            winston.info(`${SERVICE_NAME} - Finished deploying email address ${address}`);
+            return getDeployContext(ownServiceContext);
+        });
+}
+
+exports.producedEventsSupportedServices = [];
+
+exports.producedDeployOutputTypes = [
+    'environmentVariables',
+    'policies'
+];
+
+exports.consumedDeployOutputTypes = [];

--- a/lib/services/ses/index.js
+++ b/lib/services/ses/index.js
@@ -45,7 +45,7 @@ function getDeployContext(serviceContext) {
         "Resource": [
             identityArn
         ]
-    })
+    });
 
     return deployContext;
 }

--- a/test/aws/ses-calls-test.js
+++ b/test/aws/ses-calls-test.js
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const expect = require('chai').expect;
+const AWS = require('aws-sdk-mock');
+const sesCalls = require('../../lib/aws/ses-calls');
+const sinon = require('sinon');
+
+describe('sesCalls', function () {
+    let sandbox;
+
+    beforeEach(function () {
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+        AWS.restore('SES');
+    });
+
+    describe('verifyEmailAddress', function () {
+        const FAKE_ADDRESS = 'user@example.com';
+        const GARBAGE = 'garbage';
+
+        it('should not verify email address if already verified', function () {
+
+            AWS.mock('SES', 'getIdentityVerificationAttributes', {
+                VerificationAttributes: {
+                    [FAKE_ADDRESS]: {
+                        VerificationStatus: "Success"
+                    }
+                }
+            });
+            AWS.mock('SES', 'verifyEmailAddress', GARBAGE);
+            sesCalls.verifyEmailAddress(FAKE_ADDRESS).then(response => {
+                expect(response).to.not.equal(GARBAGE);
+            });
+        });
+
+        it('should verify unverified email addresses', function () {
+            
+            AWS.mock('SES', 'getIdentityVerificationAttributes', {
+                VerificationAttributes: {}
+            });
+            AWS.mock('SES', 'verifyEmailAddress', GARBAGE);
+            sesCalls.verifyEmailAddress(FAKE_ADDRESS).then(response => {
+                expect(response).to.equal(GARBAGE);
+            });
+        });
+
+        it('should retry failed verification', function () {
+
+            AWS.mock('SES', 'getIdentityVerificationAttributes', {
+                VerificationAttributes: {
+                    [FAKE_ADDRESS]: {
+                        VerificationStatus: 'Failed'
+                    }
+                }
+            });
+            AWS.mock('SES', 'verifyEmailAddress', GARBAGE);
+            sesCalls.verifyEmailAddress(FAKE_ADDRESS).then(response => {
+                expect(response).to.equal(GARBAGE);
+            });
+        });
+    });
+});

--- a/test/services/ses/ses-test.js
+++ b/test/services/ses/ses-test.js
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const ses = require('../../../lib/services/ses');
+const sesCalls = require('../../../lib/aws/ses-calls');
+const ServiceContext = require('../../../lib/datatypes/service-context');
+const DeployContext = require('../../../lib/datatypes/deploy-context');
+const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
+const sinon = require('sinon');
+const expect = require('chai').expect;
+
+describe('ses deployer', function () {
+    let sandbox;
+
+    beforeEach(function () {
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    describe('check', function () {
+        const app = `FakeApp`;
+        const env = `FakeEnv`;
+        const service = `FakeService`;
+        const serviceType = `ses`;
+        const version = `1`;
+
+        it(`should require an address`, function () {
+            const params = {};
+            const serviceContext = new ServiceContext(app, env, service, serviceType, version, params);
+            const errors = ses.check(serviceContext);
+            expect(errors.length).to.equal(1);
+            expect(errors[0]).to.include(`valid email address`);
+        });
+        it(`should require a valid email address`, function () {
+            const params = {
+                address: `example.com`
+            };
+            const serviceContext = new ServiceContext(app, env, service, serviceType, version, params);
+            const errors = ses.check(serviceContext);
+            expect(errors.length).to.equal(1);
+            expect(errors[0]).to.include(`valid email address`);
+        });
+        it(`should pass with a valid address`, function () {
+            const params = {
+                address: 'user@example.com'
+            };
+            const serviceContext = new ServiceContext(app, env, service, serviceType, version, params);
+            const errors = ses.check(serviceContext);
+            expect(errors).to.deep.equal([]);
+        });
+    });
+
+    describe('deploy', function () {
+        const app = `FakeApp`;
+        const env = `FakeEnv`;
+        const service = `FakeService`;
+        const serviceType = `ses`;
+        const version = `1`;
+
+        const address = `user@example.com`;
+        const account = 'fake account';
+        const region = 'fake region';
+        const identityArn = `arn:aws:ses:${region}:${account}:identity/${address}`
+
+        const ownServiceContext = new ServiceContext(app, env, service, serviceType, version, {
+            type: `ses`,
+            address
+        });
+        const ownPreDeployContext = new PreDeployContext(ownServiceContext);
+
+        ownServiceContext.accountConfig = {account_id: account, region};
+
+        it(`should attempt to verify email address`, function () {
+            const verifyStub = sandbox.stub(sesCalls, 'verifyEmailAddress').returns(Promise.resolve());
+
+            return ses.deploy(ownServiceContext, ownPreDeployContext, [])
+                .then(deployContext => {
+                    expect(verifyStub.calledOnce).to.be.true;
+                    expect(deployContext).to.be.instanceof(DeployContext);
+
+                    const envPrefix = service.toUpperCase();
+
+                    // Should have exported 2 env vars
+                    expect(deployContext.environmentVariables).to.have.property(`${envPrefix}_EMAIL_ADDRESS`, address);
+                    expect(deployContext.environmentVariables).to.have.property(`${envPrefix}_IDENTITY_ARN`, identityArn);
+
+                    // Should have exported 1 policy
+                    expect(deployContext.policies.length).to.equal(1); //Should have exported one policy
+                    expect(deployContext.policies[0].Resource[0]).to.equal(identityArn);
+                });
+        });
+    });
+});


### PR DESCRIPTION
So far it just asks SES to verify an email address if it has not been verified with the current AWS account and gives dependent services permission to send email from that email address.

To allow multiple applications to share an email address, I don't have it deleting email addresses when the service is deleted. I have that warning in the documentation.