### PR TITLE
Remove version flag from CLI.

### DIFF
--- a/bin/handel
+++ b/bin/handel
@@ -28,7 +28,6 @@ function printDeployUsage(errors) {
 Options:
 -c [required] -- Path to account config or base64 encoded JSON string of config
 -e [required] -- A comma-separated list of environments from your handel file to deploy
--v [required] -- An arbitrary string for the version of the current deployment
 -d -- If this flag is set, verbose debug output will be enabled
 
 Errors:

--- a/docs/getting-started/tutorial-creating-an-app.rst
+++ b/docs/getting-started/tutorial-creating-an-app.rst
@@ -118,7 +118,7 @@ Now that you've written your app, created your Handel file, and obtained your ac
 
 .. code-block:: bash
 
-    handel deploy -c default-us-east-1 -e dev -v 1
+    handel deploy -c default-us-east-1 -e dev
 
 .. NOTE::
 
@@ -126,7 +126,6 @@ Now that you've written your app, created your Handel file, and obtained your ac
 
     * The *-c* parameter specifies which :ref:`account-config-file` to use. Specifying *default-us-east-1* here tells Handel you don't have one and just want to use the default VPC AWS provides in the us-east-1 region.
     * The *-e* parameter is a comma-separated string list that specifies which environments from your Handel file you want to deploy
-    * The *-v* parameter is an arbitrary string specifying the current version being deployed.
 
 Once you've executed that command, Handel should start up and deploy your application. You can sign into the AWS Console and go to the "ElasticBeanstalk" service to see your deployed application.
 

--- a/docs/handel-basics/account-config-file.rst
+++ b/docs/handel-basics/account-config-file.rst
@@ -20,7 +20,7 @@ If you're using Handel in a personal AWS account, it's likely that you don't wan
 
 .. code-block:: none
 
-    handel deploy -c default-us-east-1 -e dev -v 1
+    handel deploy -c default-us-east-1 -e dev
 
 Notice that in the *-c* parameter, we are passing the string *default-us-east-1*, which tells Handel to use the default VPC in the us-east-1 region.
 

--- a/docs/handel-basics/consuming-service-dependencies.rst
+++ b/docs/handel-basics/consuming-service-dependencies.rst
@@ -83,7 +83,5 @@ In addition to environment variables injected by services your applications cons
      - This is the value of the *\<environment\>* field from your Handel file. It is the name of the environment the current service is a part of.
    * - HANDEL_SERVICE_NAME
      - This is the value of the *\<service_name>* field from your Handel file. It is the name of the currently deployed service.
-   * - HANDEL_SERVICE_VERSION
-     - This is the value of the version of the application being deployed. It is set to whatever the *-v* parameter was when Handel last deployed your application.
    * - HANDEL_PARAMETER_STORE_PREFIX
      - This is the :ref:`prefix <parameter-store-prefix>` used for secrets stored in Parameter Store.

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -188,11 +188,6 @@ exports.validateDeployArgs = function (argv, handelFile) {
         errors = errors.concat(validateEnvsInHandelFile(argv.e, handelFile));
     }
 
-    //Require version
-    if (!argv.v) {
-        errors.push("The '-v' parameter is required");
-    }
-
     return errors;
 }
 
