### PR TITLE
Fix KMS Key Auto-Rotation Default

### DIFF
--- a/src/services/kms/index.js
+++ b/src/services/kms/index.js
@@ -62,8 +62,10 @@ function getDeployContext(serviceContext, cfStack) {
 function getCompiledTemplate(ownServiceContext) {
     let serviceParams = ownServiceContext.params;
 
+    let autoRotate = serviceParams.hasOwnProperty('auto_rotate') ? !!serviceParams.auto_rotate : true;
+
     let handlebarsParams = {
-        autoRotate: !!serviceParams.auto_rotate,
+        autoRotate: autoRotate,
         alias: serviceParams.alias || getDefaultAlias(ownServiceContext)
     };
 

--- a/test/services/kms/kms-test.js
+++ b/test/services/kms/kms-test.js
@@ -159,6 +159,37 @@ describe('kms deployer', function () {
                 });
         });
 
+
+        it('should set auto_rotate to true if not specified', function () {
+            let alias = `alias/${appName}/${envName}/FakeService`;
+            let aliasArn = 'arn:aws:kms:us-west-2:000000000:' + alias;
+            let deployStackStub = sandbox.stub(deployPhaseCommon, 'deployCloudFormationStack').returns(Promise.resolve({
+                Outputs: [{
+                    OutputKey: 'KeyId',
+                    OutputValue: keyId
+                }, {
+                    OutputKey: 'KeyArn',
+                    OutputValue: keyArn
+                }, {
+                    OutputKey: 'AliasName',
+                    OutputValue: alias
+                }, {
+                    OutputKey: 'AliasArn',
+                    OutputValue: aliasArn
+                }]
+            }));
+
+            let preDeployContext = new PreDeployContext(serviceContext);
+
+            return kms.deploy(serviceContext, preDeployContext, [])
+                .then(deployContext => {
+                    expect(deployStackStub.callCount).to.equal(1);
+
+                    expect(deployStackStub.firstCall.args[1]).to.contain('EnableKeyRotation: true');
+                });
+        });
+
+
     });
 
     describe('unDeploy', function () {


### PR DESCRIPTION
The docs say that auto_rotate defaults to true, but the code has it
default to false. Adds a `hasOwnProperty` check to set the default
properly, as well as tests to check for regressions.