### PR TITLE
DynamoDB Autoscaling - Use DependsOn to avoid CloudWatch API Rate Limits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
     "@types/node": {
       "version": "8.0.47",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.47.tgz",
-      "integrity": "sha512-kOwL746WVvt/9Phf6/JgX/bsGQvbrK5iUgzyfwZNcKVFcjAUVSpF9HxevLTld2SG9aywYHOILj38arDdY1r/iQ=="
+      "integrity": "sha512-kOwL746WVvt/9Phf6/JgX/bsGQvbrK5iUgzyfwZNcKVFcjAUVSpF9HxevLTld2SG9aywYHOILj38arDdY1r/iQ==",
+      "dev": true
     },
     "@types/sinon": {
       "version": "2.3.7",
@@ -37,6 +38,7 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.3.tgz",
       "integrity": "sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==",
+      "dev": true,
       "requires": {
         "@types/node": "8.0.47"
       }
@@ -399,7 +401,8 @@
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
     },
     "aws-sdk": {
       "version": "2.133.0",
@@ -651,6 +654,7 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -658,7 +662,8 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "commander": {
       "version": "2.11.0",
@@ -725,7 +730,8 @@
     "diff": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
-      "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA=="
+      "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
+      "dev": true
     },
     "duplexer2": {
       "version": "0.0.2",
@@ -810,7 +816,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "eslint": {
       "version": "3.19.0",
@@ -2885,7 +2892,8 @@
     "has-flag": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "dev": true
     },
     "has-gulplog": {
       "version": "0.1.0",
@@ -2906,6 +2914,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+      "dev": true,
       "requires": {
         "parse-passwd": "1.0.0"
       }
@@ -3582,7 +3591,8 @@
     "make-error": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.0.tgz",
-      "integrity": "sha1-Uq06M5zPEM5itAQLcI/nByRLi5Y="
+      "integrity": "sha1-Uq06M5zPEM5itAQLcI/nByRLi5Y=",
+      "dev": true
     },
     "map-cache": {
       "version": "0.2.2",
@@ -3670,6 +3680,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -3677,7 +3688,8 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
         }
       }
     },
@@ -4098,7 +4110,8 @@
     "parse-passwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "dev": true
     },
     "pascal-case": {
       "version": "2.0.1",
@@ -4404,12 +4417,14 @@
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
     },
     "source-map-support": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "dev": true,
       "requires": {
         "source-map": "0.5.7"
       }
@@ -4481,7 +4496,8 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
     },
     "supports-color": {
       "version": "2.0.0",
@@ -4590,6 +4606,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-3.3.0.tgz",
       "integrity": "sha1-wTxqMCTjC+EYDdUwOPwgkonUv2k=",
+      "dev": true,
       "requires": {
         "arrify": "1.0.1",
         "chalk": "2.3.0",
@@ -4607,6 +4624,7 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
@@ -4615,6 +4633,7 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
@@ -4625,6 +4644,7 @@
           "version": "4.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -4633,6 +4653,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.0.1.tgz",
           "integrity": "sha1-3Oj8N5wX2fLJ6e142JzgAFKxt2s=",
+          "dev": true,
           "requires": {
             "homedir-polyfill": "1.0.1"
           }
@@ -4643,6 +4664,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-6.0.0.tgz",
       "integrity": "sha1-aw6DdgA9evGGT434+J3QBZ/80DI=",
+      "dev": true,
       "requires": {
         "strip-bom": "3.0.0",
         "strip-json-comments": "2.0.1"
@@ -4651,7 +4673,8 @@
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
         }
       }
     },
@@ -4943,7 +4966,8 @@
     "yn": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
