### PR TITLE
Application-level tagging

### DIFF
--- a/docs/handel-basics/handel-file.rst
+++ b/docs/handel-basics/handel-file.rst
@@ -31,6 +31,9 @@ The Handel file is a YAML file that must conform to the following specification:
 
     name: <name of the app being deployed>
 
+    tags:
+      tag-name: value
+
     environments:
       <environment_name>:
         <service_name>:

--- a/docs/handel-basics/tagging.rst
+++ b/docs/handel-basics/tagging.rst
@@ -8,11 +8,32 @@ Most AWS services support the `tagging of resources <https://aws.amazon.com/answ
 * Providing information about teams developing the product such as contact information.
 * Specifying which resources may be automatically shut down or terminated by an external script.
 
-Handel Support for Tagging
---------------------------
-On resources that support it, Handel allows you to specify tags for that resource. It will make the appropriate calls on your behalf to tag the resources it creates with whatever tags you choose to apply.
+AWS services have limits on the total number of tags that may be applied to each service. As of January 2018, most services have a limit of `50 tags <https://aws.amazon.com/blogs/security/now-organize-your-aws-resources-by-using-up-to-50-tags-per-resource/>`_.
 
-AWS services have limits on the total number of tags that may be applied to each service. Generally that limit is currently `50 tags <https://aws.amazon.com/blogs/security/now-organize-your-aws-resources-by-using-up-to-50-tags-per-resource/>`_.
+Application-Level Tags
+----------------------
+
+In your handel.yml file, you can specify tags that apply to all supported resources in the stack, as well as the underlying Cloudformation stacks.  You can specify these tags using a top-level 'tags' object:
+
+.. code-block:: yaml
+
+    version: 1
+
+    name: <name of the app being deployed>
+
+    tags:
+      your-tag: value
+      another-tag: another value
+      technical-owner: Joe Developer <joe_developer@example.com>
+      business-owner: Jill Manager <jill_manager@example.com>
+
+    environments:
+      ...
+
+
+Resource-Level Tags
+-------------------
+On resources that support it, Handel allows you to specify tags for that resource. It will make the appropriate calls on your behalf to tag the resources it creates with whatever tags you choose to apply.
 
 See a service such as :ref:`efs` for an example about how you can apply tags to Handel services.
 

--- a/docs/handel-basics/tagging.rst
+++ b/docs/handel-basics/tagging.rst
@@ -35,6 +35,8 @@ Resource-Level Tags
 -------------------
 On resources that support it, Handel allows you to specify tags for that resource. It will make the appropriate calls on your behalf to tag the resources it creates with whatever tags you choose to apply.
 
+Resource-level tags will override any application-level tags with the same name.
+
 See a service such as :ref:`efs` for an example about how you can apply tags to Handel services.
 
 .. _tagging-default-tags:

--- a/src/common/deploy-phase-common.ts
+++ b/src/common/deploy-phase-common.ts
@@ -192,16 +192,17 @@ export function getResourceName(serviceContext: ServiceContext<ServiceConfig>) {
 }
 
 export function getTags(serviceContext: ServiceContext<ServiceConfig>): Tags {
-    let tags: Tags = {
-        app: serviceContext.appName,
-        env: serviceContext.environmentName
+    const serviceParams = serviceContext.params;
+
+    const handelTags: Tags = {
+             app: serviceContext.appName,
+             env: serviceContext.environmentName
     };
 
-    // Add user-defined tags if specified
-    const serviceParams = serviceContext.params;
-    if (serviceParams.tags) {
-        tags = Object.assign(tags, serviceParams.tags);
-    }
+    const appTags = serviceContext.tags;
 
-    return tags;
+    const serviceTags = serviceParams.tags;
+
+    // Service tags overwrite app tags, which overwrite Handel tags
+    return Object.assign({}, handelTags, appTags, serviceTags);
 }

--- a/src/datatypes/index.ts
+++ b/src/datatypes/index.ts
@@ -42,19 +42,22 @@ export class ServiceContext<Config extends ServiceConfig> {
     public serviceType: string;
     public params: Config;
     public accountConfig: AccountConfig;
+    public tags: Tags;
 
     constructor(appName: string,
                 environmentName: string,
                 serviceName: string,
                 serviceType: string,
                 params: Config,
-                accountConfig: AccountConfig) {
+                accountConfig: AccountConfig,
+                tags: Tags = {}) {
             this.appName = appName;
             this.environmentName = environmentName;
             this.serviceName = serviceName;
             this.serviceType = serviceType;
             this.params = params;
             this.accountConfig = accountConfig;
+            this.tags = tags;
     }
 }
 
@@ -237,6 +240,7 @@ export interface HandelFileParser {
 export interface HandelFile {
     version: number;
     name: string;
+    tags?: Tags;
     environments: HandelFileEnvironments;
 }
 
@@ -256,14 +260,17 @@ export class EnvironmentContext {
     public environmentName: string;
     public serviceContexts: ServiceContexts;
     public accountConfig: AccountConfig;
+    public tags: Tags;
 
     constructor(appName: string,
                 environmentName: string,
-                accountConfig: AccountConfig) {
+                accountConfig: AccountConfig,
+                tags: Tags = {}) {
         this.appName = appName;
         this.environmentName = environmentName;
         this.serviceContexts = {};
         this.accountConfig = accountConfig;
+        this.tags = tags;
     }
 }
 

--- a/src/handelfile/parser-v1.ts
+++ b/src/handelfile/parser-v1.ts
@@ -199,12 +199,12 @@ export function createEnvironmentContext(handelFile: HandelFile, environmentName
         throw new Error(`Can't find the requested environment in the deploy spec: ${environmentName}`);
     }
 
-    const environmentContext = new EnvironmentContext(handelFile.name, environmentName, accountConfig);
+    const environmentContext = new EnvironmentContext(handelFile.name, environmentName, accountConfig, handelFile.tags || {});
 
     _.forEach(environmentSpec, (serviceSpec, serviceName) => {
         const serviceType = serviceSpec.type;
         const serviceContext = new ServiceContext(handelFile.name, environmentName, serviceName,
-            serviceType, serviceSpec, accountConfig);
+            serviceType, serviceSpec, accountConfig, handelFile.tags || {});
         environmentContext.serviceContexts[serviceName] = serviceContext;
     });
 

--- a/src/handelfile/v1-schema.json
+++ b/src/handelfile/v1-schema.json
@@ -18,6 +18,26 @@
                 "maxLength": "The top-level 'name' field may not be greater than 30 characters"
             }
         },
+        "tags": {
+            "type": "object",
+            "patternProperties": {
+                "^[a-zA-Z0-9+\\-=._:\\/@]{1,127}$": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 255,
+                    "errorMessage": {
+                        "type": "Each tag value must be a string",
+                        "minLength": "Tag values must have at least 1 character",
+                        "maxLength": "Tag values may contain a maximum of 255 characters"
+                    }
+                }
+            },
+            "additionalProperties": false,
+            "errorMessage": {
+                "type": "The 'tags' field must be a key-value map",
+                "additionalProperties": "Tag names may contain a maximum of 127 characters, consisting of numbers, letters, and some special characters (+-\\-=._:@/)"
+            }
+        },
         "environments": {
             "type": "object",
             "patternProperties": {

--- a/test/common/deploy-phase-common-test.ts
+++ b/test/common/deploy-phase-common-test.ts
@@ -276,5 +276,51 @@ describe('Deploy phase common module', () => {
             expect(returnTags.env).to.equal('FakeEnv');
             expect(returnTags.mytag).to.equal('myvalue');
         });
+
+        it('should include any application-level tags', () => {
+            serviceContext.tags = {
+                aTag: 'a value'
+            };
+            serviceContext.params = {
+                type: 'faketype',
+                tags: {
+                    mytag: 'myvalue'
+                }
+            };
+
+            const returnTags = deployPhaseCommon.getTags(serviceContext);
+            expect(returnTags.mytag).to.equal('myvalue');
+            expect(returnTags.aTag).to.equal('a value');
+        });
+
+        it('should prefer service tags to application tags', () => {
+            serviceContext.tags = {
+                mytag: 'application'
+            };
+            serviceContext.params = {
+                type: 'faketype',
+                tags: {
+                    mytag: 'service'
+                }
+            };
+
+            const returnTags = deployPhaseCommon.getTags(serviceContext);
+            expect(returnTags.mytag).to.equal('service');
+        });
+
+        it('should prefer Handel tags to service or application tags', () => {
+             serviceContext.tags = {
+                env: 'application'
+            };
+            serviceContext.params = {
+                type: 'faketype',
+                tags: {
+                    env: 'service'
+                }
+            };
+
+            const returnTags = deployPhaseCommon.getTags(serviceContext);
+            expect(returnTags.env).to.equal('service');
+        });
     });
 });


### PR DESCRIPTION
This PR will aim to make it easier to apply tags across all resources in a Handelfile.

For the BYU use case, this makes it easier to have consistent tagging with required tags like 'team' and 'data-sensitivity'.

This gets us part of the way towards solving the issues raised in #332.