### PR TITLE
Remove SSH ingress from Fargate security group

### DIFF
--- a/src/services/ecs-fargate/index.js
+++ b/src/services/ecs-fargate/index.js
@@ -113,7 +113,7 @@ exports.check = function(serviceContext, dependenciesServiceContexts) {
 }
 
 exports.preDeploy = function (serviceContext) {
-    return preDeployPhaseCommon.preDeployCreateSecurityGroup(serviceContext, 22, SERVICE_NAME);
+    return preDeployPhaseCommon.preDeployCreateSecurityGroup(serviceContext, null, SERVICE_NAME);
 }
 
 exports.deploy = function(ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {


### PR DESCRIPTION
This change removes the SSH ingress rule from the Fargate security group. You can't access the Fargate EC2 instances, so this rule doesn't make sense to have.