-      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo="
+      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "author": "David Woodruff",
   "license": "Apache-2.0",
   "dependencies": {
-    "@types/uuid": "^3.4.3",
     "ajv": "^5.2.3",
     "ajv-errors": "^1.0.0",
     "archiver": "^1.3.0",
@@ -38,6 +37,7 @@
     "@types/mocha": "^2.2.44",
     "@types/node": "^8.0.47",
     "@types/sinon": "^2.3.7",
+    "@types/uuid": "^3.4.3",
     "@types/winston": "^2.3.7",
     "aws-sdk-mock": "^1.6.1",
     "chai": "^3.5.0",
@@ -52,8 +52,8 @@
     "run-sequence": "^2.2.0",
     "sinon": "^1.17.7",
     "sinon-chai": "^2.13.0",
+    "ts-node": "^3.3.0",
     "tslint": "^5.8.0",
-    "typescript": "^2.5.3",
-    "ts-node": "^3.3.0"
+    "typescript": "^2.5.3"
   }
 }

--- a/src/common/handlebars-utils.js
+++ b/src/common/handlebars-utils.js
@@ -26,7 +26,7 @@ handlebars.registerHelper('logicalId', util.normalizeLogicalId);
  * 
  * @param {String} filename - The full path of the template file on disk to read 
  * @param {Object} variables - A Javascript object containing the variables to be used by Handlebars for the template
