### PR TITLE
Remove legacy injected env var format.

### DIFF
--- a/src/common/deploy-phase-common.js
+++ b/src/common/deploy-phase-common.js
@@ -36,16 +36,10 @@ exports.getInjectedEnvVarName = function (serviceContext, suffix) {
 
 exports.getInjectedEnvVarsFor = function(serviceContext, outputs) {
     return Object.keys(outputs).reduce((obj, name) => {
-        let value = outputs[name];
-        obj[exports.getInjectedEnvVarName(serviceContext, name)] = value;
-        obj[legacyEnvVarName(serviceContext, name)] = value;
+        obj[exports.getInjectedEnvVarName(serviceContext, name)] = outputs[name];
         return obj;
     }, {});
 };
-
-function legacyEnvVarName(serviceContext, name) {
-    return `${serviceContext.serviceType}_${serviceContext.appName}_${serviceContext.environmentName}_${serviceContext.serviceName}_${name}`.toUpperCase().replace(/-/g, "_");
-}
 
 function injectedSsmParamPrefix(serviceContext) {
     return `${serviceContext.appName}.${serviceContext.environmentName}.${serviceContext.serviceName}`;

--- a/test/common/deploy-phase-common-test.js
+++ b/test/common/deploy-phase-common-test.js
@@ -51,11 +51,6 @@ describe('Deploy phase common module', function () {
             let vars = deployPhaseCommon.getInjectedEnvVarsFor(serviceContext, { FOO: 'bar' });
             expect(vars).to.have.property('FAKESERVICE_FOO', 'bar');
         });
-
-        it('should return environment variables with the legacy format', function () {
-            let vars = deployPhaseCommon.getInjectedEnvVarsFor(serviceContext, { FOO: 'bar' });
-            expect(vars).to.have.property('FAKETYPE_FAKEAPP_FAKEENV_FAKESERVICE_FOO', 'bar');
-        });
     });
 
     describe('getSsmParamName', function () {


### PR DESCRIPTION
Now, it's just the DEPENDENCY_NAME_VALUE_NAME format.

We've kept the legacy version around for a while; it's about time we
drop it. This is purely unselfish on my part and has no relation to
the fact that I just hit the 4k limit on total env var length on one of
my lambdas. Nope, definitely not.

Speaking of which, we may want to come up with a strategy for dealing
with the fact that many services have a limit on environment variables.