@@ -225,7 +220,6 @@ exports.validateDeleteArgs = function (argv, handelFile) {
 exports.deployAction = function (handelFile, argv) {
     configureLogger(argv);
 
-    let deployVersion = argv.v;
     let environmentsToDeploy = argv.e.split(',');
     validateLoggedIn()
         .then(() => {
@@ -244,7 +238,7 @@ exports.deployAction = function (handelFile, argv) {
                     winston.debug("Validating and parsing Handel file");
                     let handelFileParser = util.getHandelFileParser(handelFile);
                     validateHandelFile(handelFileParser, handelFile, serviceDeployers);
-                    return deployLifecycle.deploy(accountConfig, handelFile, environmentsToDeploy, deployVersion, handelFileParser, serviceDeployers)
+                    return deployLifecycle.deploy(accountConfig, handelFile, environmentsToDeploy, handelFileParser, serviceDeployers)
                 })
                 .then(envDeployResults => {
                     logFinalResult('deploy', envDeployResults);

--- a/lib/common/deploy-phase-common.js
+++ b/lib/common/deploy-phase-common.js
@@ -60,7 +60,6 @@ exports.getEnvVarsFromServiceContext = function (serviceContext) {
     envVars['HANDEL_APP_NAME'] = serviceContext.appName;
     envVars['HANDEL_ENVIRONMENT_NAME'] = serviceContext.environmentName;
     envVars['HANDEL_SERVICE_NAME'] = serviceContext.serviceName;
-    envVars['HANDEL_SERVICE_VERSION'] = serviceContext.deployVersion;
     envVars['HANDEL_PARAMETER_STORE_PREFIX'] = ssmParamPrefix(serviceContext);
     return envVars;
 }

--- a/lib/common/util.js
+++ b/lib/common/util.js
@@ -231,9 +231,9 @@ exports.getHandelFileParser = function (handelFile) {
 /**
  * Gets the App Context from the deploy spec file
  */
-exports.createEnvironmentContext = function (handelFile, handelFileParser, environmentName, deployVersion, accountConfig) {
+exports.createEnvironmentContext = function (handelFile, handelFileParser, environmentName, accountConfig) {
     try {
-        return handelFileParser.createEnvironmentContext(handelFile, environmentName, deployVersion, accountConfig);
+        return handelFileParser.createEnvironmentContext(handelFile, environmentName, accountConfig);
     }
     catch (err) {
         winston.error(`Error while parsing deploy spec: ${err.message}`);

--- a/lib/datatypes/environment-context.js
+++ b/lib/datatypes/environment-context.js
@@ -15,9 +15,8 @@
  *
  */
 class EnvironmentContext {
-    constructor(appName, deployVersion, environmentName, accountConfig) {
+    constructor(appName, environmentName, accountConfig) {
         this.appName = appName;
-        this.deployVersion = deployVersion;
         this.environmentName = environmentName;
         this.serviceContexts = {};
         this.accountConfig = accountConfig;

--- a/lib/datatypes/service-context.js
+++ b/lib/datatypes/service-context.js
@@ -16,12 +16,11 @@
  */
 class ServiceContext {
     constructor(appName, envName, serviceName,
-                serviceType, deployVersion, params, accountConfig) {
+                serviceType, params, accountConfig) {
             this.appName = appName;
             this.environmentName = envName;
             this.serviceName = serviceName;
             this.serviceType = serviceType;
-            this.deployVersion = deployVersion;
             this.params = params;
             this.accountConfig = accountConfig;
     }

--- a/lib/handelfile/parser-v1.js
+++ b/lib/handelfile/parser-v1.js
@@ -200,21 +200,20 @@ exports.validateHandelFile = function (handelFile, serviceDeployers) {
  * 
  * @param {Object} handelFile - The Object representing the provided YAML deploy spec file
  * @param {String} environmentName - The name of the environment in the deploy spec for which we want the EnvironmentContext
- * @param {String} deployVersion - The version of the app being deployed
  * @returns {EnvironmentContext} - The generated EnvironmentContext from the specified environment in the Handel file
  */
-exports.createEnvironmentContext = function (handelFile, environmentName, deployVersion, accountConfig) {
+exports.createEnvironmentContext = function (handelFile, environmentName, accountConfig) {
     let environmentSpec = handelFile.environments[environmentName];
     if (!environmentSpec) {
         throw new Error(`Can't find the requested environment in the deploy spec: ${environmentName}`)
     }
 
-    let environmentContext = new EnvironmentContext(handelFile.name, deployVersion, environmentName, accountConfig);
+    let environmentContext = new EnvironmentContext(handelFile.name, environmentName, accountConfig);
 
     _.forEach(environmentSpec, function (serviceSpec, serviceName) {
         var serviceType = serviceSpec.type;
         var serviceContext = new ServiceContext(handelFile.name, environmentName, serviceName,
-            serviceType, deployVersion, serviceSpec, accountConfig);
+            serviceType, serviceSpec, accountConfig);
         environmentContext.serviceContexts[serviceName] = serviceContext;
     });
 

--- a/lib/lifecycles/delete.js
+++ b/lib/lifecycles/delete.js
@@ -74,7 +74,7 @@ function deleteEnvironment(accountConfig, serviceDeployers, environmentContext) 
 exports.delete = function (accountConfig, handelFile, environmentToDelete, handelFileParser, serviceDeployers) {
     return Promise.resolve().then(() => {
         //Run the delete on the environment specified
-        let environmentContext = util.createEnvironmentContext(handelFile, handelFileParser, environmentToDelete, "1", accountConfig); //Use fake version since we're deleting it
+        let environmentContext = util.createEnvironmentContext(handelFile, handelFileParser, environmentToDelete, accountConfig);
         return deleteEnvironment(accountConfig, serviceDeployers, environmentContext);
     });
 };

--- a/lib/lifecycles/deploy.js
+++ b/lib/lifecycles/deploy.js
@@ -103,12 +103,12 @@ function deployEnvironment(accountConfig, serviceDeployers, environmentContext) 
     }
 }
 
-exports.deploy = function (accountConfig, handelFile, environmentsToDeploy, deployVersion, handelFileParser, serviceDeployers) {
+exports.deploy = function (accountConfig, handelFile, environmentsToDeploy, handelFileParser, serviceDeployers) {
     return Promise.resolve().then(() => {
         //Check current credentials against the accountConfig
         let envDeployPromises = [];
         for (let environmentToDeploy of environmentsToDeploy) {
-            let environmentContext = util.createEnvironmentContext(handelFile, handelFileParser, environmentToDeploy, deployVersion, accountConfig);
+            let environmentContext = util.createEnvironmentContext(handelFile, handelFileParser, environmentToDeploy, accountConfig);
             envDeployPromises.push(deployEnvironment(accountConfig, serviceDeployers, environmentContext));
         }
         return Promise.all(envDeployPromises);

--- a/lib/services/ecs/ecs-service-template.yml
+++ b/lib/services/ecs/ecs-service-template.yml
@@ -202,11 +202,11 @@ Resources:
       Role: {{ecsServiceRoleArn}}
       {{/if}}
       TaskDefinition:
-        Ref: TaskDefinition
+        Ref: TaskDefinition{{deploymentSuffix}}
       PlacementStrategies:
         - Type: spread
           Field: instanceId
-  TaskDefinition:
+  TaskDefinition{{deploymentSuffix}}:
     Type: AWS::ECS::TaskDefinition
     Properties:
       Family: {{clusterName}}

--- a/lib/services/ecs/index.js
+++ b/lib/services/ecs/index.js
@@ -83,7 +83,7 @@ function getCompiledEcsTemplate(stackName, clusterName, ownServiceContext, ownPr
                 vpcId: accountConfig.vpc,
                 ecsServiceRoleArn: ecsServiceRole.Arn,
                 policyStatements: getTaskRoleStatements(ownServiceContext, dependenciesDeployContexts),
-                deployVersion: ownServiceContext.deployVersion.toString(),
+                deploymentSuffix: Math.floor(Math.random() * 10000), //ECS won't update unless something in the service changes.
                 tags: deployPhaseCommon.getTags(ownServiceContext),
                 containerConfigs,
                 autoScaling,

--- a/test/cli/cli-test.js
+++ b/test/cli/cli-test.js
@@ -17,7 +17,6 @@
 const expect = require('chai').expect;
 const cli = require('../../lib/cli');
 const sinon = require('sinon');
-const fs = require('fs');
 const util = require('../../lib/common/util');
 
 describe('cli module', function () {
@@ -75,8 +74,7 @@ describe('cli module', function () {
         let handelFile = util.readYamlFileSync(`${__dirname}/../test-handel.yml`);
         it('should fail if the -c param is not provided', function() {
             let argv = {
-                e: "dev,prod",
-                v: "1",
+                e: "dev,prod"
             }
             let errors = cli.validateDeployArgs(argv, handelFile);
             expect(errors.length).to.equal(1);
@@ -85,7 +83,6 @@ describe('cli module', function () {
 
         it('should fail if the -e parameter is not provided', function() {
             let argv = {
-                v: "1",
                 c: `${__dirname}/../test-account-config.yml`
             }
             let errors = cli.validateDeployArgs(argv, handelFile);
@@ -93,21 +90,10 @@ describe('cli module', function () {
             expect(errors[0]).to.contain(`'-e' parameter is required`);
         });
 
-        it('should fail if the -v param is not provided', function() {
-            let argv = {
-                e: "dev,prod",
-                c: `${__dirname}/../test-account-config.yml`
-            }
-            let errors = cli.validateDeployArgs(argv, handelFile);
-            expect(errors.length).to.equal(1);
-            expect(errors[0]).to.contain(`'-v' parameter is required`);
-        });
-
         it('should suceed if all params are provided', function() {
             let argv = {
                 e: "dev,prod",
-                c: `${__dirname}/../test-account-config.yml`,
-                v: "1"
+                c: `${__dirname}/../test-account-config.yml`
             }
             let errors = cli.validateDeployArgs(argv, handelFile);
             expect(errors.length).to.equal(0);

--- a/test/common/bind-phase-common-test.js
+++ b/test/common/bind-phase-common-test.js
@@ -29,13 +29,12 @@ describe('bind phases common module', function () {
     let serviceContext;
     let appName = "FakeApp";
     let envName = "FakeEnv";
-    let deployVersion = "1";
 
     beforeEach(function () {
         return config(`${__dirname}/../test-account-config.yml`)
             .then(accountConfig => {
                 sandbox = sinon.sandbox.create();
-                serviceContext = new ServiceContext(appName, envName, "FakeService", "mysql", deployVersion, {}, accountConfig);
+                serviceContext = new ServiceContext(appName, envName, "FakeService", "mysql", {}, accountConfig);
             });
     });
 
@@ -50,7 +49,7 @@ describe('bind phases common module', function () {
                 GroupId: 'FakeId'
             });
 
-            let dependentOfServiceContext = new ServiceContext(appName, envName, "FakeDependentOfService", "ecs", deployVersion, {});
+            let dependentOfServiceContext = new ServiceContext(appName, envName, "FakeDependentOfService", "ecs", {});
             let dependentOfPreDeployContext = new PreDeployContext(dependentOfServiceContext);
             dependentOfPreDeployContext.securityGroups.push({
                 GroupId: 'OtherId'

--- a/test/common/delete-phases-common-test.js
+++ b/test/common/delete-phases-common-test.js
@@ -35,7 +35,7 @@ describe('Delete phases common module', function () {
         return config(`${__dirname}/../test-account-config.yml`)
             .then(accountConfig => {
                 sandbox = sinon.sandbox.create();
-                serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "dynamodb", "1", {}, accountConfig);
+                serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "dynamodb", {}, accountConfig);
             });
     });
 

--- a/test/common/deploy-phase-common-test.js
+++ b/test/common/deploy-phase-common-test.js
@@ -33,13 +33,12 @@ describe('Deploy phase common module', function () {
     let appName = "FakeApp";
     let envName = "FakeEnv";
     let serviceName = "FakeService";
-    let deployVersion = "1";
 
     beforeEach(function () {
         return config(`${__dirname}/../test-account-config.yml`)
             .then(accountConfig => {
                 sandbox = sinon.sandbox.create();
-                serviceContext = new ServiceContext(appName, envName, serviceName, "FakeType", deployVersion, {}, accountConfig);
+                serviceContext = new ServiceContext(appName, envName, serviceName, "FakeType", {}, accountConfig);
             });
     });
 
@@ -72,21 +71,20 @@ describe('Deploy phase common module', function () {
             expect(returnEnvVars['HANDEL_APP_NAME']).to.equal(appName);
             expect(returnEnvVars['HANDEL_ENVIRONMENT_NAME']).to.equal(envName);
             expect(returnEnvVars['HANDEL_SERVICE_NAME']).to.equal(serviceName);
-            expect(returnEnvVars['HANDEL_SERVICE_VERSION']).to.equal(deployVersion);
         });
     });
 
     describe('getEnvVarsFromDependencyDeployContexts', function () {
         it('should return an object with the env vars from all given DeployContexts', function () {
             let deployContexts = []
-            let serviceContext1 = new ServiceContext("FakeApp", "FakeEnv", "FakeService1", "FakeType1", "1", {}, serviceContext.accountConfig);
+            let serviceContext1 = new ServiceContext("FakeApp", "FakeEnv", "FakeService1", "FakeType1", {}, serviceContext.accountConfig);
             let deployContext1 = new DeployContext(serviceContext1);
             let envVarName1 = "ENV_VAR_1";
             let envVarValue1 = "someValue1";
             deployContext1.environmentVariables[envVarName1] = envVarValue1;
             deployContexts.push(deployContext1);
 
-            let serviceContext2 = new ServiceContext("FakeApp", "FakeEnv", "FakeService2", "FakeType2", "1", {}, serviceContext.accountConfig);
+            let serviceContext2 = new ServiceContext("FakeApp", "FakeEnv", "FakeService2", "FakeType2", {}, serviceContext.accountConfig);
             let deployContext2 = new DeployContext(serviceContext2);
             let envVarName2 = "ENV_VAR_2";
             let envVarValue2 = "someValue2";
@@ -146,7 +144,7 @@ describe('Deploy phase common module', function () {
             }];
 
             let dependenciesDeployContexts = [];
-            let dependencyServiceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "sqs", "1", {}, serviceContext.accountConfig);
+            let dependencyServiceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "sqs", {}, serviceContext.accountConfig);
             let dependencyDeployContext = new DeployContext(dependencyServiceContext);
             dependencyDeployContext.policies.push({
                 "Effect": "Allow",

--- a/test/common/elasticache-deployers-common-test.js
+++ b/test/common/elasticache-deployers-common-test.js
@@ -32,7 +32,7 @@ describe('elasticache deployers common module', function () {
 
     describe('getClusterName', function () {
         it('should return the shortened cluster name from the ServiceContext', function () {
-            let serviceContext = new ServiceContext("MyFakeAppWithALongNameWithManyCharacters", "MyLongEnvName", "MyLongishServiceName", "redis", "1", {});
+            let serviceContext = new ServiceContext("MyFakeAppWithALongNameWithManyCharacters", "MyLongEnvName", "MyLongishServiceName", "redis", {});
             let clusterName = elasticacheDeployersCommon.getClusterName(serviceContext);
             expect(clusterName).to.equal("MyFakeApp-MyL-MyLong");
         });

--- a/test/common/iot-deployers-common-test.js
+++ b/test/common/iot-deployers-common-test.js
@@ -32,7 +32,7 @@ describe('iot deployers common module', function () {
         sandbox.restore();
     });
 
-    let producerServiceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService-Name", "iot", "1", {});
+    let producerServiceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService-Name", "iot", {});
 
     describe('getTopicRuleNamePrefix', function () {
         it('should return the prefix for the topic rule name (minus the consumer service name)', function () {

--- a/test/common/lifecycles-common-test.js
+++ b/test/common/lifecycles-common-test.js
@@ -38,7 +38,7 @@ describe('lifecycles common module', function () {
 
     describe('preDeployNotRequired', function() {
         it('should return an empty predeploy context', function() {
-            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", {});
             return lifecyclesCommon.preDeployNotRequired(serviceContext)
                 .then(preDeployContext => {
                     expect(preDeployContext).to.be.instanceof(PreDeployContext);
@@ -50,8 +50,8 @@ describe('lifecycles common module', function () {
         it('should return an empty bind context', function () {
             let appName = "FakeApp";
             let envName = "FakeEnv";
-            let ownServiceContext = new ServiceContext(appName, envName, "FakeService", "efs", "1", {});
-            let dependentOfServiceContext = new ServiceContext(appName, envName, "FakeDependentService", "ecs", "1", {});
+            let ownServiceContext = new ServiceContext(appName, envName, "FakeService", "efs", {});
+            let dependentOfServiceContext = new ServiceContext(appName, envName, "FakeDependentService", "ecs", {});
             
             return lifecyclesCommon.bindNotRequired(ownServiceContext, dependentOfServiceContext, "FakeService")
                 .then(bindContext => {
@@ -62,7 +62,7 @@ describe('lifecycles common module', function () {
     
     describe('deployNotRequired', function() {
         it('should return an empty deploy context', function() {
-            let ownServiceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "efs", "1", {});
+            let ownServiceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "efs", {});
 
             return lifecyclesCommon.deployNotRequired(ownServiceContext)
                 .then(deployContext => {

--- a/test/common/pre-deploy-phase-common-test.js
+++ b/test/common/pre-deploy-phase-common-test.js
@@ -32,7 +32,7 @@ describe('PreDeploy Phase Common module', function () {
         return config(`${__dirname}/../test-account-config.yml`)
             .then(accountConfig => {
                 sandbox = sinon.sandbox.create();
-                serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {}, accountConfig);
+                serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", {}, accountConfig);
             });
     });
 

--- a/test/common/produce-events-phase-common-test.js
+++ b/test/common/produce-events-phase-common-test.js
@@ -33,13 +33,12 @@ describe('produce events phase common module', function () {
     describe('getEventConsumerConfigParams', function () {
         let appName = "FakeApp";
         let envName = "FakeEnv";
-        let deployVersion = "1";
         let consumerServiceName = "ConsumerServiceName";
         let producerServiceName = "ProducerServiceName";
 
         it('should return the config for the consumer from the producer', function () {
             let eventInputVal = '{"notify": false}';
-            let producerServiceContext = new ServiceContext(appName, envName, producerServiceName, "cloudwatchevent", deployVersion, {
+            let producerServiceContext = new ServiceContext(appName, envName, producerServiceName, "cloudwatchevent", {
                 event_consumers: [{
                     service_name: consumerServiceName,
                     event_input: eventInputVal
@@ -52,7 +51,7 @@ describe('produce events phase common module', function () {
         });
 
         it('should return null when no config exists in the producer for the consumer', function () {
-            let producerServiceContext = new ServiceContext(appName, envName, producerServiceName, "cloudwatchevent", deployVersion, {
+            let producerServiceContext = new ServiceContext(appName, envName, producerServiceName, "cloudwatchevent", {
                 event_consumers: []
             });
 

--- a/test/common/rds-deployers-common-test.js
+++ b/test/common/rds-deployers-common-test.js
@@ -33,7 +33,7 @@ describe('RDS deployers common module', function () {
 
     describe('getDeployContext', function () {
         it('should return the RDS deploy context from the service context and deployed stack', function () {
-            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", {});
             let dbAddress = "FakeAddress";
             let dbPort = 55555;
             let dbUsername = "FakeUsername";
@@ -72,7 +72,7 @@ describe('RDS deployers common module', function () {
         it('should store the database password to the parameter store', function() {
             let storeParamStub = sandbox.stub(ssmCalls, 'storeParameter').returns(Promise.resolve(true));
 
-            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", {});
             return rdsDeployersCommon.addDbCredentialToParameterStore(serviceContext, 'FakePassword', {})
                 .then(deployedStack => {
                     expect(deployedStack).to.deep.equal({});
@@ -85,7 +85,7 @@ describe('RDS deployers common module', function () {
         it('should delete the RDS parameters from the parameter store', function() {
             let deleteParamsStub = sandbox.stub(ssmCalls, 'deleteParameters').returns(Promise.resolve(true));
 
-            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", {});
             return rdsDeployersCommon.deleteParametersFromParameterStore(serviceContext, {})
                 .then(unDeployContext => {
                     expect(unDeployContext).to.deep.equal({});

--- a/test/common/s3-deployers-common-test.js
+++ b/test/common/s3-deployers-common-test.js
@@ -56,7 +56,7 @@ describe('S3 deployers common module', function () {
 
     describe('getLogFilePrefix', function () {
         it('should return the proper s3 prefix', function () {
-            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", {});
             let prefix = s3DeployersCommon.getLogFilePrefix(serviceContext);
             expect(prefix).to.equal('FakeApp/FakeEnv/FakeService/');
         });

--- a/test/common/util-test.js
+++ b/test/common/util-test.js
@@ -200,9 +200,8 @@ describe('util module', function () {
         let handelFile = util.readYamlFileSync(`${__dirname}/../test-handel.yml`);
         let handelFileParser = util.getHandelFileParser(handelFile);
         let environmentName = "dev";
-        let deployVersion = "1";
 
-        let environmentContext = util.createEnvironmentContext(handelFile, handelFileParser, environmentName, deployVersion);
+        let environmentContext = util.createEnvironmentContext(handelFile, handelFileParser, environmentName, {});
         expect(environmentContext).to.be.instanceof(EnvironmentContext);
     });
 })

--- a/test/datatypes/environment-context-test.js
+++ b/test/datatypes/environment-context-test.js
@@ -20,12 +20,12 @@ const expect = require('chai').expect;
 describe('EnvironmentContext', function () {
     it('should be able to be constructed with required parameters', function () {
         let appName = "FakeApp";
-        let deployVersion = 1;
         let environmentName = "FakeEnvironment";
-        let environmentContext = new EnvironmentContext(appName, deployVersion, environmentName);
+        let accountConfig = {};
+        let environmentContext = new EnvironmentContext(appName, environmentName, accountConfig);
         expect(environmentContext.appName).to.equal(appName);
-        expect(environmentContext.deployVersion).to.equal(deployVersion);
         expect(environmentContext.environmentName).to.equal(environmentName);
+        expect(environmentContext.accountConfig).to.deep.equal(accountConfig);
         expect(environmentContext.serviceContexts).to.deep.equal({});
     });
 });

--- a/test/datatypes/service-context-test.js
+++ b/test/datatypes/service-context-test.js
@@ -23,14 +23,12 @@ describe('ServiceContext', function () {
         let environmentName = "FakeEnv";
         let serviceName = "FakeService";
         let serviceType = "FakeType";
-        let deployVersion = 1;
         let params = {};
-        let serviceContext = new ServiceContext(appName, environmentName, serviceName, serviceType, deployVersion, params);
+        let serviceContext = new ServiceContext(appName, environmentName, serviceName, serviceType, params);
         expect(serviceContext.appName).to.equal(appName);
         expect(serviceContext.environmentName).to.equal(environmentName);
         expect(serviceContext.serviceName).to.equal(serviceName);
         expect(serviceContext.serviceType).to.equal(serviceType);
-        expect(serviceContext.deployVersion).to.equal(deployVersion);
         expect(serviceContext.params).to.deep.equal(params);
     });
 });

--- a/test/deploy/deploy-order-calc-test.js
+++ b/test/deploy/deploy-order-calc-test.js
@@ -24,9 +24,9 @@ const expect = require('chai').expect;
 function getEnvironmentContextFromYamlFile(filePath) {
     let doc = yaml.safeLoad(fs.readFileSync(filePath, 'utf8'));
 
-    let environmentContext = new EnvironmentContext(doc.name, 1, "dev");
+    let environmentContext = new EnvironmentContext(doc.name, "dev", {});
     for(let serviceName in doc.environments.dev) {
-        let serviceContext = new ServiceContext(environmentContext.appName, environmentContext.environmentName, serviceName, doc.environments.dev[serviceName].type, 1, doc.environments.dev[serviceName])
+        let serviceContext = new ServiceContext(environmentContext.appName, environmentContext.environmentName, serviceName, doc.environments.dev[serviceName].type, doc.environments.dev[serviceName])
         environmentContext.serviceContexts[serviceName] = serviceContext;
     }
     return environmentContext;

--- a/test/handelfile/parser-v1-test.js
+++ b/test/handelfile/parser-v1-test.js
@@ -213,7 +213,7 @@ describe('parser-v1', function () {
                     }
                 }
             };
-            let environmentContext = parserV1.createEnvironmentContext(handelFile, "dev", "1");
+            let environmentContext = parserV1.createEnvironmentContext(handelFile, "dev", {});
             expect(environmentContext.appName).to.equal('test');
             expect(environmentContext.environmentName).to.equal('dev');
             expect(environmentContext.serviceContexts['A'].serviceType).to.equal('dynamodb');

--- a/test/lifecycles/deploy-test.js
+++ b/test/lifecycles/deploy-test.js
@@ -47,7 +47,7 @@ describe('deploy lifecycle module', function () {
             let deployServicesInlevelStub = sandbox.stub(deployPhase, 'deployServicesInLevel').returns({});
             let handelFile = util.readYamlFileSync(`${__dirname}/../test-handel.yml`);
             let serviceDeployers = util.getServiceDeployers();
-            return deployLifecycle.deploy(`${__dirname}/../test-account-config.yml`, handelFile, ["dev", "prod"], "1", handelFileParser, serviceDeployers)
+            return deployLifecycle.deploy(`${__dirname}/../test-account-config.yml`, handelFile, ["dev", "prod"], handelFileParser, serviceDeployers)
                 .then(results => {
                     expect(checkServicesStub.calledTwice).to.be.true;
                     expect(preDeployServicesStub.calledTwice).to.be.true;

--- a/test/phases/bind-test.js
+++ b/test/phases/bind-test.js
@@ -35,10 +35,10 @@ describe('bind', function () {
 
     describe('bindServicesInLevel', function () {
         //Construct EnvironmentContext
-        let appName = "FakeApp"
-        let deployVersion = "1";
+        let appName = "FakeApp";
         let environmentName = "dev";
-        let environmentContext = new EnvironmentContext(appName, deployVersion, environmentName);
+        let accountConfig = {};
+        let environmentContext = new EnvironmentContext(appName, environmentName, accountConfig);
 
         //Construct ServiceContext B
         let serviceNameB = "B";
@@ -46,7 +46,7 @@ describe('bind', function () {
         let paramsB = {
             other: "param"
         }
-        let serviceContextB = new ServiceContext(appName, environmentName, serviceNameB, serviceTypeB, deployVersion, paramsB);
+        let serviceContextB = new ServiceContext(appName, environmentName, serviceNameB, serviceTypeB, paramsB, accountConfig);
         environmentContext.serviceContexts[serviceNameB] = serviceContextB;
 
         //Construct ServiceContext A
@@ -56,7 +56,7 @@ describe('bind', function () {
             some: "param",
             dependencies: [serviceNameB]
         }
-        let serviceContextA = new ServiceContext(appName, environmentName, serviceNameA, serviceTypeA, deployVersion, paramsA);
+        let serviceContextA = new ServiceContext(appName, environmentName, serviceNameA, serviceTypeA, paramsA, accountConfig);
         environmentContext.serviceContexts[serviceNameA] = serviceContextA;
 
         //Construct ServiceContext C
@@ -66,7 +66,7 @@ describe('bind', function () {
             some: "param",
             dependencies: [serviceNameB]
         }
-        let serviceContextC = new ServiceContext(appName, environmentName, serviceNameC, serviceTypeC, deployVersion, paramsC);
+        let serviceContextC = new ServiceContext(appName, environmentName, serviceNameC, serviceTypeC, paramsC, accountConfig);
         environmentContext.serviceContexts[serviceNameC] = serviceContextC;
 
 

--- a/test/phases/check-test.js
+++ b/test/phases/check-test.js
@@ -35,10 +35,10 @@ function getServiceDeployers() {
 
 function getEnvironmentContext() {
     //Construct EnvironmentContext
-    let appName = "FakeApp"
-    let deployVersion = "1";
+    let appName = "FakeApp";
     let environmentName = "dev";
-    let environmentContext = new EnvironmentContext(appName, deployVersion, environmentName);
+    let accountConfig = {};
+    let environmentContext = new EnvironmentContext(appName, environmentName, accountConfig);
 
     //Construct ServiceContext A
     let serviceNameA = "A";
@@ -46,7 +46,7 @@ function getEnvironmentContext() {
     let paramsA = {
         some: "param"
     }
-    let serviceContextA = new ServiceContext(appName, environmentName, serviceNameA, serviceTypeA, deployVersion, paramsA);
+    let serviceContextA = new ServiceContext(appName, environmentName, serviceNameA, serviceTypeA, paramsA, accountConfig);
     environmentContext.serviceContexts[serviceNameA] = serviceContextA;
 
     //Construct ServiceContext B
@@ -55,7 +55,7 @@ function getEnvironmentContext() {
     let paramsB = {
         other: "param"
     }
-    let serviceContextB = new ServiceContext(appName, environmentName, serviceNameB, serviceTypeB, deployVersion, paramsB);
+    let serviceContextB = new ServiceContext(appName, environmentName, serviceNameB, serviceTypeB, paramsB, accountConfig);
     environmentContext.serviceContexts[serviceNameB] = serviceContextB;
     return environmentContext;
 }

--- a/test/phases/consume-events-test.js
+++ b/test/phases/consume-events-test.js
@@ -50,9 +50,9 @@ describe('consumeEvents module', function () {
 
             //Create EnvironmentContext
             let appName = "test";
-            let deployVersion = "1";
             let environmentName = "dev";
-            let environmentContext = new EnvironmentContext(appName, deployVersion, environmentName);
+            let accountConfig = {};
+            let environmentContext = new EnvironmentContext(appName, environmentName, accountConfig);
 
             //Construct ServiceContext B (Consuming service)
             let serviceNameB = "B";
@@ -60,7 +60,7 @@ describe('consumeEvents module', function () {
             let paramsB = {
                 other: "param"
             }
-            let serviceContextB = new ServiceContext(appName, environmentName, serviceNameB, serviceTypeB, deployVersion, paramsB);
+            let serviceContextB = new ServiceContext(appName, environmentName, serviceNameB, serviceTypeB, paramsB, accountConfig);
             environmentContext.serviceContexts[serviceNameB] = serviceContextB;
 
             //Construct ServiceContext A (Producing service)
@@ -72,7 +72,7 @@ describe('consumeEvents module', function () {
                     service_name: "B"
                 }]
             }
-            let serviceContextA = new ServiceContext(appName, environmentName, serviceNameA, serviceTypeA, deployVersion, paramsA);
+            let serviceContextA = new ServiceContext(appName, environmentName, serviceNameA, serviceTypeA, paramsA, accountConfig);
             environmentContext.serviceContexts[serviceNameA] = serviceContextA;
 
             //Create deployContexts

--- a/test/phases/deploy-test.js
+++ b/test/phases/deploy-test.js
@@ -36,9 +36,9 @@ describe('deploy', function () {
     describe('deployServicesInLevel', function () {
         //Create EnvironmentContext
         let appName = "test";
-        let deployVersion = "1";
         let environmentName = "dev";
-        let environmentContext = new EnvironmentContext(appName, deployVersion, environmentName);
+        let accountConfig = {};
+        let environmentContext = new EnvironmentContext(appName, environmentName, accountConfig);
 
 
         //Construct ServiceContext B
@@ -47,7 +47,7 @@ describe('deploy', function () {
         let paramsB = {
             other: "param"
         }
-        let serviceContextB = new ServiceContext(appName, environmentName, serviceNameB, serviceTypeB, deployVersion, paramsB);
+        let serviceContextB = new ServiceContext(appName, environmentName, serviceNameB, serviceTypeB, paramsB, accountConfig);
         environmentContext.serviceContexts[serviceNameB] = serviceContextB;
 
         //Construct ServiceContext A
@@ -57,7 +57,7 @@ describe('deploy', function () {
             some: "param",
             dependencies: [serviceNameB]
         }
-        let serviceContextA = new ServiceContext(appName, environmentName, serviceNameA, serviceTypeA, deployVersion, paramsA);
+        let serviceContextA = new ServiceContext(appName, environmentName, serviceNameA, serviceTypeA, paramsA, accountConfig);
         environmentContext.serviceContexts[serviceNameA] = serviceContextA;
 
         //Construct PreDeployContexts

--- a/test/phases/pre-deploy-test.js
+++ b/test/phases/pre-deploy-test.js
@@ -24,9 +24,9 @@ describe('preDeploy', function () {
     describe('preDeployServices', function () {
         //Create EnvironmentContext
         let appName = "test";
-        let deployVersion = "1";
         let environmentName = "dev";
-        let environmentContext = new EnvironmentContext(appName, deployVersion, environmentName);
+        let accountConfig = {};
+        let environmentContext = new EnvironmentContext(appName, environmentName, accountConfig);
 
 
         //Construct ServiceContext B
@@ -35,7 +35,7 @@ describe('preDeploy', function () {
         let paramsB = {
             other: "param"
         }
-        let serviceContextB = new ServiceContext(appName, environmentName, serviceNameB, serviceTypeB, deployVersion, paramsB);
+        let serviceContextB = new ServiceContext(appName, environmentName, serviceNameB, serviceTypeB, paramsB, accountConfig);
         environmentContext.serviceContexts[serviceNameB] = serviceContextB;
 
         //Construct ServiceContext A
@@ -45,7 +45,7 @@ describe('preDeploy', function () {
             some: "param",
             dependencies: [serviceNameB]
         }
-        let serviceContextA = new ServiceContext(appName, environmentName, serviceNameA, serviceTypeA, deployVersion, paramsA);
+        let serviceContextA = new ServiceContext(appName, environmentName, serviceNameA, serviceTypeA, paramsA, accountConfig);
         environmentContext.serviceContexts[serviceNameA] = serviceContextA;
 
         it('should execute predeploy on all services, even across levels', function () {

--- a/test/phases/produce-events-test.js
+++ b/test/phases/produce-events-test.js
@@ -51,9 +51,9 @@ describe('produceEvents module', function () {
 
             //Create EnvironmentContext
             let appName = "test";
-            let deployVersion = "1";
             let environmentName = "dev";
-            let environmentContext = new EnvironmentContext(appName, deployVersion, environmentName);
+            let accountConfig = {};
+            let environmentContext = new EnvironmentContext(appName, environmentName, accountConfig);
 
             //Construct ServiceContext B (Consuming service)
             let serviceNameB = "B";
@@ -61,7 +61,7 @@ describe('produceEvents module', function () {
             let paramsB = {
                 other: "param"
             }
-            let serviceContextB = new ServiceContext(appName, environmentName, serviceNameB, serviceTypeB, deployVersion, paramsB);
+            let serviceContextB = new ServiceContext(appName, environmentName, serviceNameB, serviceTypeB, paramsB, accountConfig);
             environmentContext.serviceContexts[serviceNameB] = serviceContextB;
 
             //Construct ServiceContext A (Producing service)
@@ -73,7 +73,7 @@ describe('produceEvents module', function () {
                     service_name: "B"
                 }]
             }
-            let serviceContextA = new ServiceContext(appName, environmentName, serviceNameA, serviceTypeA, deployVersion, paramsA);
+            let serviceContextA = new ServiceContext(appName, environmentName, serviceNameA, serviceTypeA, paramsA, accountConfig);
             environmentContext.serviceContexts[serviceNameA] = serviceContextA;
 
             //Create deployContexts

--- a/test/phases/un-bind-test.js
+++ b/test/phases/un-bind-test.js
@@ -34,10 +34,10 @@ describe('unBind', function () {
 
     describe('unBindServicesInLevel', function () {
         //Construct EnvironmentContext
-        let appName = "FakeApp"
-        let deployVersion = "1";
+        let appName = "FakeApp";
         let environmentName = "dev";
-        let environmentContext = new EnvironmentContext(appName, deployVersion, environmentName);
+        let accountConfig = {};
+        let environmentContext = new EnvironmentContext(appName, environmentName, accountConfig);
 
         //Construct ServiceContext B
         let serviceNameB = "B";
@@ -45,7 +45,7 @@ describe('unBind', function () {
         let paramsB = {
             other: "param"
         }
-        let serviceContextB = new ServiceContext(appName, environmentName, serviceNameB, serviceTypeB, deployVersion, paramsB);
+        let serviceContextB = new ServiceContext(appName, environmentName, serviceNameB, serviceTypeB, paramsB, accountConfig);
         environmentContext.serviceContexts[serviceNameB] = serviceContextB;
 
         //Construct ServiceContext A
@@ -55,7 +55,7 @@ describe('unBind', function () {
             some: "param",
             dependencies: [serviceNameB]
         }
-        let serviceContextA = new ServiceContext(appName, environmentName, serviceNameA, serviceTypeA, deployVersion, paramsA);
+        let serviceContextA = new ServiceContext(appName, environmentName, serviceNameA, serviceTypeA, paramsA, accountConfig);
         environmentContext.serviceContexts[serviceNameA] = serviceContextA;
 
         //Set deploy order 

--- a/test/phases/un-deploy-test.js
+++ b/test/phases/un-deploy-test.js
@@ -35,9 +35,9 @@ describe('unDeploy', function () {
     describe('unDeployServicesInLevel', function () {
         //Create EnvironmentContext
         let appName = "test";
-        let deployVersion = "1";
         let environmentName = "dev";
-        let environmentContext = new EnvironmentContext(appName, deployVersion, environmentName);
+        let accountConfig = {};
+        let environmentContext = new EnvironmentContext(appName, environmentName, accountConfig);
 
 
         //Construct ServiceContext B
@@ -46,7 +46,7 @@ describe('unDeploy', function () {
         let paramsB = {
             other: "param"
         }
-        let serviceContextB = new ServiceContext(appName, environmentName, serviceNameB, serviceTypeB, deployVersion, paramsB);
+        let serviceContextB = new ServiceContext(appName, environmentName, serviceNameB, serviceTypeB, paramsB, accountConfig);
         environmentContext.serviceContexts[serviceNameB] = serviceContextB;
 
         //Construct ServiceContext A
@@ -56,7 +56,7 @@ describe('unDeploy', function () {
             some: "param",
             dependencies: [serviceNameB]
         }
-        let serviceContextA = new ServiceContext(appName, environmentName, serviceNameA, serviceTypeA, deployVersion, paramsA);
+        let serviceContextA = new ServiceContext(appName, environmentName, serviceNameA, serviceTypeA, paramsA, accountConfig);
         environmentContext.serviceContexts[serviceNameA] = serviceContextA;
 
         //Set deploy order 

--- a/test/phases/un-pre-deploy-test.js
+++ b/test/phases/un-pre-deploy-test.js
@@ -24,9 +24,9 @@ describe('preDeploy', function () {
     describe('preDeployServices', function () {
         //Create EnvironmentContext
         let appName = "test";
-        let deployVersion = "1";
         let environmentName = "dev";
-        let environmentContext = new EnvironmentContext(appName, deployVersion, environmentName);
+        let accountConfig = {};
+        let environmentContext = new EnvironmentContext(appName, environmentName, accountConfig);
 
         //Construct ServiceContext B
         let serviceNameB = "B";
@@ -34,7 +34,7 @@ describe('preDeploy', function () {
         let paramsB = {
             other: "param"
         }
-        let serviceContextB = new ServiceContext(appName, environmentName, serviceNameB, serviceTypeB, deployVersion, paramsB);
+        let serviceContextB = new ServiceContext(appName, environmentName, serviceNameB, serviceTypeB, paramsB, accountConfig);
         environmentContext.serviceContexts[serviceNameB] = serviceContextB;
 
         //Construct ServiceContext A
@@ -44,7 +44,7 @@ describe('preDeploy', function () {
             some: "param",
             dependencies: [serviceNameB]
         }
-        let serviceContextA = new ServiceContext(appName, environmentName, serviceNameA, serviceTypeA, deployVersion, paramsA);
+        let serviceContextA = new ServiceContext(appName, environmentName, serviceNameA, serviceTypeA, paramsA, accountConfig);
         environmentContext.serviceContexts[serviceNameA] = serviceContextA;
 
         it('should execute unpredeploy on all services, even across levels', function () {

--- a/test/services/alexaskillkit/alexaskillkit-test.js
+++ b/test/services/alexaskillkit/alexaskillkit-test.js
@@ -31,7 +31,7 @@ describe('alexaskillkit deployer', function () {
         return config(`${__dirname}/../../test-account-config.yml`)
             .then(accountConfig => {
                 sandbox = sinon.sandbox.create();
-                serviceContext = new ServiceContext("Fakepp", "FakeEnv", "FakeService", "alexaskillkit", "1", {}, accountConfig);
+                serviceContext = new ServiceContext("Fakepp", "FakeEnv", "FakeService", "alexaskillkit", {}, accountConfig);
             });
     });
 

--- a/test/services/apiaccess/apiaccess-test.js
+++ b/test/services/apiaccess/apiaccess-test.js
@@ -31,7 +31,7 @@ describe('apiaccess deployer', function () {
         return config(`${__dirname}/../../test-account-config.yml`)
             .then(accountConfig => {
                 sandbox = sinon.sandbox.create();
-                serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "apiaccess", "1", {}, accountConfig);
+                serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "apiaccess", {}, accountConfig);
             });
     });
 

--- a/test/services/apigateway/apigateway-test.js
+++ b/test/services/apigateway/apigateway-test.js
@@ -34,13 +34,12 @@ describe('apigateway deployer', function () {
     let serviceContext;
     let appName = "FakeApp";
     let envName = "FakeEnv";
-    let deployVersion = "1";
 
     beforeEach(function () {
         return config(`${__dirname}/../../test-account-config.yml`)
             .then(accountConfig => {
                 sandbox = sinon.sandbox.create();
-                serviceContext = new ServiceContext(appName, envName, "FakeService", "FakeType", deployVersion, {}, accountConfig);
+                serviceContext = new ServiceContext(appName, envName, "FakeService", "FakeType", {}, accountConfig);
             });
     });
 

--- a/test/services/apigateway/common-test.js
+++ b/test/services/apigateway/common-test.js
@@ -27,13 +27,12 @@ describe('apigateway common module', function () {
     let serviceContext;
     let appName = "FakeApp";
     let envName = "FakeEnv";
-    let deployVersion = "1";
 
     beforeEach(function () {
         return config(`${__dirname}/../../test-account-config.yml`)
             .then(accountConfig => {
                 sandbox = sinon.sandbox.create();
-                serviceContext = new ServiceContext(appName, envName, "FakeService", "FakeType", deployVersion, {}, accountConfig);
+                serviceContext = new ServiceContext(appName, envName, "FakeService", "FakeType", {}, accountConfig);
             });
     });
 

--- a/test/services/apigateway/proxy/proxy-passthrough-deploy-type-test.js
+++ b/test/services/apigateway/proxy/proxy-passthrough-deploy-type-test.js
@@ -29,13 +29,12 @@ describe('apigateway proxy deploy type', function () {
     let serviceContext;
     let appName = "FakeApp";
     let envName = "FakeEnv";
-    let deployVersion = "1";
 
     beforeEach(function () {
         return config(`${__dirname}/../../../test-account-config.yml`)
             .then(accountConfig => {
                 sandbox = sinon.sandbox.create();
-                serviceContext = new ServiceContext(appName, envName, "FakeService", "FakeType", deployVersion, {}, accountConfig);
+                serviceContext = new ServiceContext(appName, envName, "FakeService", "FakeType", {}, accountConfig);
             });
     });
 
@@ -95,7 +94,7 @@ describe('apigateway proxy deploy type', function () {
                 ]
             }
             let dependenciesServiceContexts = [];
-            dependenciesServiceContexts.push(new ServiceContext("FakeApp", "FakeEnv", "FakeDependency", "mysql", "1"))
+            dependenciesServiceContexts.push(new ServiceContext("FakeApp", "FakeEnv", "FakeDependency", "mysql", {}, {}))
             let errors = proxyPassthroughDeployType.check(serviceContext, dependenciesServiceContexts, "API Gateway");
             expect(errors.length).to.equal(1);
             expect(errors[0]).to.contain("'vpc' parameter is required and must be true when declaring dependencies of type");
@@ -113,12 +112,12 @@ describe('apigateway proxy deploy type', function () {
             }
         });
 
-        function getDependencyDeployContexts(appName, envName, deployVersion) {
+        function getDependencyDeployContexts(appName, envName) {
             let dependenciesDeployContexts = [];
             let dependencyServiceName = "DependencyService";
             let dependencyServiceType = "dynamodb";
             let dependencyServiceParams = {}
-            let dependencyServiceContext = new ServiceContext(appName, envName, dependencyServiceName, dependencyServiceType, deployVersion, dependencyServiceParams);
+            let dependencyServiceContext = new ServiceContext(appName, envName, dependencyServiceName, dependencyServiceType, dependencyServiceParams, {});
             let dependencyDeployContext = new DeployContext(dependencyServiceContext);
             dependenciesDeployContexts.push(dependencyDeployContext);
             return dependenciesDeployContexts;
@@ -127,7 +126,7 @@ describe('apigateway proxy deploy type', function () {
         it('should deploy the service', function () {
             //Set up input parameters
             let ownPreDeployContext = new PreDeployContext(serviceContext);
-            let dependenciesDeployContexts = getDependencyDeployContexts(appName, envName, deployVersion);
+            let dependenciesDeployContexts = getDependencyDeployContexts(appName, envName);
 
             //Stub out dependent services
             let bucketName = "FakeBucket";

--- a/test/services/apigateway/swagger/swagger-deploy-type-test.js
+++ b/test/services/apigateway/swagger/swagger-deploy-type-test.js
@@ -29,7 +29,6 @@ describe('apigateway swagger deploy type', function () {
     let serviceContext;
     let appName = "FakeApp";
     let envName = "FakeEnv";
-    let deployVersion = "1";
 
     beforeEach(function () {
         return config(`${__dirname}/../../../test-account-config.yml`)
@@ -38,7 +37,7 @@ describe('apigateway swagger deploy type', function () {
                 let params = {
                     swagger: `${__dirname}/test-swagger.json`
                 }
-                serviceContext = new ServiceContext(appName, envName, "FakeService", "FakeType", deployVersion, params, accountConfig);
+                serviceContext = new ServiceContext(appName, envName, "FakeService", "FakeType", params, accountConfig);
             });
     });
 
@@ -54,12 +53,12 @@ describe('apigateway swagger deploy type', function () {
     });
 
     describe('deploy', function () {
-        function getDependencyDeployContexts(appName, envName, deployVersion) {
+        function getDependencyDeployContexts(appName, envName) {
             let dependenciesDeployContexts = [];
             let dependencyServiceName = "DependencyService";
             let dependencyServiceType = "dynamodb";
             let dependencyServiceParams = {}
-            let dependencyServiceContext = new ServiceContext(appName, envName, dependencyServiceName, dependencyServiceType, deployVersion, dependencyServiceParams);
+            let dependencyServiceContext = new ServiceContext(appName, envName, dependencyServiceName, dependencyServiceType, dependencyServiceParams, {});
             let dependencyDeployContext = new DeployContext(dependencyServiceContext);
             dependenciesDeployContexts.push(dependencyDeployContext);
             return dependenciesDeployContexts;
@@ -68,7 +67,7 @@ describe('apigateway swagger deploy type', function () {
         it('should deploy the service', function () {
             //Set up input parameters
             let ownPreDeployContext = new PreDeployContext(serviceContext);
-            let dependenciesDeployContexts = getDependencyDeployContexts(appName, envName, deployVersion);
+            let dependenciesDeployContexts = getDependencyDeployContexts(appName, envName);
 
             //Stub out dependent services
             let uploadDeployableArtifactStub = sandbox.stub(deployPhaseCommon, 'uploadDeployableArtifactToHandelBucket').returns(Promise.resolve({

--- a/test/services/beanstalk/beanstalk-test.js
+++ b/test/services/beanstalk/beanstalk-test.js
@@ -38,7 +38,7 @@ describe('beanstalk deployer', function () {
         return config(`${__dirname}/../../test-account-config.yml`)
             .then(accountConfig => {
                 sandbox = sinon.sandbox.create();
-                serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {}, accountConfig);
+                serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", {}, accountConfig);
             });
     });
 

--- a/test/services/beanstalk/deployable-artifact-test.js
+++ b/test/services/beanstalk/deployable-artifact-test.js
@@ -34,7 +34,7 @@ describe('deployable artifact module', function () {
         return config(`${__dirname}/../../test-account-config.yml`)
             .then(accountConfig => {
                 sandbox = sinon.sandbox.create();
-                serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "beanstalk", "1", {}, accountConfig);
+                serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "beanstalk", {}, accountConfig);
             });
     });
 

--- a/test/services/cloudwatchevent/cloudwatchevent-test.js
+++ b/test/services/cloudwatchevent/cloudwatchevent-test.js
@@ -33,13 +33,11 @@ describe('cloudwatchevent deployer', function () {
     let serviceContext;
     let appName = "FakeApp";
     let envName = "FakeEnv";
-    let deployVersion = "1";
-
     beforeEach(function () {
         return config(`${__dirname}/../../test-account-config.yml`)
             .then(accountConfig => {
                 sandbox = sinon.sandbox.create();
-                serviceContext = new ServiceContext(appName, envName, "FakeService", "cloudwatchevent", deployVersion, {}, accountConfig);
+                serviceContext = new ServiceContext(appName, envName, "FakeService", "cloudwatchevent", {}, accountConfig);
             });
     });
 
@@ -91,7 +89,7 @@ describe('cloudwatchevent deployer', function () {
     describe('produceEvents', function () {
         it('should add a target for the lambda service type', function () {
             let consumerServiceName = "ConsumerService";
-            let consumerServiceContext = new ServiceContext(appName, envName, consumerServiceName, "lambda", deployVersion, {});
+            let consumerServiceContext = new ServiceContext(appName, envName, consumerServiceName, "lambda", {}, {});
             let consumerDeployContext = new DeployContext(consumerServiceContext);
             consumerDeployContext.lambdaArn = "FakeLambdaArn";
 
@@ -116,7 +114,7 @@ describe('cloudwatchevent deployer', function () {
 
         it('should throw an error for an unsupported consumer service type', function () {
             let consumerServiceName = "ConsumerService";
-            let consumerServiceContext = new ServiceContext(appName, envName, consumerServiceName, "dynamodb", deployVersion, {});
+            let consumerServiceContext = new ServiceContext(appName, envName, consumerServiceName, "dynamodb", {}, {});
             let consumerDeployContext = new DeployContext(consumerServiceContext);
 
             serviceContext.params = {

--- a/test/services/dynamodb/dynamodb-test.js
+++ b/test/services/dynamodb/dynamodb-test.js
@@ -88,13 +88,12 @@ describe('dynamodb deployer', function () {
     let envName = "FakeEnv";
     let serviceName = "FakeService";
     let serviceType = "dynamodb";
-    let deployVersion = "1";
 
     beforeEach(function () {
         return config(`${__dirname}/../../test-account-config.yml`)
             .then(accountConfig => {
                 sandbox = sinon.sandbox.create();
-                serviceContext = new ServiceContext(appName, envName, serviceName, serviceType, deployVersion, {}, accountConfig);
+                serviceContext = new ServiceContext(appName, envName, serviceName, serviceType, {}, accountConfig);
             });
     });
 

--- a/test/services/ecs/ecs-test.js
+++ b/test/services/ecs/ecs-test.js
@@ -75,13 +75,12 @@ describe('ecs deployer', function () {
     let serviceContext;
     let appName = "FakeApp";
     let envName = "FakeEnv";
-    let deployVersion = "1";
 
     beforeEach(function () {
         return config(`${__dirname}/../../test-account-config.yml`)
             .then(accountConfig => {
                 sandbox = sinon.sandbox.create();
-                serviceContext = new ServiceContext(appName, envName, "FakeService", "ecs", deployVersion, {}, accountConfig);
+                serviceContext = new ServiceContext(appName, envName, "FakeService", "ecs", {}, accountConfig);
             });
     });
 
@@ -240,12 +239,12 @@ describe('ecs deployer', function () {
             return ownPreDeployContext;
         }
 
-        function getDependenciesDeployContextsForDeploy(appName, envName, deployVersion) {
+        function getDependenciesDeployContextsForDeploy(appName, envName) {
             let dependenciesDeployContexts = [];
             let dependency1ServiceName = "Dependency1Service";
             let dependency1ServiceType = "dynamodb";
             let dependency1Params = {}
-            let dependency1DeployContext = new DeployContext(new ServiceContext(appName, envName, dependency1ServiceName, dependency1ServiceType, deployVersion, dependency1Params));
+            let dependency1DeployContext = new DeployContext(new ServiceContext(appName, envName, dependency1ServiceName, dependency1ServiceType, dependency1Params, {}));
             dependenciesDeployContexts.push(dependency1DeployContext);
             let envVarName = 'DYNAMODB_SOME_VAR';
             let envVarValue = 'SomeValue'
@@ -264,7 +263,7 @@ describe('ecs deployer', function () {
             let dependency2ServiceName = "Dependency2Service";
             let dependency2ServiceType = "efs";
             let dependency2Params = {}
-            let dependency2DeployContext = new DeployContext(new ServiceContext(appName, envName, dependency2ServiceName, dependency2ServiceType, deployVersion, dependency2Params));
+            let dependency2DeployContext = new DeployContext(new ServiceContext(appName, envName, dependency2ServiceName, dependency2ServiceType, dependency2Params, {}));
             dependenciesDeployContexts.push(dependency2DeployContext);
             let scriptContents = "SOME SCRIPT";
             dependency2DeployContext.scripts.push(scriptContents);
@@ -273,7 +272,7 @@ describe('ecs deployer', function () {
 
         it('should deploy the ECS service stack', function () {
             let ownPreDeployContext = getOwnPreDeployContextForDeploy(serviceContext);
-            let dependenciesDeployContexts = getDependenciesDeployContextsForDeploy(appName, envName, deployVersion);
+            let dependenciesDeployContexts = getDependenciesDeployContextsForDeploy(appName, envName);
 
             //Stub out AWS calls
             let getLatestAmiByNameStub = sandbox.stub(ec2Calls, 'getLatestAmiByName').returns(Promise.resolve({
@@ -322,7 +321,7 @@ describe('ecs deployer', function () {
 
         it('should deploy a new ECS service stack', function () {
             let ownPreDeployContext = getOwnPreDeployContextForDeploy(serviceContext);
-            let dependenciesDeployContexts = getDependenciesDeployContextsForDeploy(appName, envName, deployVersion);
+            let dependenciesDeployContexts = getDependenciesDeployContextsForDeploy(appName, envName);
 
             //Stub out AWS calls
             let getLatestAmiByNameStub = sandbox.stub(ec2Calls, 'getLatestAmiByName').returns(Promise.resolve({

--- a/test/services/efs/efs-test.js
+++ b/test/services/efs/efs-test.js
@@ -36,13 +36,12 @@ describe('efs deployer', function () {
     let serviceContext;
     let appName = "FakeApp";
     let envName = "FakeEnv";
-    let deployVersion = "1";
 
     beforeEach(function () {
         return config(`${__dirname}/../../test-account-config.yml`)
             .then(accountConfig => {
                 sandbox = sinon.sandbox.create();
-                serviceContext = new ServiceContext(appName, envName, "FakeService", "efs", deployVersion, {}, accountConfig);
+                serviceContext = new ServiceContext(appName, envName, "FakeService", "efs", {}, accountConfig);
             });
     });
 
@@ -154,7 +153,7 @@ describe('efs deployer', function () {
 
     describe('unDeploy', function () {
         it('should undeploy the stack', function () {
-            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "efs", "1", {});
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "efs", {}, {});
             let unDeployStackStub = sandbox.stub(deletePhasesCommon, 'unDeployService').returns(Promise.resolve(new UnDeployContext(serviceContext)));
 
             return efs.unDeploy(serviceContext)

--- a/test/services/iot/iot-test.js
+++ b/test/services/iot/iot-test.js
@@ -30,14 +30,13 @@ describe('iot deployer', function () {
     let sandbox;
     let appName = "FakeApp";
     let envName = "FakeEnv";
-    let deployVersion = "1";
     let serviceContext;
 
     beforeEach(function () {
         return config(`${__dirname}/../../test-account-config.yml`)
             .then(accountConfig => {
                 sandbox = sinon.sandbox.create();
-                serviceContext = new ServiceContext(appName, envName, "FakeService", "iot", deployVersion, {}, accountConfig);
+                serviceContext = new ServiceContext(appName, envName, "FakeService", "iot", {}, accountConfig);
             });
     });
 
@@ -106,7 +105,7 @@ describe('iot deployer', function () {
 
 
         it('should create topic rules when lambda is the event consumer', function () {
-            let consumerServiceContext = new ServiceContext(appName, envName, "FakeConsumer", "lambda", deployVersion, {});
+            let consumerServiceContext = new ServiceContext(appName, envName, "FakeConsumer", "lambda", {}, {});
             let consumerDeployContext = new DeployContext(consumerServiceContext);
             consumerDeployContext.eventOutputs.lambdaArn = "FakeArn";
 
@@ -127,7 +126,7 @@ describe('iot deployer', function () {
         });
 
         it('should return an error if any other consumer type is specified', function () {
-            let consumerServiceContext = new ServiceContext(appName, envName, "FakeConsumer", "unknowntype", deployVersion, {});
+            let consumerServiceContext = new ServiceContext(appName, envName, "FakeConsumer", "unknowntype", {}, {});
             let consumerDeployContext = new DeployContext(consumerServiceContext);
 
             return iot.produceEvents(serviceContext, ownDeployContext, consumerServiceContext, consumerDeployContext)

--- a/test/services/kms/kms-test.js
+++ b/test/services/kms/kms-test.js
@@ -31,13 +31,12 @@ describe('kms deployer', function () {
     let serviceContext;
     let appName = "FakeApp";
     let envName = "FakeEnv";
-    let deployVersion = "1";
 
     beforeEach(function () {
         return config(`${__dirname}/../../test-account-config.yml`)
             .then(accountConfig => {
                 sandbox = sinon.sandbox.create();
-                serviceContext = new ServiceContext(appName, envName, "FakeService", "kms", deployVersion, {}, accountConfig);
+                serviceContext = new ServiceContext(appName, envName, "FakeService", "kms", {}, accountConfig);
             });
     });
 

--- a/test/services/lambda/lambda-test.js
+++ b/test/services/lambda/lambda-test.js
@@ -37,13 +37,12 @@ describe('lambda deployer', function () {
     let serviceContext;
     let appName = "FakeApp";
     let envName = "FakeEnv";
-    let deployVersion = "1";
 
     beforeEach(function () {
         return config(`${__dirname}/../../test-account-config.yml`)
             .then(accountConfig => {
                 sandbox = sinon.sandbox.create();
-                serviceContext = new ServiceContext(appName, envName, "FakeService", "FakeType", deployVersion, {}, accountConfig);
+                serviceContext = new ServiceContext(appName, envName, "FakeService", "FakeType", {}, accountConfig);
             });
     });
 
@@ -102,7 +101,7 @@ describe('lambda deployer', function () {
                 ]
             }
             let dependenciesServiceContexts = [];
-            dependenciesServiceContexts.push(new ServiceContext("FakeApp", "FakeEnv", "FakeDependency", "mysql", "1"))
+            dependenciesServiceContexts.push(new ServiceContext("FakeApp", "FakeEnv", "FakeDependency", "mysql", {}, {}))
             let errors = lambda.check(serviceContext, dependenciesServiceContexts);
             expect(errors.length).to.equal(1);
             expect(errors[0]).to.contain("'vpc' parameter is required and must be true when declaring dependencies of type");
@@ -163,7 +162,7 @@ describe('lambda deployer', function () {
         function getDependenciesDeployContexts() {
             let dependenciesDeployContexts = [];
 
-            let otherServiceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService2", "dynamodb", "1", {}, serviceContext.accountConfig);
+            let otherServiceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService2", "dynamodb", {}, serviceContext.accountConfig);
             let deployContext = new DeployContext(otherServiceContext);
             deployContext.environmentVariables['INJECTED_VAR'] = 'injectedValue';
             deployContext.policies.push({});
@@ -215,7 +214,7 @@ describe('lambda deployer', function () {
         });
 
         it('should add permissions for the sns service type', function () {
-            let producerServiceContext = new ServiceContext(appName, envName, "producerService", "sns", deployVersion, {});
+            let producerServiceContext = new ServiceContext(appName, envName, "producerService", "sns", {}, {});
             let producerDeployContext = new DeployContext(producerServiceContext);
             producerDeployContext.eventOutputs.principal = "FakePrincipal";
             producerDeployContext.eventOutputs.topicArn = "FakeTopicArn";
@@ -230,7 +229,7 @@ describe('lambda deployer', function () {
         });
 
         it('should add permissions for the cloudwatchevent service type', function () {
-            let producerServiceContext = new ServiceContext(appName, envName, "producerService", "cloudwatchevent", deployVersion, {});
+            let producerServiceContext = new ServiceContext(appName, envName, "producerService", "cloudwatchevent", {}, {});
             let producerDeployContext = new DeployContext(producerServiceContext);
             producerDeployContext.eventOutputs.principal = "FakePrincipal";
             producerDeployContext.eventOutputs.eventRuleArn = "FakeEventRuleArn";
@@ -245,7 +244,7 @@ describe('lambda deployer', function () {
         });
 
         it('should add permissions for the alexaskillkit service type', function () {
-            let producerServiceContext = new ServiceContext(appName, envName, "producerService", "alexaskillkit", deployVersion, {});
+            let producerServiceContext = new ServiceContext(appName, envName, "producerService", "alexaskillkit", {}, {});
             let producerDeployContext = new DeployContext(producerServiceContext);
             let addLambdaPermissionStub = sandbox.stub(lambdaCalls, 'addLambdaPermissionIfNotExists').returns(Promise.resolve({}));
 
@@ -257,7 +256,7 @@ describe('lambda deployer', function () {
         });
 
         it('should add permissions for the iot service type', function () {
-            let producerServiceContext = new ServiceContext(appName, envName, "producerService", "iot", deployVersion, {});
+            let producerServiceContext = new ServiceContext(appName, envName, "producerService", "iot", {}, {});
             let producerDeployContext = new DeployContext(producerServiceContext);
             producerDeployContext.eventOutputs.principal = "FakePrincipal";
             producerDeployContext.eventOutputs.topicRuleArnPrefix = "FakeTopicRuleArnPrefix";
@@ -272,7 +271,7 @@ describe('lambda deployer', function () {
         });
 
         it('should add permissions for the dynamodb service type', function () {
-            let producerServiceContext = new ServiceContext(appName, envName, "producerService", "dynamodb", deployVersion, {});
+            let producerServiceContext = new ServiceContext(appName, envName, "producerService", "dynamodb", {}, {});
             let producerDeployContext = new DeployContext(producerServiceContext);
             producerDeployContext.eventOutputs.principal = "FakePrincipal";
             producerDeployContext.eventOutputs.topicRuleArnPrefix = "FakeTopicRuleArnPrefix";
@@ -295,7 +294,7 @@ describe('lambda deployer', function () {
         });
 
         it('should return an error for any other service type', function () {
-            let producerServiceContext = new ServiceContext(appName, envName, "producerService", "efs", deployVersion, {});
+            let producerServiceContext = new ServiceContext(appName, envName, "producerService", "efs", {}, {});
             let producerDeployContext = new DeployContext(producerServiceContext);
 
             let addLambdaPermissionStub = sandbox.stub(lambdaCalls, 'addLambdaPermissionIfNotExists').returns(Promise.resolve({}));

--- a/test/services/memcached/memcached-test.js
+++ b/test/services/memcached/memcached-test.js
@@ -35,14 +35,13 @@ describe('memcached deployer', function () {
     let sandbox;
     let appName = "FakeApp";
     let envName = "FakeEnv";
-    let deployVersion = "1";
     let serviceContext;
 
     beforeEach(function () {
         return config(`${__dirname}/../../test-account-config.yml`)
             .then(accountConfig => {
                 sandbox = sinon.sandbox.create();
-                serviceContext = new ServiceContext(appName, envName, "FakeService", "memcached", deployVersion, {}, accountConfig);
+                serviceContext = new ServiceContext(appName, envName, "FakeService", "memcached", {}, accountConfig);
             });
     });
 
@@ -181,7 +180,7 @@ describe('memcached deployer', function () {
 
     describe('unDeploy', function () {
         it('should undeploy the stack', function () {
-            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "memcached", "1", {});
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "memcached", {}, {});
             let unDeployStackStub = sandbox.stub(deletePhasesCommon, 'unDeployService').returns(Promise.resolve(new UnDeployContext(serviceContext)));
 
             return memcached.unDeploy(serviceContext)

--- a/test/services/mysql/mysql-test.js
+++ b/test/services/mysql/mysql-test.js
@@ -36,14 +36,13 @@ describe('mysql deployer', function () {
     let sandbox;
     let appName = "FakeApp";
     let envName = "FakeEnv";
-    let deployVersion = "1";
     let serviceContext;
 
     beforeEach(function () {
         return config(`${__dirname}/../../test-account-config.yml`)
             .then(accountConfig => {
                 sandbox = sinon.sandbox.create();
-                serviceContext = new ServiceContext(appName, envName, "FakeService", "mysql", deployVersion, {}, accountConfig);
+                serviceContext = new ServiceContext(appName, envName, "FakeService", "mysql", {}, accountConfig);
             });
     });
 
@@ -219,7 +218,7 @@ describe('mysql deployer', function () {
 
     describe('unDeploy', function () {
         it('should undeploy the stack', function () {
-            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "mysql", "1", {});
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "mysql", {}, {});
             let unDeployStackStub = sandbox.stub(deletePhasesCommon, 'unDeployService').returns(Promise.resolve(new UnDeployContext(serviceContext)));
             let deleteParametersStub = sandbox.stub(ssmCalls, 'deleteParameters').returns(Promise.resolve({}));
 

--- a/test/services/postgresql/postgresql-test.js
+++ b/test/services/postgresql/postgresql-test.js
@@ -42,7 +42,7 @@ describe('postgresql deployer', function () {
         return config(`${__dirname}/../../test-account-config.yml`)
             .then(accountConfig => {
                 sandbox = sinon.sandbox.create();
-                serviceContext = new ServiceContext(appName, envName, "FakeService", "postgresql", "1", {}, accountConfig);
+                serviceContext = new ServiceContext(appName, envName, "FakeService", "postgresql", {}, accountConfig);
             });
     });
 
@@ -201,7 +201,7 @@ describe('postgresql deployer', function () {
 
     describe('unDeploy', function () {
         it('should undeploy the stack', function () {
-            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "postgresql", "1", {});
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "postgresql", {}, {});
             let unDeployContext = new UnDeployContext(serviceContext);
             let unDeployStackStub = sandbox.stub(deletePhasesCommon, 'unDeployService').returns(Promise.resolve(unDeployContext));
             let deleteParametersStub = sandbox.stub(rdsDeployersCommon, 'deleteParametersFromParameterStore').returns(Promise.resolve(unDeployContext));

--- a/test/services/redis/redis-test.js
+++ b/test/services/redis/redis-test.js
@@ -41,7 +41,7 @@ describe('redis deployer', function () {
         return config(`${__dirname}/../../test-account-config.yml`)
             .then(accountConfig => {
                 sandbox = sinon.sandbox.create();
-                serviceContext = new ServiceContext(appName, envName, "FakeService", "redis", "1", {}, accountConfig);
+                serviceContext = new ServiceContext(appName, envName, "FakeService", "redis", {}, accountConfig);
             });
     });
 
@@ -197,7 +197,7 @@ describe('redis deployer', function () {
 
     describe('unDeploy', function () {
         it('should undeploy the stack', function () {
-            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "redis", "1", {});
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "redis", {}, {});
             let unDeployStackStub = sandbox.stub(deletePhasesCommon, 'unDeployService').returns(Promise.resolve(new UnDeployContext(serviceContext)));
 
             return redis.unDeploy(serviceContext)

--- a/test/services/route53zone/route53zone-test.js
+++ b/test/services/route53zone/route53zone-test.js
@@ -29,7 +29,6 @@ const config = require('../../../lib/account-config/account-config');
 describe('route53zone deployer', function () {
     let appName = "FakeApp";
     let envName = "FakeEnv";
-    let deployVersion = "1";
     let sandbox;
     let serviceContext;
 
@@ -37,7 +36,7 @@ describe('route53zone deployer', function () {
         return config(`${__dirname}/../../test-account-config.yml`)
             .then(accountConfig => {
                 sandbox = sinon.sandbox.create();
-                serviceContext = new ServiceContext(appName, envName, "FakeService", "route53", deployVersion, {}, accountConfig);
+                serviceContext = new ServiceContext(appName, envName, "FakeService", "route53", {}, accountConfig);
             });
     });
 

--- a/test/services/s3/s3-test.js
+++ b/test/services/s3/s3-test.js
@@ -33,7 +33,7 @@ describe('s3 deployer', function () {
     beforeEach(function () {
         return config(`${__dirname}/../../test-account-config.yml`)
             .then(accountConfig => {
-                ownServiceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "s3", "1", {}, accountConfig);
+                ownServiceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "s3", {}, accountConfig);
                 sandbox = sinon.sandbox.create();
             });
     });

--- a/test/services/s3staticsite/s3staticsite-test.js
+++ b/test/services/s3staticsite/s3staticsite-test.js
@@ -39,7 +39,7 @@ describe('s3staticsite deployer', function () {
         };
         return config(`${__dirname}/../../test-account-config.yml`)
             .then(accountConfig => {
-                ownServiceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "s3staticsite", "1", serviceParams, accountConfig);
+                ownServiceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "s3staticsite", serviceParams, accountConfig);
                 sandbox = sinon.sandbox.create();
             });
     });

--- a/test/services/ses/ses-test.js
+++ b/test/services/ses/ses-test.js
@@ -38,11 +38,10 @@ describe('ses deployer', function () {
         const env = `FakeEnv`;
         const service = `FakeService`;
         const serviceType = `ses`;
-        const version = `1`;
 
         it(`should require an address`, function () {
             const params = {};
-            const serviceContext = new ServiceContext(app, env, service, serviceType, version, params);
+            const serviceContext = new ServiceContext(app, env, service, serviceType, params, {});
             const errors = ses.check(serviceContext);
             expect(errors.length).to.equal(1);
             expect(errors[0]).to.include(`valid email address`);
@@ -51,7 +50,7 @@ describe('ses deployer', function () {
             const params = {
                 address: `example.com`
             };
-            const serviceContext = new ServiceContext(app, env, service, serviceType, version, params);
+            const serviceContext = new ServiceContext(app, env, service, serviceType, params, {});
             const errors = ses.check(serviceContext);
             expect(errors.length).to.equal(1);
             expect(errors[0]).to.include(`valid email address`);
@@ -60,7 +59,7 @@ describe('ses deployer', function () {
             const params = {
                 address: 'user@example.com'
             };
-            const serviceContext = new ServiceContext(app, env, service, serviceType, version, params);
+            const serviceContext = new ServiceContext(app, env, service, serviceType, params, {});
             const errors = ses.check(serviceContext);
             expect(errors).to.deep.equal([]);
         });
@@ -71,17 +70,16 @@ describe('ses deployer', function () {
         const env = `FakeEnv`;
         const service = `FakeService`;
         const serviceType = `ses`;
-        const version = `1`;
 
         const address = `user@example.com`;
         const account = 'fake account';
         const region = 'fake region';
         const identityArn = `arn:aws:ses:${region}:${account}:identity/${address}`
 
-        const ownServiceContext = new ServiceContext(app, env, service, serviceType, version, {
+        const ownServiceContext = new ServiceContext(app, env, service, serviceType, {
             type: `ses`,
             address
-        });
+        }, {});
         const ownPreDeployContext = new PreDeployContext(ownServiceContext);
 
         ownServiceContext.accountConfig = {account_id: account, region};

--- a/test/services/sns/sns-test.js
+++ b/test/services/sns/sns-test.js
@@ -39,7 +39,7 @@ describe('sns deployer', function () {
 
     describe('check', function () {
         it('should handle no subscriptions', function () {
-            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", {}, {});
             let errors = sns.check(serviceContext);
             expect(errors).to.deep.equal([]);
         });
@@ -49,7 +49,7 @@ describe('sns deployer', function () {
                     protocol: 'http'
                 }]
             };
-            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", params);
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", params, {});
             let errors = sns.check(serviceContext);
             expect(errors.length).to.equal(1);
             expect(errors[0]).to.include(`requires an 'endpoint'`);
@@ -60,7 +60,7 @@ describe('sns deployer', function () {
                     endpoint: 'http://example.com/'
                 }]
             };
-            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", params);
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", params, {});
             let errors = sns.check(serviceContext);
             expect(errors.length).to.equal(1);
             expect(errors[0]).to.include(`requires a 'protocol'`);
@@ -72,7 +72,7 @@ describe('sns deployer', function () {
                     protocol: 'webhook'
                 }]
             };
-            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", params);
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", params, {});
             let errors = sns.check(serviceContext);
             expect(errors.length).to.equal(1);
             expect(errors[0]).to.include(`Protocol must be one of`);
@@ -87,9 +87,9 @@ describe('sns deployer', function () {
         let topicName = "FakeTopic";
         let topicArn = "FakeArn";
 
-        let ownServiceContext = new ServiceContext(appName, envName, serviceName, serviceType, "1", {
+        let ownServiceContext = new ServiceContext(appName, envName, serviceName, serviceType, {
             type: 'sns'
-        });
+        }, {});
         let ownPreDeployContext = new PreDeployContext(ownServiceContext);
 
         it('should deploy the topic', function () {
@@ -128,12 +128,11 @@ describe('sns deployer', function () {
         it('should subscribe the service to the topic when a lambda is given', function () {
             let appName = "FakeApp";
             let envName = "FakeEnv";
-            let deployVersion = "1";
-            let ownServiceContext = new ServiceContext(appName, envName, "consumerService", "sns", deployVersion, {});
+            let ownServiceContext = new ServiceContext(appName, envName, "consumerService", "sns", {}, {});
             let ownDeployContext = new DeployContext(ownServiceContext);
             ownDeployContext.eventOutputs.topicArn = "FakeTopicArn";
 
-            let consumerServiceContext = new ServiceContext(appName, envName, "producerService", "lambda", deployVersion, {});
+            let consumerServiceContext = new ServiceContext(appName, envName, "producerService", "lambda", {}, {});
             let consumerDeployContext = new DeployContext(consumerServiceContext);
             consumerDeployContext.eventOutputs.lambdaArn = "FakeLambdaArn";
 
@@ -149,12 +148,11 @@ describe('sns deployer', function () {
         it('should return an error for any other service type', function () {
             let appName = "FakeApp";
             let envName = "FakeEnv";
-            let deployVersion = "1";
-            let ownServiceContext = new ServiceContext(appName, envName, "consumerService", "sns", deployVersion, {});
+            let ownServiceContext = new ServiceContext(appName, envName, "consumerService", "sns", {}, {});
             let ownDeployContext = new DeployContext(ownServiceContext);
             ownDeployContext.eventOutputs.topicArn = "FakeTopicArn";
 
-            let consumerServiceContext = new ServiceContext(appName, envName, "producerService", "efs", deployVersion, {});
+            let consumerServiceContext = new ServiceContext(appName, envName, "producerService", "efs", {}, {});
             let consumerDeployContext = new DeployContext(consumerServiceContext);
 
             let subscribeToTopicStub = sandbox.stub(snsCalls, 'subscribeToTopic').returns(Promise.resolve({}));
@@ -173,7 +171,7 @@ describe('sns deployer', function () {
 
     describe('unDeploy', function () {
         it('should undeploy the stack', function () {
-            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "sns", "1", {});
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "sns", {}, {});
             let unDeployStackStub = sandbox.stub(deletePhasesCommon, 'unDeployService').returns(Promise.resolve(new UnDeployContext(serviceContext)));
 
             return sns.unDeploy(serviceContext)

--- a/test/services/sqs/sqs-test.js
+++ b/test/services/sqs/sqs-test.js
@@ -39,7 +39,7 @@ describe('sqs deployer', function () {
 
     describe('check', function () {
         it('shouldnt validate anything yet', function () {
-            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", {}, {});
             let errors = sqs.check(serviceContext);
             expect(errors).to.deep.equal([]);
         });
@@ -57,7 +57,7 @@ describe('sqs deployer', function () {
         let deadLetterQueueArn = "FakeDeadLetterArn";
         let deadLetterQueueUrl = "FakeDeadLetterUrl";
 
-        let ownServiceContext = new ServiceContext(appName, envName, serviceName, serviceType, "1", {
+        let ownServiceContext = new ServiceContext(appName, envName, serviceName, serviceType, {
             type: 'sqs',
             queue_type: 'fifo',
             content_based_deduplication: true,
@@ -74,7 +74,7 @@ describe('sqs deployer', function () {
               message_retention_period: 345601,
               visibility_timeout: 40
             }
-        });
+        }, {});
         let ownPreDeployContext = new PreDeployContext(ownServiceContext);
 
         it('should deploy the queue', function () {
@@ -136,13 +136,12 @@ describe('sqs deployer', function () {
         it('should throw an error because SQS cant consume event services', function () {
             let appName = "FakeApp";
             let envName = "FakeEnv";
-            let deployVersion = "1";
-            let consumerServiceContext = new ServiceContext(appName, envName, "ConsumerService", "sqs", deployVersion, {});
+            let consumerServiceContext = new ServiceContext(appName, envName, "ConsumerService", "sqs", {}, {});
             let consumerDeployContext = new DeployContext(consumerServiceContext);
             consumerDeployContext.eventOutputs.queueUrl = "FakeQueueUrl";
             consumerDeployContext.eventOutputs.queueArn = "FakeQueueArn";
 
-            let producerServiceContext = new ServiceContext(appName, envName, "ProducerService", "sns", deployVersion, {});
+            let producerServiceContext = new ServiceContext(appName, envName, "ProducerService", "sns", {}, {});
             let producerDeployContext = new DeployContext(producerServiceContext);
             producerDeployContext.eventOutputs.topicArn = "FakeTopicArn";
 
@@ -158,7 +157,7 @@ describe('sqs deployer', function () {
 
     describe('unDeploy', function () {
         it('should undeploy the stack', function () {
-            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "sqs", "1", {});
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "sqs", {}, {});
             let unDeployStackStub = sandbox.stub(deletePhasesCommon, 'unDeployService').returns(Promise.resolve(new UnDeployContext(serviceContext)));
 
             return sqs.unDeploy(serviceContext)


### PR DESCRIPTION
This flag ended up not being used anywhere. Instead we're doing things
like using a random number where an arbitrary modification to the
template is required to update the stack properly.

Resolves #297 