- * @returns {String} - The finished template with variables replaced
+ * @returns {Promise<String>} - The finished template with variables replaced
  */
 exports.compileTemplate = function (filename, variables) {
     //TODO - This doesn't handle errors yet

--- a/src/datatypes/service-config.ts
+++ b/src/datatypes/service-config.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+export default interface ServiceConfig {
+    type: string;
+}

--- a/src/datatypes/service-context.ts
+++ b/src/datatypes/service-context.ts
@@ -16,20 +16,21 @@
  */
 
 import { AccountConfig } from './account-config';
+import ServiceConfig from './service-config';
 
-export class ServiceContext {
+export class ServiceContext<Config extends ServiceConfig = any> {
     public appName: string;
     public environmentName: string;
     public serviceName: string;
     public serviceType: string;
-    public params: any;
+    public params: Config;
     public accountConfig: AccountConfig;
 
     constructor(appName: string,
                 environmentName: string,
                 serviceName: string,
                 serviceType: string,
-                params: any,
+                params: Config | any,
                 accountConfig: AccountConfig) {
             this.appName = appName;
             this.environmentName = environmentName;

--- a/src/datatypes/tags.ts
+++ b/src/datatypes/tags.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+export default interface Tags {
+    [key: string]: string;
+}

--- a/src/services/dynamodb/autoscaling.ts
+++ b/src/services/dynamodb/autoscaling.ts
@@ -1,0 +1,317 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import * as cloudFormationCalls from '../../aws/cloudformation-calls';
+import * as deployPhaseCommon from '../../common/deploy-phase-common';
+import * as handlebarsUtils from '../../common/handlebars-utils';
+import {normalizeLogicalId} from '../../common/util';
+import Tags from '../../datatypes/tags';
+import * as types from './config-types';
+
+/* tslint:disable:max-classes-per-file */
+
+const enum ScalingTypes {
+    READ,
+    WRITE
+}
+
+const LogicalIdSuffixes = {
+    [ScalingTypes.READ]: 'Read',
+    [ScalingTypes.WRITE]: 'Write'
+};
+
+const enum ScalingTargetTypes {
+    TABLE = 'table',
+    INDEX = 'index'
+}
+
+const ScalingDimensionUnits = {
+    [ScalingTypes.READ]: 'ReadCapacityUnits',
+    [ScalingTypes.WRITE]: 'WriteCapacityUnits'
+};
+
+const ScalingMetricTypes = {
+    [ScalingTypes.READ]: 'DynamoDBReadCapacityUtilization',
+    [ScalingTypes.WRITE]: 'DynamoDBWriteCapacityUtilization'
+};
+
+const DEFAULT_CAPACITY_UNITS = 1;
+const DEFAULT_AUTOSCALING_TARGET_UTILIZATION = 70;
+const VALID_THROUGHPUT_PATTERN = /^(\d+)(?:-(\d+))?$/;
+
+export function deployAutoscaling(mainStackName: string,
+                                  ownServiceContext: types.DynamoDBContext,
+                                  serviceName: string,
+                                  stackTags: Tags): Promise<any> {
+    if (!tableOrIndexesHaveAutoscaling(ownServiceContext)) {
+        return Promise.resolve();
+    }
+    return getCompiledAutoscalingTemplate(mainStackName, ownServiceContext)
+        .then((compiledTemplate: string) => {
+            const stackName = getAutoscalingStackName(ownServiceContext);
+            return deployPhaseCommon.deployCloudFormationStack(
+                stackName, compiledTemplate, [], true, serviceName, stackTags
+            );
+        });
+}
+
+export function undeployAutoscaling(ownServiceContext: types.DynamoDBContext) {
+    const stackName = getAutoscalingStackName(ownServiceContext);
+    return cloudFormationCalls.getStack(stackName).then(result => {
+        if (result) {
+            return cloudFormationCalls.deleteStack(stackName);
+        }
+    });
+}
+
+export function checkProvisionedThroughput(throughput: types.ProvisionedThroughput | undefined, errorPrefix: string) {
+    if (!throughput) {
+        return [];
+    }
+
+    const errors: string[] = [];
+
+    const read = throughput.read_capacity_units;
+    const write = throughput.write_capacity_units;
+    const readTarget = throughput.read_target_utilization;
+    const writeTarget = throughput.write_target_utilization;
+
+    if (read && !VALID_THROUGHPUT_PATTERN.test(String(read))) {
+        errors.push(`'read_capacity_units' must be either a number or a numeric range (ex: 1-100)`);
+    }
+    if (write && !VALID_THROUGHPUT_PATTERN.test(String(write))) {
+        errors.push(`'write_capacity_units' must be either a number or a numeric range (ex: 1-100)`);
+    }
+    if (readTarget && !isValidTargetUtilization(readTarget)) {
+        errors.push(`'read_target_utilization' must be a number between 0 and 100`);
+    }
+    if (writeTarget && !isValidTargetUtilization(writeTarget)) {
+        errors.push(`'write_target_utilization' must be a number between 0 and 100`);
+    }
+
+    return errors.map(it => errorPrefix + it);
+}
+
+export function getThroughputConfig(throughputConfig: types.ProvisionedThroughput | undefined,
+                                    defaultConfig: ThroughputConfig | null): ThroughputConfig {
+    const throughput = throughputConfig || {};
+    const defaults = defaultConfig || {} as ThroughputConfig;
+    const defaultRead = defaults.read || {};
+    const defaultWrite = defaults.write || {};
+
+    const read = assembleThroughputConfig(
+        throughput.read_capacity_units,
+        throughput.read_target_utilization,
+        defaultRead
+    );
+
+    const write = assembleThroughputConfig(
+        throughput.write_capacity_units,
+        throughput.write_target_utilization,
+        defaultWrite
+    );
+
+    return {read, write};
+}
+
+function isValidTargetUtilization(target: number): boolean {
+    return target > 0 && target <= 100;
+}
+
+function tableOrIndexesHaveAutoscaling(ownServiceContext: types.DynamoDBContext): boolean {
+    const params = ownServiceContext.params;
+    if (params.provisioned_throughput) {
+        if (provisionedThroughputHasAutoscaling(params.provisioned_throughput)) {
+            return true;
+        }
+    }
+
+    if (params.global_indexes) {
+        return params.global_indexes
+            .some((idx: any) => provisionedThroughputHasAutoscaling(idx.provisioned_throughput));
+    }
+
+    return false;
+}
+
+function getAutoscalingStackName(ownServiceContext: types.DynamoDBContext) {
+    return deployPhaseCommon.getResourceName(ownServiceContext) + '-autoscaling';
+}
+
+function getCompiledAutoscalingTemplate(tableName: string, ownServiceContext: types.DynamoDBContext): Promise<string> {
+    const serviceParams = ownServiceContext.params;
+
+    const handlebarsParams = {
+        tableName,
+        targets: getScalingTargets(serviceParams, tableName)
+    };
+
+    return handlebarsUtils.compileTemplate(`${__dirname}/dynamodb-autoscaling-template.yml`, handlebarsParams);
+}
+
+function getScalingTargets(serviceParams: types.DynamoDBConfig, tableName: string) {
+    const configs = [];
+
+    const tableThroughput = getThroughputConfig(serviceParams.provisioned_throughput, null);
+
+    configs.push(...extractScalingTargets(tableThroughput, ScalingTargetTypes.TABLE, 'Table', 'table/' + tableName));
+
+    if (serviceParams.global_indexes) {
+        const indexConfigs = serviceParams.global_indexes
+            .map(config => {
+                const throughput = getThroughputConfig(config.provisioned_throughput, tableThroughput);
+                const idxName = config.name;
+                return extractScalingTargets(
+                    throughput,
+                    ScalingTargetTypes.INDEX,
+                    'Index' + normalizeLogicalId(idxName),
+                    'table/' + tableName + '/index/' + idxName
+                );
+            }).reduce((acc, cur) => {
+                return acc.concat(cur);
+            }, []);
+        configs.push(...indexConfigs);
+    }
+
+    configs.forEach((each, idx, array) => {
+        if (idx === 0) {
+            return;
+        }
+        const prev = array[idx - 1];
+        each.dependsOn = prev.logicalIdPrefix;
+    });
+
+    return configs;
+}
+
+interface ThroughputConfig {
+    read: ThroughputCapacity;
+    write: ThroughputCapacity;
+}
+
+function assembleThroughputConfig(capacity: string | number | undefined,
+                                  targetUtilization: number | undefined,
+                                  defaultConfig: ThroughputCapacity): ThroughputCapacity {
+    const result = {} as ThroughputCapacity;
+    if (capacity) {
+        Object.assign(result, parseThroughputCapacity(capacity));
+        result.target = targetUtilization || defaultConfig.target || DEFAULT_AUTOSCALING_TARGET_UTILIZATION;
+    } else {
+        Object.assign(
+            result,
+            {initial: DEFAULT_CAPACITY_UNITS, target: DEFAULT_AUTOSCALING_TARGET_UTILIZATION, scaled: false},
+            defaultConfig
+        );
+    }
+    return result;
+}
+
+function provisionedThroughputHasAutoscaling(provisionedThroughput: types.ProvisionedThroughput): boolean {
+    if (!provisionedThroughput) {
+        return false;
+    }
+    const read = parseThroughputCapacity(provisionedThroughput.read_capacity_units);
+    const write = parseThroughputCapacity(provisionedThroughput.write_capacity_units);
+
+    return read.scaled || write.scaled;
+}
+
+function parseThroughputCapacity(capacity: string | number | undefined): ThroughputCapacity {
+    if (!capacity) {
+        return new ThroughputCapacity(false);
+    }
+    const result = VALID_THROUGHPUT_PATTERN.exec(capacity as string);
+    if (!result) {
+        return new ThroughputCapacity(false, capacity);
+    }
+    const [, min, max] = result;
+    if (!max) {
+        return new ThroughputCapacity(false, capacity);
+    }
+    return new ThroughputCapacity(true, min, min, max);
+}
+
+function extractScalingTargets(throughputConfig: ThroughputConfig,
+                               targetType: ScalingTargetTypes,
+                               logicalIdPrefix: string,
+                               resourceId: string) {
+    const configs = [];
+    if (throughputConfig.read.scaled) {
+        configs.push(
+            getScalingConfig(throughputConfig.read, ScalingTypes.READ, logicalIdPrefix, targetType, resourceId)
+        );
+    }
+    if (throughputConfig.write.scaled) {
+        configs.push(
+            getScalingConfig(throughputConfig.write, ScalingTypes.WRITE, logicalIdPrefix, targetType, resourceId)
+        );
+    }
+    return configs;
+}
+
+function getScalingConfig(config: ThroughputCapacity,
+                          scalingType: ScalingTypes,
+                          logicalIdPrefix: string,
+                          targetType: ScalingTargetTypes,
+                          resourceId: string) {
+    return new AutoscalingDefinition(
+        logicalIdPrefix + LogicalIdSuffixes[scalingType],
+        config.min,
+        config.max,
+        config.target,
+        targetType + ':' + ScalingDimensionUnits[scalingType],
+        ScalingMetricTypes[scalingType],
+        resourceId
+    );
+}
+
+class ThroughputCapacity {
+
+    public target: number;
+
+    public readonly initial: number;
+    public readonly min: number;
+    public readonly max: number;
+
+    constructor(readonly scaled: boolean,
+                initial: number | string = DEFAULT_CAPACITY_UNITS,
+                min: number | string = DEFAULT_CAPACITY_UNITS,
+                max: number | string = DEFAULT_CAPACITY_UNITS) {
+        this.initial = Number(initial);
+        this.min = Number(min);
+        this.max = Number(max);
+    }
+}
+
+class AutoscalingDefinition {
+
+    public dependsOn: string;
+    public readonly min: number;
+    public readonly max: number;
+    public readonly target: number;
+
+    constructor(readonly logicalIdPrefix: string,
+                min: number | string,
+                max: number | string,
+                target: number | string,
+                readonly dimension: string,
+                readonly metric: string,
+                readonly resourceId: string) {
+        this.min = Number(min);
+        this.max = Number(max);
+        this.target = Number(target);
+    }
+}

--- a/src/services/dynamodb/config-types.ts
+++ b/src/services/dynamodb/config-types.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import ServiceConfig from '../../datatypes/service-config';
+import {ServiceContext} from '../../datatypes/service-context';
+import Tags from '../../datatypes/tags';
+
+export type DynamoDBContext = ServiceContext<DynamoDBConfig>;
+
+export interface DynamoDBConfig extends ServiceConfig {
+    partition_key: KeyDefinition;
+    sort_key?: KeyDefinition;
+    provisioned_throughput?: ProvisionedThroughput;
+    stream_view_type?: StreamViewType;
+    local_index_config?: LocalIndexConfig[];
+    global_indexes?: GlobalIndexConfig[];
+    tags?: Tags;
+}
+
+export declare enum StreamViewType {
+    KEYS_ONLY = 'KEYS_ONLY',
+    NEW_IMAGE = 'NEW_IMAGE',
+    OLD_IMAGE = 'OLD_IMAGE',
+    NEW_AND_OLD_IMAGES = 'NEW_AND_OLD_IMAGES'
+}
+
+export interface ProvisionedThroughput {
+    read_capacity_units?: string | number;
+    read_target_utilization?: number;
+    write_capacity_units?: string | number;
+    write_target_utilization?: number;
+}
+
+export interface LocalIndexConfig {
+    name: string;
+    sort_key: KeyDefinition;
+    attributes_to_copy: string[];
+}
+
+export interface GlobalIndexConfig {
+    name: string;
+    partition_key: KeyDefinition;
+    sort_key?: KeyDefinition;
+    attributes_to_copy: string[];
+    provisioned_throughput?: ProvisionedThroughput;
+}
+
+export interface KeyDefinition {
+    name: string;
+    type: KeyDataType;
+}
+
+export declare enum KeyDataType {
+    String = 'String', Number = 'Number'
+}

--- a/src/services/dynamodb/dynamodb-autoscaling-template.yml
+++ b/src/services/dynamodb/dynamodb-autoscaling-template.yml
@@ -38,107 +38,32 @@ Resources:
                   - "dynamodb:UpdateTable"
                 Resource: !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/{{tableName}}"
 
-  {{#if read.scaled}}
-  TableReadCapacityScalableTarget:
+  {{#each targets}}
+  {{logicalIdPrefix}}CapacityScalableTarget:
     Type: "AWS::ApplicationAutoScaling::ScalableTarget"
     Properties:
-      MaxCapacity: {{read.max}}
-      MinCapacity: {{read.min}}
-      ResourceId: "table/{{tableName}}"
+      MaxCapacity: {{max}}
+      MinCapacity: {{min}}
+      ResourceId: "{{resourceId}}"
       RoleARN: !GetAtt ScalingRole.Arn
-      ScalableDimension: dynamodb:table:ReadCapacityUnits
+      ScalableDimension: dynamodb:{{dimension}}
       ServiceNamespace: dynamodb
 
-  TableReadScalingPolicy:
+  {{logicalIdPrefix}}ScalingPolicy:
     Type: "AWS::ApplicationAutoScaling::ScalingPolicy"
+    {{#if dependsOn}}
+    DependsOn:
+      - {{dependsOn}}ScalingPolicy
+    {{/if}}
     Properties:
-      PolicyName: ReadAutoScalingPolicy
+      PolicyName: {{logicalIdPrefix}}AutoScalingPolicy
       PolicyType: TargetTrackingScaling
-      ScalingTargetId: !Ref TableReadCapacityScalableTarget
+      ScalingTargetId: !Ref {{logicalIdPrefix}}CapacityScalableTarget
       TargetTrackingScalingPolicyConfiguration:
-        TargetValue: {{read.target}}
+        TargetValue: {{target}}
         ScaleInCooldown: 60
         ScaleOutCooldown: 60
         PredefinedMetricSpecification:
-          PredefinedMetricType: DynamoDBReadCapacityUtilization
+          PredefinedMetricType: {{metric}}
 
-  {{/if}}
-
-  {{#if write.scaled}}
-  TableWriteCapacityScalableTarget:
-    Type: "AWS::ApplicationAutoScaling::ScalableTarget"
-    Properties:
-      MaxCapacity: {{write.max}}
-      MinCapacity: {{write.min}}
-      ResourceId: "table/{{tableName}}"
-      RoleARN: !GetAtt ScalingRole.Arn
-      ScalableDimension: dynamodb:table:WriteCapacityUnits
-      ServiceNamespace: dynamodb
-
-  TableWriteScalingPolicy:
-    Type: "AWS::ApplicationAutoScaling::ScalingPolicy"
-    Properties:
-      PolicyName: WriteAutoScalingPolicy
-      PolicyType: TargetTrackingScaling
-      ScalingTargetId: !Ref TableWriteCapacityScalableTarget
-      TargetTrackingScalingPolicyConfiguration:
-        TargetValue: {{write.target}}
-        ScaleInCooldown: 60
-        ScaleOutCooldown: 60
-        PredefinedMetricSpecification:
-          PredefinedMetricType: DynamoDBWriteCapacityUtilization
-
-  {{/if}}
-
-  {{#each globalIndexes}}
-  {{#if read.scaled}}
-  Index{{logicalId indexName}}ReadCapacityScalableTarget:
-    Type: "AWS::ApplicationAutoScaling::ScalableTarget"
-    Properties:
-      MaxCapacity: {{read.max}}
-      MinCapacity: {{read.min}}
-      ResourceId: "table/{{../tableName}}/index/{{indexName}}"
-      RoleARN: !GetAtt ScalingRole.Arn
-      ScalableDimension: dynamodb:index:ReadCapacityUnits
-      ServiceNamespace: dynamodb
-
-  Index{{logicalId indexName}}ReadScalingPolicy:
-    Type: "AWS::ApplicationAutoScaling::ScalingPolicy"
-    Properties:
-      PolicyName: ReadAutoScalingPolicy
-      PolicyType: TargetTrackingScaling
-      ScalingTargetId: !Ref Index{{logicalId indexName}}ReadCapacityScalableTarget
-      TargetTrackingScalingPolicyConfiguration:
-        TargetValue: {{read.target}}
-        ScaleInCooldown: 60
-        ScaleOutCooldown: 60
-        PredefinedMetricSpecification:
-          PredefinedMetricType: DynamoDBReadCapacityUtilization
-
-  {{/if}}
-  {{#if write.scaled}}
-  Index{{logicalId indexName}}WriteCapacityScalableTarget:
-    Type: "AWS::ApplicationAutoScaling::ScalableTarget"
-    Properties:
-      MaxCapacity: {{write.max}}
-      MinCapacity: {{write.min}}
-      ResourceId: "table/{{../tableName}}/index/{{indexName}}"
-      RoleARN: !GetAtt ScalingRole.Arn
-      ScalableDimension: dynamodb:index:WriteCapacityUnits
-      ServiceNamespace: dynamodb
-
-  Index{{logicalId indexName}}WriteScalingPolicy:
-    Type: "AWS::ApplicationAutoScaling::ScalingPolicy"
-    Properties:
-      PolicyName: WriteAutoScalingPolicy
-      PolicyType: TargetTrackingScaling
-      ScalingTargetId: !Ref Index{{logicalId indexName}}WriteCapacityScalableTarget
-      TargetTrackingScalingPolicyConfiguration:
-        TargetValue: {{write.target}}
-        ScaleInCooldown: 60
-        ScaleOutCooldown: 60
-        PredefinedMetricSpecification:
-          PredefinedMetricType: DynamoDBWriteCapacityUtilization
-
-  {{/if}}
   {{/each}}

--- a/test/services/dynamodb/dynamodb-test.js
+++ b/test/services/dynamodb/dynamodb-test.js
@@ -337,8 +337,8 @@ describe('dynamodb deployer', function () {
                         let tableParams = templateSpy.firstCall.args[1];
                         let autoscaleParams = templateSpy.lastCall.args[1];
 
-                        expect(tableParams).to.have.property('tableReadCapacityUnits', '1');
-                        expect(tableParams).to.have.property('tableWriteCapacityUnits', '2');
+                        expect(tableParams).to.have.property('tableReadCapacityUnits', 1);
+                        expect(tableParams).to.have.property('tableWriteCapacityUnits', 2);
 
                         expect(autoscaleParams).to.have.property('targets')
                             .with.lengthOf(2);
@@ -347,20 +347,19 @@ describe('dynamodb deployer', function () {
 
                         expect(targets[0], 'table read target').to.include({
                             logicalIdPrefix: 'TableRead',
-                            min: '1',
-                            max: '10',
-                            target: '70',
+                            min: 1,
+                            max: 10,
+                            target: 70,
                             dimension: 'table:ReadCapacityUnits',
                             metric: 'DynamoDBReadCapacityUtilization',
-                            resourceId: 'table/' + fullTableName,
-                            dependsOn: null
+                            resourceId: 'table/' + fullTableName
                         });
 
                         expect(targets[1], 'table write target').to.include({
                             logicalIdPrefix: 'TableWrite',
-                            min: '2',
-                            max: '5',
-                            target: '99',
+                            min: 2,
+                            max: 5,
+                            target: 99,
                             dimension: 'table:WriteCapacityUnits',
                             metric: 'DynamoDBWriteCapacityUtilization',
                             resourceId: 'table/' + fullTableName,
@@ -385,9 +384,9 @@ describe('dynamodb deployer', function () {
                         let autoscaleParams = templateSpy.lastCall.args[1];
 
                         expect(tableParams).to.have.property('globalIndexes').which.has.lengthOf(1);
-                        expect(tableParams.globalIndexes[0]).to.have.property('indexReadCapacityUnits', '1');
-                        expect(tableParams.globalIndexes[0]).to.have.property('indexWriteCapacityUnits', '2');
-                        expect(tableParams).to.have.property('tableWriteCapacityUnits', '2');
+                        expect(tableParams.globalIndexes[0]).to.have.property('indexReadCapacityUnits', 1);
+                        expect(tableParams.globalIndexes[0]).to.have.property('indexWriteCapacityUnits', 2);
+                        expect(tableParams).to.have.property('tableWriteCapacityUnits', 2);
 
                         expect(autoscaleParams).to.have.property('targets')
                             .with.lengthOf(4);
@@ -396,9 +395,9 @@ describe('dynamodb deployer', function () {
 
                         expect(targets[2], 'index read target').to.deep.include({
                             logicalIdPrefix: 'IndexMyglobalRead',
-                            min: '1',
-                            max: '10',
-                            target: '70',
+                            min: 1,
+                            max: 10,
+                            target: 70,
                             dimension: 'index:ReadCapacityUnits',
                             metric: 'DynamoDBReadCapacityUtilization',
                             resourceId: 'table/' + fullTableName + '/index/myglobal',
@@ -407,9 +406,9 @@ describe('dynamodb deployer', function () {
 
                         expect(targets[3], 'index write target').to.deep.include({
                             logicalIdPrefix: 'IndexMyglobalWrite',
-                            min: '2',
-                            max: '5',
-                            target: '99',
+                            min: 2,
+                            max: 5,
+                            target: 99,
                             dimension: 'index:WriteCapacityUnits',
                             metric: 'DynamoDBWriteCapacityUtilization',
                             resourceId: 'table/' + fullTableName + '/index/myglobal',
@@ -433,13 +432,13 @@ describe('dynamodb deployer', function () {
                         let tableParams = templateSpy.firstCall.args[1];
                         let autoscaleParams = templateSpy.lastCall.args[1];
 
-                        expect(tableParams).to.have.property('tableReadCapacityUnits', '3');
-                        expect(tableParams).to.have.property('tableWriteCapacityUnits', '3');
+                        expect(tableParams).to.have.property('tableReadCapacityUnits', 3);
+                        expect(tableParams).to.have.property('tableWriteCapacityUnits', 3);
 
                         expect(tableParams).to.have.property('globalIndexes').which.has.lengthOf(1);
-                        expect(tableParams.globalIndexes[0]).to.have.property('indexReadCapacityUnits', '1');
-                        expect(tableParams.globalIndexes[0]).to.have.property('indexWriteCapacityUnits', '2');
-                        expect(tableParams).to.have.property('tableWriteCapacityUnits', '3');
+                        expect(tableParams.globalIndexes[0]).to.have.property('indexReadCapacityUnits', 1);
+                        expect(tableParams.globalIndexes[0]).to.have.property('indexWriteCapacityUnits', 2);
+                        expect(tableParams).to.have.property('tableWriteCapacityUnits', 3);
 
                         expect(autoscaleParams).to.have.property('targets').which.has.lengthOf(2);
 
@@ -447,20 +446,19 @@ describe('dynamodb deployer', function () {
 
                         expect(targets[0], 'index read target').to.deep.include({
                             logicalIdPrefix: 'IndexMyglobalRead',
-                            min: '1',
-                            max: '10',
-                            target: '70',
+                            min: 1,
+                            max: 10,
+                            target: 70,
                             dimension: 'index:ReadCapacityUnits',
                             metric: 'DynamoDBReadCapacityUtilization',
                             resourceId: 'table/' + fullTableName + '/index/myglobal',
-                            dependsOn: null
                         });
 
                         expect(targets[1], 'index write target').to.deep.include({
                             logicalIdPrefix: 'IndexMyglobalWrite',
-                            min: '2',
-                            max: '5',
-                            target: '99',
+                            min: 2,
+                            max: 5,
+                            target: 99,
                             dimension: 'index:WriteCapacityUnits',
                             metric: 'DynamoDBWriteCapacityUtilization',
                             resourceId: 'table/' + fullTableName + '/index/myglobal',
@@ -491,7 +489,7 @@ describe('dynamodb deployer', function () {
             return dynamodb.unDeploy(serviceContext)
                 .then(unDeployContext => {
                     expect(unDeployContext).to.be.instanceof(UnDeployContext);
-                    expect(unDeployStackStub.calledOnce).to.be.ture;
+                    expect(unDeployStackStub.calledOnce).to.be.true;
                 });
         });
     });


### PR DESCRIPTION
Cloudwatch has very low API Rate Limits. Turns out, it's pretty easy to
hit that limit when setting up lots of application autoscaling rules in
Cloudformation (see https://forum.serverless.com/t/autoscaling-for-amazon-dynamodb/2071). So, by adding a DependsOn to all of our scaling targets,
we can avoid hitting that rate limit by forcing Cloudformation to only
make one call at a time, rather than parallelizing all of them.

In order to make that happen, I've also restructured the autoscaling
template.  It should produce the same output as before, with added
'DependsOn' attributes, but with a lot less duplication in the
Handlebars template itself. Plus, the new structure makes it a LOT
easier to compute the 'DependsOn' values.