### PR TITLE
Typo in Beanstalk Docs

### DIFF
--- a/docs/supported-services/beanstalk.rst
+++ b/docs/supported-services/beanstalk.rst
@@ -155,7 +155,7 @@ The Routing element is defined by the following schema:
     
     routing:
       type: <http|https>
-      https_certificate # Required if you select https as the routing type
+      https_certificate: <string> # Required if you select https as the routing type
       dns_names:
        - <string> # Optional
 


### PR DESCRIPTION
Adding clarification that "https_certificate" should be "https_certificate: <string>" (like other supported services in Handel)