### PR TITLE
Add required tags to account config

### DIFF
--- a/docs/handel-basics/account-config-file.rst
+++ b/docs/handel-basics/account-config-file.rst
@@ -58,3 +58,5 @@ The account config file is a YAML file that must contain the following informati
   ssh_bastion_sg: <string> # The ID of the security group you
   elasticache_subnet_group: <string> # The name of the ElastiCache subnet group to use when deploying ElastiCache clusters.
   rds_subnet_group: <string> # The name of the RDS subnet group to use when deploying RDS clusters.
+  required_tags: # Optional. Allows an organization to enforce rules about tagging resources. This is a list of tag names that must be set on each Handel application or resource.
+  - <string>

--- a/docs/handel-basics/handel-file.rst
+++ b/docs/handel-basics/handel-file.rst
@@ -31,6 +31,9 @@ The Handel file is a YAML file that must conform to the following specification:
 
     name: <name of the app being deployed>
 
+    tags:
+      tag-name: value
+
     environments:
       <environment_name>:
         <service_name>:

--- a/docs/handel-basics/tagging.rst
+++ b/docs/handel-basics/tagging.rst
@@ -8,11 +8,34 @@ Most AWS services support the `tagging of resources <https://aws.amazon.com/answ
 * Providing information about teams developing the product such as contact information.
 * Specifying which resources may be automatically shut down or terminated by an external script.
 
-Handel Support for Tagging
---------------------------
+AWS services have limits on the total number of tags that may be applied to each service. As of January 2018, most services have a limit of `50 tags <https://aws.amazon.com/blogs/security/now-organize-your-aws-resources-by-using-up-to-50-tags-per-resource/>`_.
+
+Application-Level Tags
+----------------------
+
+In your handel.yml file, you can specify tags that apply to all supported resources in the stack, as well as the underlying Cloudformation stacks.  You can specify these tags using a top-level 'tags' object:
+
+.. code-block:: yaml
+
+    version: 1
+
+    name: <name of the app being deployed>
+
+    tags:
+      your-tag: value
+      another-tag: another value
+      technical-owner: Joe Developer <joe_developer@example.com>
+      business-owner: Jill Manager <jill_manager@example.com>
+
+    environments:
+      ...
+
+
+Resource-Level Tags
+-------------------
 On resources that support it, Handel allows you to specify tags for that resource. It will make the appropriate calls on your behalf to tag the resources it creates with whatever tags you choose to apply.
 
-AWS services have limits on the total number of tags that may be applied to each service. Generally that limit is currently `50 tags <https://aws.amazon.com/blogs/security/now-organize-your-aws-resources-by-using-up-to-50-tags-per-resource/>`_.
+Resource-level tags will override any application-level tags with the same name.
 
 See a service such as :ref:`efs` for an example about how you can apply tags to Handel services.
 

--- a/docs/handel-basics/tagging.rst
+++ b/docs/handel-basics/tagging.rst
@@ -10,8 +10,10 @@ Most AWS services support the `tagging of resources <https://aws.amazon.com/answ
 
 AWS services have limits on the total number of tags that may be applied to each service. As of January 2018, most services have a limit of `50 tags <https://aws.amazon.com/blogs/security/now-organize-your-aws-resources-by-using-up-to-50-tags-per-resource/>`_.
 
-Application-Level Tags
-----------------------
+.. _tagging-application:
+
+Application Tags
+----------------
 
 In your handel.yml file, you can specify tags that apply to all supported resources in the stack, as well as the underlying Cloudformation stacks.  You can specify these tags using a top-level 'tags' object:
 
@@ -30,14 +32,39 @@ In your handel.yml file, you can specify tags that apply to all supported resour
     environments:
       ...
 
+.. _tagging-resources:
 
-Resource-Level Tags
--------------------
+Resource Tags
+-------------
+
 On resources that support it, Handel allows you to specify tags for that resource. It will make the appropriate calls on your behalf to tag the resources it creates with whatever tags you choose to apply.
 
 Resource-level tags will override any application-level tags with the same name.
 
-See a service such as :ref:`efs` for an example about how you can apply tags to Handel services.
+Resource-level tags are defined by the following schema:
+
+.. code-block:: yaml
+
+    environments:
+      my-service:
+        type: foo-service
+        tags:
+          yourtag: value
+          another-tag: another value
+
+.. _tagging-unsupported-resources:
+
+Tagging Unsupported Resources
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. ATTENTION::
+
+    Some AWS resource types do not support tagging. In these cases, any related, taggable resources will be tagged, as will the Cloudformation stack that Handel uses to provision the resources.
+
+    If AWS adds tagging support to any of these services, the next Handel deploy should result in tags automatically being applied to the resources by Cloudformation.
+
+    Example: ECS does not currently support tagging Task Definitions. Handel will, however, tag any Application Load Balancers that are provisioned to service that ECS configuration, as well as the Cloudformation stack that provisioned them.
+
 
 .. _tagging-default-tags:
 
@@ -49,6 +76,8 @@ In addition to the ones you specify yourself, Handel will automatically apply th
 * *env* - This will contain the value of the *<environment_name>* that your service is a part of.
 
 See :ref:`handel-file-explanation` for a refresher on where these automatically applied values fit in your Handel file.
+
+.. _tagging-requiring-tags:
 
 Requiring Tags
 --------------

--- a/docs/handel-basics/tagging.rst
+++ b/docs/handel-basics/tagging.rst
@@ -49,3 +49,10 @@ In addition to the ones you specify yourself, Handel will automatically apply th
 * *env* - This will contain the value of the *<environment_name>* that your service is a part of.
 
 See :ref:`handel-file-explanation` for a refresher on where these automatically applied values fit in your Handel file.
+
+Requiring Tags
+--------------
+
+Some organizations may wish to enforce a specific resource tagging scheme. For example, in addition to Handel's `app` and `env` tags, they may wish to require that all resource have a `technical-owner` and `business-owner` tag.
+
+Tag requirements can be configured in the :ref:`account-config-file`. If a user attempts to deploy an application that does not define the required tags either at the application level or the resource level, the deployment will fail.

--- a/docs/supported-services/alexaskillkit.rst
+++ b/docs/supported-services/alexaskillkit.rst
@@ -1,8 +1,13 @@
 .. _alexaskillkit:
 
 Alexa Skill Kit
-=================
+===============
 This document contains information about the Alexa Skill kit service supported in Handel. This Handel service provisions a Alexa Skill kit permission, which is used to integrate with Lambda to invoke them.
+
+.. NOTE::
+
+    This service does not currently support resource tagging.
+
 
 Parameters
 ----------

--- a/docs/supported-services/apiaccess.rst
+++ b/docs/supported-services/apiaccess.rst
@@ -12,7 +12,12 @@ This service does not provision any AWS resources, it just serves to add additio
 
     As an example of how you would use this service, you may want to run a Lambda that inspects your EC2 instances to audit them for certain characteristics. You can use this *apiaccess* service to grant that read-only access to EC2 to give you that information. 
     
-    Since this service provides limited read-only access, in the EC2 exammple you would not be able to do things like start instances, create AMIs, etc.
+    Since this service provides limited read-only access, in the EC2 example you would not be able to do things like start instances, create AMIs, etc.
+
+.. NOTE::
+
+    This service does not currently support resource tagging.
+
 
 Parameters
 ----------

--- a/docs/supported-services/apigateway.rst
+++ b/docs/supported-services/apigateway.rst
@@ -52,7 +52,7 @@ Parameters
      - false
      - If true, your Lambdas will be deployed inside your account's VPC.
    * - tags
-     - :ref:`apigateway-tags`
+     - :ref:`tagging-resources`
      - No
      - 
      - Any tags you want to apply to your API Gateway app.
@@ -283,21 +283,6 @@ If you need to use path params with the HTTP passthrough, you can use the *x-htt
     }
 
 The above example shows mapping the "name" path parameter in the API Gateway request to the "person" path parameter in the backend request.
-
-.. _apigateway-tags:
-
-Tags
-~~~~
-The Tags element is defined by the following schema:
-
-.. code-block:: yaml
-
-  tags:
-   <your_tag_name>: <your_tag_value>
-
-.. NOTE::
-
-    Handel automatically applies some tags for you. See :ref:`tagging-default-tags` for information about these tags.
 
 Example Handel File
 -------------------

--- a/docs/supported-services/beanstalk.rst
+++ b/docs/supported-services/beanstalk.rst
@@ -8,8 +8,19 @@ Service Limitations
 -------------------
 
 No WAR support
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 This Handel Beanstalk service does not yet support Java WAR stack types. Support is planned to be added in the near future.
+
+Limited Tagging Support
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. ATTENTION::
+
+  CloudFormation doesn't allow Beanstalk tags to be modified after initial environment creation. Beanstalk just recently added
+  support for updating tags, but CloudFormation doesn't yet support that feature change for Beanstalk.
+
+  Until this support is added, if you try to modify your *tags* element after your environment is created, your CloudFormation stack will fail to update.
+
 
 Parameters
 ----------
@@ -73,7 +84,7 @@ Parameters
      - 
      - Any user-specified environment variables to inject in the application.
    * - tags
-     - :ref:`beanstalk-tags`
+     - :ref:`tagging-resources`
      - No
      - 
      - Any tags you want to apply to your Beanstalk environment
@@ -161,29 +172,6 @@ The Routing element is defined by the following schema:
        - <string> # Optional
 
 The `dns_names` section creates one or more dns names that point to this load balancer. See :ref:`route53zone-records` for more.
-
-.. _beanstalk-tags:
-
-Tags
-~~~~
-The Tags element is defined by the following schema:
-
-.. code-block:: yaml
-
-  tags:
-   <your_tag_name>: <your_tag_value>
-
-
-.. ATTENTION::
-
-  CloudFormation doesn't allow Beanstalk tags to be modified after initial environment creation. Beanstalk just recently added
-  support for updating tags, but CloudFormation doesn't yet support that feature change for Beanstalk.
-
-  Until this support is added, if you try to modify your *tags* element after your environment is created, your CloudFormation stack will fail to update.
-
-.. NOTE::
-
-    Handel automatically applies some tags for you. See :ref:`tagging-default-tags` for information about these tags.
 
 .. _beanstalk-example-handel-files:
 

--- a/docs/supported-services/cloudwatchevents.rst
+++ b/docs/supported-services/cloudwatchevents.rst
@@ -4,6 +4,11 @@ CloudWatch Events
 =================
 This document contains information about the CloudWatch Events service supported in Handel. This Handel service provisions a CloudWatch Events rule, which can then be integrated with services like Lambda to invoke them when events fire.
 
+.. IMPORTANT::
+
+    This service only offers limited tagging support. Cloudwatch events will not be tagged, but the Cloudformation stack used to create them will be. See :ref:`tagging-unsupported-resources`.
+
+
 Parameters
 ----------
 
@@ -40,6 +45,11 @@ Parameters
      - No
      - enabled
      - What state the rule should be in. Allowed values: 'enabled', 'disabled'
+   * - tags
+     - :ref:`tagging-resources`
+     - No
+     -
+     - Tags to be applied to the Cloudformation stack which provisions this resource.
 
 Example Handel Files
 --------------------

--- a/docs/supported-services/dynamodb.rst
+++ b/docs/supported-services/dynamodb.rst
@@ -58,7 +58,7 @@ Parameters
      -
      - You can configure `global secondary indexes <http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GSI.html>`_ for fast queries on other partition and sort keys in addition to the ones on your table.
    * - tags
-     - :ref:`dynamodb-tags`
+     - :ref:`tagging-resources`
      - No
      - 
      - Any tags you want to apply to your Dynamo Table
@@ -164,21 +164,6 @@ throughput is not configured for the index, the table's configuration will be us
 .. WARNING::
 
     Be aware that using Global Secondary Indexes can greatly increase your cost. When you use global indexes, you are effectively creating a new table. This will increase your cost by the amount required for storage and allocated IOPS for the global index.
-
-.. _dynamodb-tags:
-
-Tags
-~~~~
-The Tags element is defined by the following schema:
-
-.. code-block:: yaml
-
-  tags:
-   <your_tag_name>: <your_tag_value>
-
-.. NOTE::
-
-    Handel automatically applies some tags for you. See :ref:`tagging-default-tags` for information about these tags.
 
 Example Handel File
 -------------------

--- a/docs/supported-services/ecs-fargate.rst
+++ b/docs/supported-services/ecs-fargate.rst
@@ -22,6 +22,11 @@ This service currently does not support the following ECS task features:
 * Extra networking items such as manually specifying DNS Servers, DNS Search Domains, and extra hosts in the /etc/hosts file
 * Task definition options such as specifying an entry point, command, or working directory. These options are available in your Dockerfile and can be specified there.
 
+.. IMPORTANT::
+
+    This service only offers limited tagging support. ECS resources will not be tagged, but any load balancers and the Cloudformation stack used to create them will be. See :ref:`tagging-unsupported-resources`.
+
+
 Parameters
 ----------
 .. list-table::
@@ -68,7 +73,7 @@ Parameters
      - 30
      - Configures the log retention duration for CloudWatch logs.
    * - tags
-     - :ref:`ecs-fargate-tags`
+     - :ref:`tagging-resources`
      - No
      - 
      - This section allows you to specify any tags you wish to apply to your ECS service.
@@ -181,21 +186,6 @@ The `load_balancer` section is defined by the following schema:
        - <string> # Optional.
 
 The `dns_names` section creates one or more dns names that point to this load balancer. See :ref:`route53zone-records` for more.
-
-.. _ecs-fargate-tags:
-
-Tags
-~~~~
-The `tags` section is defined by the following schema:
-
-.. code-block:: yaml
-
-  tags:
-   <your_tag_name>: <your_tag_value>
-
-.. NOTE::
-
-    Handel automatically applies some tags for you. See :ref:`tagging-default-tags` for information about these tags.
 
 .. _ecs-fargate-logging:
 

--- a/docs/supported-services/ecs.rst
+++ b/docs/supported-services/ecs.rst
@@ -18,6 +18,10 @@ This service currently does not support the following ECS task features:
 * Extra networking items such as manually specifying DNS Servers, DNS Search Domains, and extra hosts in the /etc/hosts file
 * Task definition options such as specifying an entry point, command, or working directory. These options are available in your Dockerfile and can be specified there.
 
+.. IMPORTANT::
+
+    This service only offers limited tagging support. ECS resources will not be tagged, but any load balancers, EC2 instances, and the Cloudformation stack used to create them will be. See :ref:`tagging-unsupported-resources`.
+
 Parameters
 ----------
 .. list-table::
@@ -64,7 +68,7 @@ Parameters
      - 0
      - Configures the log retention duration for CloudWatch logs. If set to `0`, logs are kept indefinitely.
    * - tags
-     - :ref:`ecs-tags`
+     - :ref:`tagging-resources`
      - No
      - 
      - This section allows you to specify any tags you wish to apply to your ECS service.
@@ -191,21 +195,6 @@ The `load_balancer` section is defined by the following schema:
        - <string> # Optional.
 
 The `dns_names` section creates one or more dns names that point to this load balancer. See :ref:`route53zone-records` for more.
-
-.. _ecs-tags:
-
-Tags
-~~~~
-The `tags` section is defined by the following schema:
-
-.. code-block:: yaml
-
-  tags:
-   <your_tag_name>: <your_tag_value>
-
-.. NOTE::
-
-    Handel automatically applies some tags for you. See :ref:`tagging-default-tags` for information about these tags.
 
 .. _ecs-logging:
 

--- a/docs/supported-services/efs.rst
+++ b/docs/supported-services/efs.rst
@@ -32,25 +32,10 @@ Parameters
      - general_purpose
      - What kind of performance for the EFS mount. Allowed values: general_purpose, max_io
    * - tags
-     - :ref:`efs-tags`
+     - :ref:`tagging-resources`
      - No
      - 
      - Any tags you wish to apply to this EFS mount.
-
-.. _efs-tags:
-
-Tags
-~~~~
-The Tags element is defined by the following schema:
-
-.. code-block:: yaml
-
-  tags:
-   <your_tag_name>: <your_tag_value>
-
-.. NOTE::
-
-    Handel automatically applies some tags for you. See :ref:`tagging-default-tags` for information about these tags.
 
 Example Handel File
 -------------------

--- a/docs/supported-services/iot.rst
+++ b/docs/supported-services/iot.rst
@@ -12,6 +12,11 @@ This Handel service is quite new, and as such doesn't support all of IoT yet. In
 * Creating IoT Certificates.
 * Creating IoT Policies.
 
+.. IMPORTANT::
+
+    This service only offers limited tagging support. IoT resources will not be tagged, but the Cloudformation stack used to create them will be. See :ref:`tagging-unsupported-resources`.
+
+
 Parameters
 ----------
 .. list-table:: 
@@ -32,6 +37,11 @@ Parameters
      - No
      - AWS IoT rule created by Handel
      - The description you would like to be applied to the IoT rule.
+   * - tags
+     - :ref:`tagging-resources`
+     - No
+     -
+     - Tags to be applied to the Cloudformation stack which provisions this resource.
 
 Example Handel File
 -------------------

--- a/docs/supported-services/kms.rst
+++ b/docs/supported-services/kms.rst
@@ -12,6 +12,11 @@ access to the key, as key policies can easily make keys unmanageable.
 While the AWS API allows for multiple aliases to point to a single key, this service matches the AWS Console in enforcing
 a one-to-one relationship between keys.
 
+.. IMPORTANT::
+
+    This service only offers limited tagging support. KMS Keys will not be tagged, but the Cloudformation stack used to create them will be. See :ref:`tagging-unsupported-resources`.
+
+
 Parameters
 ----------
 This service takes the following parameters:
@@ -39,6 +44,11 @@ This service takes the following parameters:
      - No
      - true
      - Whether to allow AWS to auto-rotate the underlying Master Key.
+   * - tags
+     - :ref:`tagging-resources`
+     - No
+     -
+     - Tags to be applied to the Cloudformation stack which provisions this resource.
 
 Example Handel File
 -------------------

--- a/docs/supported-services/lambda.rst
+++ b/docs/supported-services/lambda.rst
@@ -66,7 +66,7 @@ Parameters
      - 
      - Any environment variables you want to inject into your code.
    * - tags
-     - :ref:`lambda-tags`
+     - :ref:`tagging-resources`
      - No
      - 
      - Any tags you want to apply to your Lambda
@@ -83,21 +83,6 @@ The EnvironmentVariables element is defined by the following schema:
       <YOUR_ENV_NAME>: <your_env_value>
 
 <YOUR_ENV_NAME> is a string that will be the name of the injected environment variable. <your_env_value> is its value. You may specify an arbitrary number of environment variables in this section.
-
-.. _lambda-tags:
-
-Tags
-~~~~
-The Tags element is defined by the following schema:
-
-.. code-block:: yaml
-
-  tags:
-   <your_tag_name>: <your_tag_value>
-
-.. NOTE::
-
-    Handel automatically applies some tags for you. See :ref:`tagging-default-tags` for information about these tags.
 
 Example Handel File
 -------------------

--- a/docs/supported-services/memcached.rst
+++ b/docs/supported-services/memcached.rst
@@ -60,7 +60,7 @@ Parameters
      - 
      - Any cache parameters you wish for your Memcached cluster. See `Memcached Specific Parameters <http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ParameterGroups.Memcached.html>`_ for the list of parameters you can provide.
    * - tags
-     - :ref:`memcached-tags`
+     - :ref:`tagging-resources`
      - No
      - 
      - Any tags you wish to apply to this Memcached cluster.
@@ -74,22 +74,6 @@ Parameters
     If you have that same cache.m4.large type, but with a cluster size of 4, it will cost about $448/month since you are being charged for four full Memcached instances.
 
     **Be careful to calculate how much this service will cost you if you are using a cluster of more than 1 node.**
-
-.. _memcached-tags:
-
-Tags
-~~~~
-The Tags element is defined by the following schema:
-
-.. code-block:: yaml
-
-  tags:
-   <your_tag_name>: <your_tag_value>
-
-.. NOTE::
-
-    Handel automatically applies some tags for you. See :ref:`tagging-default-tags` for information about these tags.
-
 
 Example Handel File
 -------------------

--- a/docs/supported-services/mysql.rst
+++ b/docs/supported-services/mysql.rst
@@ -75,7 +75,7 @@ Parameters
      - 
      - A list of key/value MySQL parameter group pairs to configure your database. You will need to look in the AWS Console to see the list of available parameters for MySQL.
    * - tags
-     - :ref:`mysql-tags`
+     - :ref:`tagging-resources`
      - No
      - 
      - Any tags you wish to apply to this MySQL instance.
@@ -85,22 +85,6 @@ Parameters
     Be aware that large database instances are very expensive. The *db.cr1.8xl* instance type, for example, costs about $3,400/month. Make sure you check how much you will be paying!
 
     You can use the excellent `EC2Instances.info <http://www.ec2instances.info/rds/>`_ site to easily see pricing information for RDS databases.
-
-
-.. _mysql-tags:
-
-Tags
-~~~~
-The Tags element is defined by the following schema:
-
-.. code-block:: yaml
-
-  tags:
-   <your_tag_name>: <your_tag_value>
-
-.. NOTE::
-
-    Handel automatically applies some tags for you. See :ref:`tagging-default-tags` for information about these tags.
 
 
 Example Handel File

--- a/docs/supported-services/postgresql.rst
+++ b/docs/supported-services/postgresql.rst
@@ -75,7 +75,7 @@ Parameters
      - 
      - A list of key/value PostgreSQL parameter group pairs to configure your database. You will need to look in the AWS Console to see the list of available parameters for PostgreSQL.
    * - tags
-     - :ref:`postgresql-tags`
+     - :ref:`tagging-resources`
      - No
      - 
      - Any tags you wish to apply to this PostgreSQL instance.
@@ -85,22 +85,6 @@ Parameters
     Be aware that large database instances are very expensive. The *db.cr1.8xl* instance type, for example, costs about $3,400/month. Make sure you check how much you will be paying!
 
     You can use the excellent `EC2Instances.info <http://www.ec2instances.info/rds/>`_ site to easily see pricing information for RDS databases.
-
-.. _postgresql-tags:
-
-Tags
-~~~~
-The Tags element is defined by the following schema:
-
-.. code-block:: yaml
-
-  tags:
-   <your_tag_name>: <your_tag_value>
-
-.. NOTE::
-
-    Handel automatically applies some tags for you. See :ref:`tagging-default-tags` for information about these tags.
-
 
 Example Handel File
 -------------------

--- a/docs/supported-services/redis.rst
+++ b/docs/supported-services/redis.rst
@@ -66,7 +66,7 @@ Parameters
      - 
      - Any cache parameters you wish for your Redis cluster. See `Redis Specific Parameters <http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ParameterGroups.Redis.html>`_ for the list of parameters you can provide.
    * - tags
-     - :ref:`redis-tags`
+     - :ref:`tagging-resources`
      - No
      - 
      - Any tags you wish to apply to this Redis cluster.
@@ -80,22 +80,6 @@ Parameters
     If you have that same cache.m4.large type, but with 1 read replica, it will cost you double at about $224/month since you are being charged for two full Redis instances.
 
     Taken to its extreme, a cache.m4.large with 5 read replicas will cost about $673/month. **Be careful to calculate how much this service will cost you if you are using read replicas**
-
-.. _redis-tags:
-
-Tags
-~~~~
-The Tags element is defined by the following schema:
-
-.. code-block:: yaml
-
-  tags:
-   <your_tag_name>: <your_tag_value>
-
-.. NOTE::
-
-    Handel automatically applies some tags for you. See :ref:`tagging-default-tags` for information about these tags.
-
 
 Example Handel File
 -------------------

--- a/docs/supported-services/route53zone.rst
+++ b/docs/supported-services/route53zone.rst
@@ -42,25 +42,10 @@ Parameters
      - false
      - Whether or not this is a private zone. If it is a private zone, it is only accessible by the VPC in your account config file.
    * - tags
-     - :ref:`route53zone-tags`
+     - :ref:`tagging-resources`
      - No
      -
      - Any tags you want to apply to your Hosted Zone
-
-.. _route53zone-tags:
-
-Tags
-~~~~
-The Tags element is defined by the following schema:
-
-.. code-block:: yaml
-
-  tags:
-   <your_tag_name>: <your_tag_value>
-
-.. NOTE::
-
-    Handel automatically applies some tags for you. See :ref:`tagging-default-tags` for information about these tags.
 
 Example Handel File
 -------------------

--- a/docs/supported-services/s3.rst
+++ b/docs/supported-services/s3.rst
@@ -59,7 +59,7 @@ This service takes the following parameters:
      - 
      - Lifecycle Policies to apply to the bucket. See `AWS Docs for more info <http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-lifecycleconfig-rule.html>`_
    * - tags
-     - :ref:`s3-tags`
+     - :ref:`tagging-resources`
      - No
      -
      - Any tags you want to apply to your S3 bucket
@@ -127,21 +127,6 @@ More complex example:
               days: 30
             - type: expiration
               days: 90
-
-.. _s3-tags:
-
-Tags
-~~~~
-The Tags element is defined by the following schema:
-
-.. code-block:: yaml
-
-  tags:
-   <your_tag_name>: <your_tag_value>
-
-.. NOTE::
-
-    Handel automatically applies some tags for you. See :ref:`tagging-default-tags` for information about these tags.
 
 Example Handel File
 -------------------

--- a/docs/supported-services/s3staticsite.rst
+++ b/docs/supported-services/s3staticsite.rst
@@ -69,7 +69,7 @@ This service takes the following parameters:
      -
      - Configuration for CloudFront. If not specified, CloudFront is not enabled.
    * - tags
-     - :ref:`s3staticsite-tags`
+     - :ref:`tagging-resources`
      - No
      -
      - Any tags you want to apply to your S3 bucket
@@ -163,21 +163,6 @@ is equivalent to:
 .. code-block:: yaml
 
     cloudfront_max_ttl: 172800
-
-.. _s3staticsite-tags:
-
-Tags
-~~~~
-The Tags element is defined by the following schema:
-
-.. code-block:: yaml
-
-  tags:
-   <your_tag_name>: <your_tag_value>
-
-.. NOTE::
-
-    Handel automatically applies some tags for you. See :ref:`tagging-default-tags` for information about these tags.
 
 Example Handel File
 -------------------

--- a/docs/supported-services/ses.rst
+++ b/docs/supported-services/ses.rst
@@ -1,8 +1,13 @@
 .. _ses:
 
 SES (Simple Email Service)
-=================================
+==========================
 This document contains information about the SES service supported in Handel. This Handel service verifies an email address for use by your applications.
+
+.. NOTE::
+
+    This service does not currently support resource tagging.
+
 
 Parameters
 ----------

--- a/docs/supported-services/sns.rst
+++ b/docs/supported-services/sns.rst
@@ -4,6 +4,14 @@ SNS (Simple Notification Service)
 =================================
 This document contains information about the SNS service supported in Handel. This Handel service provisions an SNS topic for use by your applications.
 
+Service Limitations
+-------------------
+
+.. IMPORTANT::
+
+    This service only offers limited tagging support. SNS Topics will not be tagged, but the Cloudformation stack used to create them will be. See :ref:`tagging-unsupported-resources`.
+
+
 Parameters
 ----------
 .. list-table::
@@ -24,6 +32,11 @@ Parameters
      - No
      -
      - An optional list of statically-defined subscriptions. You can also dynamically add subscriptions in your application code.
+   * - tags
+     - :ref:`tagging-resources`
+     - No
+     -
+     - Tags to be applied to the Cloudformation stack which provisions this resource.
 
 .. _sns-subscriptions:
 

--- a/docs/supported-services/sqs.rst
+++ b/docs/supported-services/sqs.rst
@@ -4,6 +4,14 @@ SQS (Simple Queue Service)
 ==========================
 This document contains information about the SQS service supported in Handel. This Handel service provisions an SQS queue for use by your applications.
 
+Service Limitations
+-------------------
+
+.. IMPORTANT::
+
+    This service only offers limited tagging support. SNS Topics will not be tagged, but the Cloudformation stack used to create them will be. See :ref:`tagging-unsupported-resources`.
+
+
 Parameters
 ----------
 
@@ -60,6 +68,11 @@ Parameters
      - No
      -
      - If present, indicates that the queue will use a `Dead-Letter Queue <http://http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html>`_.
+   * - tags
+     - :ref:`tagging-resources`
+     - No
+     -
+     - Tags to be applied to the Cloudformation stack which provisions this resource.
 
 
 .. _sqs-dead-letter:

--- a/src/common/deploy-phase-common.ts
+++ b/src/common/deploy-phase-common.ts
@@ -21,7 +21,14 @@ import * as cloudformationCalls from '../aws/cloudformation-calls';
 import * as iamCalls from '../aws/iam-calls';
 import * as s3Calls from '../aws/s3-calls';
 import * as util from '../common/util';
-import { AccountConfig, DeployContext, EnvironmentVariables, ServiceConfig, ServiceContext, Tags } from '../datatypes/index';
+import {
+    AccountConfig,
+    DeployContext,
+    EnvironmentVariables,
+    ServiceConfig,
+    ServiceContext,
+    Tags
+} from '../datatypes';
 
 /**
  * Given a ServiceContext and suffix, return the env var name used for environment variables naming
@@ -189,20 +196,4 @@ export function getAppSecretsAccessPolicyStatements(serviceContext: ServiceConte
 
 export function getResourceName(serviceContext: ServiceContext<ServiceConfig>) {
     return `${serviceContext.appName}-${serviceContext.environmentName}-${serviceContext.serviceName}-${serviceContext.serviceType}`;
-}
-
-export function getTags(serviceContext: ServiceContext<ServiceConfig>): Tags {
-    const serviceParams = serviceContext.params;
-
-    const handelTags: Tags = {
-             app: serviceContext.appName,
-             env: serviceContext.environmentName
-    };
-
-    const appTags = serviceContext.tags;
-
-    const serviceTags = serviceParams.tags;
-
-    // Service tags overwrite app tags, which overwrite Handel tags
-    return Object.assign({}, handelTags, appTags, serviceTags);
 }

--- a/src/common/deploy-phase-common.ts
+++ b/src/common/deploy-phase-common.ts
@@ -192,16 +192,17 @@ export function getResourceName(serviceContext: ServiceContext<ServiceConfig>) {
 }
 
 export function getTags(serviceContext: ServiceContext<ServiceConfig>): Tags {
-    let tags: Tags = {
-        app: serviceContext.appName,
-        env: serviceContext.environmentName
+    const serviceParams = serviceContext.params;
+
+    const handelTags: Tags = {
+             app: serviceContext.appName,
+             env: serviceContext.environmentName
     };
 
-    // Add user-defined tags if specified
-    const serviceParams = serviceContext.params;
-    if (serviceParams.tags) {
-        tags = Object.assign(tags, serviceParams.tags);
-    }
+    const appTags = serviceContext.tags;
 
-    return tags;
+    const serviceTags = serviceParams.tags;
+
+    // Service tags overwrite app tags, which overwrite Handel tags
+    return Object.assign({}, handelTags, appTags, serviceTags);
 }

--- a/src/common/tagging-common.ts
+++ b/src/common/tagging-common.ts
@@ -1,0 +1,17 @@
+import {ServiceConfig, ServiceContext, Tags} from '../datatypes';
+
+export function getTags(serviceContext: ServiceContext<ServiceConfig>): Tags {
+    const serviceParams = serviceContext.params;
+
+    const handelTags: Tags = {
+        app: serviceContext.appName,
+        env: serviceContext.environmentName
+    };
+
+    const appTags = serviceContext.tags;
+
+    const serviceTags = serviceParams.tags;
+
+    // Service tags overwrite app tags, which overwrite Handel tags
+    return Object.assign({}, handelTags, appTags, serviceTags);
+}

--- a/src/datatypes/index.ts
+++ b/src/datatypes/index.ts
@@ -30,6 +30,9 @@ export interface AccountConfig {
     elasticache_subnet_group: string;
     rds_subnet_group: string;
     redshift_subnet_group: string;
+    required_tags?: string[];
+    // Allow for account config extensions. Allows future plugins to have their own account-level settings.
+    [key: string]: any;
 }
 
 /***********************************

--- a/src/datatypes/index.ts
+++ b/src/datatypes/index.ts
@@ -42,19 +42,22 @@ export class ServiceContext<Config extends ServiceConfig> {
     public serviceType: string;
     public params: Config;
     public accountConfig: AccountConfig;
+    public tags: Tags;
 
     constructor(appName: string,
                 environmentName: string,
                 serviceName: string,
                 serviceType: string,
                 params: Config,
-                accountConfig: AccountConfig) {
+                accountConfig: AccountConfig,
+                tags: Tags = {}) {
             this.appName = appName;
             this.environmentName = environmentName;
             this.serviceName = serviceName;
             this.serviceType = serviceType;
             this.params = params;
             this.accountConfig = accountConfig;
+            this.tags = tags;
     }
 }
 
@@ -237,6 +240,7 @@ export interface HandelFileParser {
 export interface HandelFile {
     version: number;
     name: string;
+    tags?: Tags;
     environments: HandelFileEnvironments;
 }
 
@@ -256,14 +260,17 @@ export class EnvironmentContext {
     public environmentName: string;
     public serviceContexts: ServiceContexts;
     public accountConfig: AccountConfig;
+    public tags: Tags;
 
     constructor(appName: string,
                 environmentName: string,
-                accountConfig: AccountConfig) {
+                accountConfig: AccountConfig,
+                tags: Tags = {}) {
         this.appName = appName;
         this.environmentName = environmentName;
         this.serviceContexts = {};
         this.accountConfig = accountConfig;
+        this.tags = tags;
     }
 }
 

--- a/src/datatypes/index.ts
+++ b/src/datatypes/index.ts
@@ -214,6 +214,14 @@ export interface ServiceDeployer {
     producedEventsSupportedServices: string[];
     producedDeployOutputTypes: string[];
     consumedDeployOutputTypes: string[];
+    /**
+     * If true, indicates that a deployer supports tagging its resources. This is used to enforce tagging rules.
+     *
+     * If not specified, 'true' is assumed, effectively making tagging enforcement opt-out.
+     *
+     * If the deployer deploys anything to Cloudformation, it should declare that it supports tagging.
+     */
+    supportsTagging: boolean;
     check?(serviceContext: ServiceContext<ServiceConfig>, dependenciesServiceContexts: Array<ServiceContext<ServiceConfig>>): string[];
     preDeploy?(serviceContext: ServiceContext<ServiceConfig>): Promise<PreDeployContext>;
     bind?(ownServiceContext: ServiceContext<ServiceConfig>, ownPreDeployContext: PreDeployContext, dependentOfServiceContext: ServiceContext<ServiceConfig>, dependentOfPreDeployContext: PreDeployContext): Promise<BindContext>;

--- a/src/handelfile/parser-v1.ts
+++ b/src/handelfile/parser-v1.ts
@@ -199,12 +199,12 @@ export function createEnvironmentContext(handelFile: HandelFile, environmentName
         throw new Error(`Can't find the requested environment in the deploy spec: ${environmentName}`);
     }
 
-    const environmentContext = new EnvironmentContext(handelFile.name, environmentName, accountConfig);
+    const environmentContext = new EnvironmentContext(handelFile.name, environmentName, accountConfig, handelFile.tags || {});
 
     _.forEach(environmentSpec, (serviceSpec, serviceName) => {
         const serviceType = serviceSpec.type;
         const serviceContext = new ServiceContext(handelFile.name, environmentName, serviceName,
-            serviceType, serviceSpec, accountConfig);
+            serviceType, serviceSpec, accountConfig, handelFile.tags || {});
         environmentContext.serviceContexts[serviceName] = serviceContext;
     });
 

--- a/src/handelfile/v1-schema.json
+++ b/src/handelfile/v1-schema.json
@@ -18,6 +18,26 @@
                 "maxLength": "The top-level 'name' field may not be greater than 30 characters"
             }
         },
+        "tags": {
+            "type": "object",
+            "patternProperties": {
+                "^[a-zA-Z0-9+\\-=._:\\/@]{1,127}$": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 255,
+                    "errorMessage": {
+                        "type": "Each tag value must be a string",
+                        "minLength": "Tag values must have at least 1 character",
+                        "maxLength": "Tag values may contain a maximum of 255 characters"
+                    }
+                }
+            },
+            "additionalProperties": false,
+            "errorMessage": {
+                "type": "The 'tags' field must be a key-value map",
+                "additionalProperties": "Tag names may contain a maximum of 127 characters, consisting of numbers, letters, and some special characters (+-\\-=._:@/)"
+            }
+        },
         "environments": {
             "type": "object",
             "patternProperties": {

--- a/src/services/alexaskillkit/index.ts
+++ b/src/services/alexaskillkit/index.ts
@@ -52,3 +52,5 @@ export const producedEventsSupportedServices = [
 export const producedDeployOutputTypes = [];
 
 export const consumedDeployOutputTypes = [];
+
+export const supportsTagging = false;

--- a/src/services/apiaccess/index.ts
+++ b/src/services/apiaccess/index.ts
@@ -77,3 +77,5 @@ export const producedDeployOutputTypes = [
 ];
 
 export const consumedDeployOutputTypes = [];
+
+export const supportsTagging = true;

--- a/src/services/apiaccess/index.ts
+++ b/src/services/apiaccess/index.ts
@@ -78,4 +78,4 @@ export const producedDeployOutputTypes = [
 
 export const consumedDeployOutputTypes = [];
 
-export const supportsTagging = true;
+export const supportsTagging = false;

--- a/src/services/apigateway/index.ts
+++ b/src/services/apigateway/index.ts
@@ -88,3 +88,5 @@ export const consumedDeployOutputTypes = [
     'policies',
     'securityGroups'
 ];
+
+export const supportsTagging = true;

--- a/src/services/apigateway/swagger/swagger-deploy-type.ts
+++ b/src/services/apigateway/swagger/swagger-deploy-type.ts
@@ -21,10 +21,11 @@ import * as uuid from 'uuid';
 import * as winston from 'winston';
 import * as deployPhaseCommon from '../../../common/deploy-phase-common';
 import * as handlebarsUtils from '../../../common/handlebars-utils';
+import {getTags} from '../../../common/tagging-common';
 import * as util from '../../../common/util';
-import { AccountConfig, DeployContext, PreDeployContext, ServiceConfig, ServiceContext, Tags } from '../../../datatypes';
+import {AccountConfig, DeployContext, PreDeployContext, ServiceConfig, ServiceContext, Tags} from '../../../datatypes';
 import * as apigatewayCommon from '../common';
-import { APIGatewayConfig } from '../config-types';
+import {APIGatewayConfig} from '../config-types';
 
 const VALID_METHOD_NAMES = [
     'get',
@@ -244,7 +245,7 @@ export function check(ownServiceContext: ServiceContext<APIGatewayConfig>, depen
 export async function deploy(stackName: string, ownServiceContext: ServiceContext<APIGatewayConfig>, ownPreDeployContext: PreDeployContext, dependenciesDeployContexts: DeployContext[], serviceName: string) {
     const swagger = loadSwaggerFile(ownServiceContext);
     let lambdasToCreate = getLambdasToCreate(stackName, swagger, ownServiceContext, dependenciesDeployContexts);
-    const stackTags = deployPhaseCommon.getTags(ownServiceContext);
+    const stackTags = getTags(ownServiceContext);
     const enrichedSwagger = enrichSwagger(stackName, swagger, ownServiceContext.accountConfig);
 
     lambdasToCreate = await uploadDeployableArtifactsToS3(ownServiceContext, lambdasToCreate, serviceName, enrichedSwagger);

--- a/src/services/beanstalk/index.ts
+++ b/src/services/beanstalk/index.ts
@@ -21,9 +21,27 @@ import * as deletePhasesCommon from '../../common/delete-phases-common';
 import * as deployPhaseCommon from '../../common/deploy-phase-common';
 import * as handlebarsUtils from '../../common/handlebars-utils';
 import * as preDeployPhaseCommon from '../../common/pre-deploy-phase-common';
+import {getTags} from '../../common/tagging-common';
 import * as util from '../../common/util';
-import { DeployContext, EnvironmentVariables, PreDeployContext, ServiceConfig, ServiceContext, UnDeployContext, UnPreDeployContext } from '../../datatypes';
-import { BeanstalkScalingPolicyAlarmDimensions, BeanstalkServiceConfig, EbextensionsToInject, HandlebarsBeanstalkAutoScalingDimension, HandlebarsBeanstalkAutoScalingTemplate, HandlebarsBeanstalkOptionSetting, HandlebarsBeanstalkScalingPolicy, HandlebarsBeanstalkTemplate } from './config-types';
+import {
+    DeployContext,
+    EnvironmentVariables,
+    PreDeployContext,
+    ServiceConfig,
+    ServiceContext,
+    UnDeployContext,
+    UnPreDeployContext
+} from '../../datatypes';
+import {
+    BeanstalkScalingPolicyAlarmDimensions,
+    BeanstalkServiceConfig,
+    EbextensionsToInject,
+    HandlebarsBeanstalkAutoScalingDimension,
+    HandlebarsBeanstalkAutoScalingTemplate,
+    HandlebarsBeanstalkOptionSetting,
+    HandlebarsBeanstalkScalingPolicy,
+    HandlebarsBeanstalkTemplate
+} from './config-types';
 import * as deployableArtifact from './deployable-artifact';
 
 const SERVICE_NAME = 'Beanstalk';
@@ -76,7 +94,7 @@ async function getCompiledBeanstalkTemplate(stackName: string, preDeployContext:
         solutionStack: serviceParams.solution_stack,
         optionSettings: [],
         policyStatements,
-        tags: deployPhaseCommon.getTags(serviceContext)
+        tags: getTags(serviceContext)
     };
 
     // Configure min and max size of ASG
@@ -328,7 +346,7 @@ export async function deploy(ownServiceContext: ServiceContext<BeanstalkServiceC
     const ebextensionFiles = await getSystemInjectedEbExtensions(stackName, ownServiceContext, dependenciesDeployContexts);
     const s3ArtifactInfo = await deployableArtifact.prepareAndUploadDeployableArtifact(ownServiceContext, ebextensionFiles);
     const compiledBeanstalkTemplate = await getCompiledBeanstalkTemplate(stackName, ownPreDeployContext, ownServiceContext, dependenciesDeployContexts, serviceRole, s3ArtifactInfo);
-    const stackTags = deployPhaseCommon.getTags(ownServiceContext);
+    const stackTags = getTags(ownServiceContext);
     const deployedStack = await deployPhaseCommon.deployCloudFormationStack(stackName, compiledBeanstalkTemplate, [], true, SERVICE_NAME, stackTags);
     winston.info(`${SERVICE_NAME} - Finished deploying Beanstalk application '${stackName}'`);
     return getDeployContext(ownServiceContext, deployedStack);
@@ -353,3 +371,5 @@ export const consumedDeployOutputTypes = [
     'credentials',
     'securityGroups'
 ];
+
+export const supportsTagging = true;

--- a/src/services/cloudwatchevent/index.ts
+++ b/src/services/cloudwatchevent/index.ts
@@ -22,8 +22,16 @@ import * as deletePhasesCommon from '../../common/delete-phases-common';
 import * as deployPhaseCommon from '../../common/deploy-phase-common';
 import * as handlebarsUtils from '../../common/handlebars-utils';
 import * as produceEventsPhaseCommon from '../../common/produce-events-phase-common';
-import { AccountConfig, DeployContext, PreDeployContext, ProduceEventsContext, ServiceConfig, ServiceContext, ServiceEventConsumer, UnDeployContext } from '../../datatypes';
-import { CloudWatchEventsConfig, CloudWatchEventsServiceEventConsumer } from './config-types';
+import {getTags} from '../../common/tagging-common';
+import {
+    DeployContext,
+    PreDeployContext,
+    ProduceEventsContext,
+    ServiceConfig,
+    ServiceContext,
+    UnDeployContext
+} from '../../datatypes';
+import {CloudWatchEventsConfig, CloudWatchEventsServiceEventConsumer} from './config-types';
 
 const SERVICE_NAME = 'CloudWatch Events';
 
@@ -85,7 +93,7 @@ export async function deploy(ownServiceContext: ServiceContext<CloudWatchEventsC
     winston.info(`${SERVICE_NAME} - Deploying event rule ${stackName}`);
 
     const eventRuleTemplate = await getCompiledEventRuleTemplate(stackName, ownServiceContext);
-    const stackTags = deployPhaseCommon.getTags(ownServiceContext);
+    const stackTags = getTags(ownServiceContext);
     const deployedStack = await deployPhaseCommon.deployCloudFormationStack(stackName, eventRuleTemplate, [], true, SERVICE_NAME, stackTags);
     winston.info(`${SERVICE_NAME} - Finished deploying event rule ${stackName}`);
     return getDeployContext(ownServiceContext, deployedStack);
@@ -145,3 +153,5 @@ export const producedEventsSupportedServices = [
 export const producedDeployOutputTypes = [];
 
 export const consumedDeployOutputTypes = [];
+
+export const supportsTagging = true;

--- a/src/services/dynamodb/index.ts
+++ b/src/services/dynamodb/index.ts
@@ -19,9 +19,17 @@ import * as cloudFormationCalls from '../../aws/cloudformation-calls';
 import * as deletePhasesCommon from '../../common/delete-phases-common';
 import * as deployPhaseCommon from '../../common/deploy-phase-common';
 import * as handlebarsUtils from '../../common/handlebars-utils';
-import { AccountConfig, DeployContext, PreDeployContext, ProduceEventsContext, ServiceConfig, ServiceContext } from '../../datatypes';
+import {getTags} from '../../common/tagging-common';
+import {
+    AccountConfig,
+    DeployContext,
+    PreDeployContext,
+    ProduceEventsContext,
+    ServiceConfig,
+    ServiceContext
+} from '../../datatypes';
 import * as autoscaling from './autoscaling';
-import { DynamoDBConfig, DynamoDBServiceEventConsumer } from './config-types';
+import {DynamoDBConfig, DynamoDBServiceEventConsumer} from './config-types';
 
 const KEY_TYPE_TO_ATTRIBUTE_TYPE: any = {
     String: 'S',
@@ -207,7 +215,7 @@ async function getCompiledDynamoTemplate(stackName: string, ownServiceContext: S
         tablePartitionKeyName: serviceParams.partition_key.name,
         tableReadCapacityUnits: throughputConfig.read.initial,
         tableWriteCapacityUnits: throughputConfig.write.initial,
-        tags: deployPhaseCommon.getTags(ownServiceContext)
+        tags: getTags(ownServiceContext)
     };
 
     // Add sort key if provided
@@ -302,7 +310,7 @@ export async function deploy(ownServiceContext: ServiceContext<DynamoDBConfig>, 
     const stackName = deployPhaseCommon.getResourceName(ownServiceContext);
     winston.info(`${SERVICE_NAME} - Deploying table ${stackName}`);
 
-    const stackTags = deployPhaseCommon.getTags(ownServiceContext);
+    const stackTags = getTags(ownServiceContext);
 
     const compiledTemplate = await getCompiledDynamoTemplate(stackName, ownServiceContext);
     const deployedStack = await deployPhaseCommon.deployCloudFormationStack(stackName, compiledTemplate, [], false, SERVICE_NAME, stackTags);
@@ -330,3 +338,5 @@ export const producedDeployOutputTypes = [
 ];
 
 export const consumedDeployOutputTypes = [];
+
+export const supportsTagging = true;

--- a/src/services/ecs-fargate/index.ts
+++ b/src/services/ecs-fargate/index.ts
@@ -25,8 +25,9 @@ import * as serviceAutoScalingSection from '../../common/ecs-service-auto-scalin
 import * as volumesSection from '../../common/ecs-volumes';
 import * as handlebarsUtils from '../../common/handlebars-utils';
 import * as preDeployPhaseCommon from '../../common/pre-deploy-phase-common';
-import { DeployContext, PreDeployContext, ServiceConfig, ServiceContext } from '../../datatypes';
-import { FargateServiceConfig, HandlebarsFargateTemplateConfig } from './config-types';
+import {getTags} from '../../common/tagging-common';
+import {DeployContext, PreDeployContext, ServiceConfig, ServiceContext} from '../../datatypes';
+import {FargateServiceConfig, HandlebarsFargateTemplateConfig} from './config-types';
 
 const SERVICE_NAME = 'ECS Fargate';
 
@@ -65,7 +66,7 @@ async function getCompiledEcsFargateTemplate(serviceName: string, ownServiceCont
                 vpcId: accountConfig.vpc,
                 policyStatements: getTaskRoleStatements(ownServiceContext, dependenciesDeployContexts),
                 deploymentSuffix: Math.floor(Math.random() * 10000), // ECS won't update unless something in the service changes.
-                tags: deployPhaseCommon.getTags(ownServiceContext),
+                tags: getTags(ownServiceContext),
                 containerConfigs,
                 autoScaling,
                 oneOrMoreTasksHasRouting,
@@ -119,7 +120,7 @@ export async function deploy(ownServiceContext: ServiceContext<FargateServiceCon
 
     await ecsCalls.createDefaultClusterIfNotExists();
     const compiledFargateTemplate = await getCompiledEcsFargateTemplate(stackName, ownServiceContext, ownPreDeployContext, dependenciesDeployContexts);
-    const stackTags = deployPhaseCommon.getTags(ownServiceContext);
+    const stackTags = getTags(ownServiceContext);
     const deployedStack = await deployPhaseCommon.deployCloudFormationStack(stackName, compiledFargateTemplate, [], true, SERVICE_NAME, stackTags);
     winston.info(`${SERVICE_NAME} - Finished deploying ECS Fargate Service '${stackName}'`);
     return new DeployContext(ownServiceContext);
@@ -142,3 +143,5 @@ export const consumedDeployOutputTypes = [
     'policies',
     'securityGroups'
 ];
+
+export const supportsTagging = true;

--- a/src/services/efs/index.ts
+++ b/src/services/efs/index.ts
@@ -21,8 +21,18 @@ import * as deletePhasesCommon from '../../common/delete-phases-common';
 import * as deployPhaseCommon from '../../common/deploy-phase-common';
 import * as handlebarsUtils from '../../common/handlebars-utils';
 import * as preDeployPhaseCommon from '../../common/pre-deploy-phase-common';
-import { BindContext, DeployContext, PreDeployContext, ServiceConfig, ServiceContext, UnBindContext, UnDeployContext, UnPreDeployContext } from '../../datatypes';
-import { EfsServiceConfig } from './config-types';
+import {getTags} from '../../common/tagging-common';
+import {
+    BindContext,
+    DeployContext,
+    PreDeployContext,
+    ServiceConfig,
+    ServiceContext,
+    UnBindContext,
+    UnDeployContext,
+    UnPreDeployContext
+} from '../../datatypes';
+import {EfsServiceConfig} from './config-types';
 
 const SERVICE_NAME = 'EFS';
 const EFS_PORT = 2049;
@@ -94,7 +104,7 @@ async function getCompiledEfsTemplate(stackName: string, ownServiceContext: Serv
         securityGroupId,
         subnetAId,
         subnetBId,
-        tags: deployPhaseCommon.getTags(ownServiceContext)
+        tags: getTags(ownServiceContext)
     };
 
     return handlebarsUtils.compileTemplate(`${__dirname}/efs-template.yml`, handlebarsParams);
@@ -132,7 +142,7 @@ export async function deploy(ownServiceContext: ServiceContext<EfsServiceConfig>
     winston.info(`${SERVICE_NAME} - Deploying EFS mount '${stackName}'`);
 
     const compiledTemplate = await getCompiledEfsTemplate(stackName, ownServiceContext, ownPreDeployContext);
-    const stackTags = deployPhaseCommon.getTags(ownServiceContext);
+    const stackTags = getTags(ownServiceContext);
     const deployedStack = await deployPhaseCommon.deployCloudFormationStack(stackName, compiledTemplate, [], false, SERVICE_NAME, stackTags);
     winston.info(`${SERVICE_NAME} - Finished deploying EFS mount '${stackName}'`);
     const fileSystemId = getFileSystemIdFromStack(deployedStack);
@@ -161,3 +171,5 @@ export const producedDeployOutputTypes = [
 ];
 
 export const consumedDeployOutputTypes = [];
+
+export const supportsTagging = true;

--- a/src/services/iot/index.ts
+++ b/src/services/iot/index.ts
@@ -20,8 +20,16 @@ import * as deployPhaseCommon from '../../common/deploy-phase-common';
 import * as handlebarsUtils from '../../common/handlebars-utils';
 import * as iotDeployersCommon from '../../common/iot-deployers-common';
 import * as produceEventsPhaseCommon from '../../common/produce-events-phase-common';
-import { DeployContext, PreDeployContext, ProduceEventsContext, ServiceConfig, ServiceContext, ServiceEventConsumer, UnDeployContext } from '../../datatypes';
-import { IotServiceConfig, IotServiceEventConsumer } from './config-types';
+import {getTags} from '../../common/tagging-common';
+import {
+    DeployContext,
+    PreDeployContext,
+    ProduceEventsContext,
+    ServiceConfig,
+    ServiceContext,
+    UnDeployContext
+} from '../../datatypes';
+import {IotServiceConfig, IotServiceEventConsumer} from './config-types';
 
 const SERVICE_NAME = 'IOT';
 
@@ -121,7 +129,7 @@ export async function produceEvents(ownServiceContext: ServiceContext<IotService
         throw new Error(`${SERVICE_NAME} - Unsupported event consumer type given: ${consumerServiceType}`);
     }
 
-    const stackTags = deployPhaseCommon.getTags(ownServiceContext);
+    const stackTags = getTags(ownServiceContext);
     const serviceParams = ownServiceContext.params;
     const stackName = getStackNameFromRuleName(ruleName);
     const description = serviceParams.description || 'AWS IoT rule created by Handel for ' + stackName;
@@ -159,3 +167,5 @@ export const producedEventsSupportedServices = [
 export const producedDeployOutputTypes = [];
 
 export const consumedDeployOutputTypes = [];
+
+export const supportsTagging = true;

--- a/src/services/kms/index.ts
+++ b/src/services/kms/index.ts
@@ -19,8 +19,9 @@ import * as cloudFormationCalls from '../../aws/cloudformation-calls';
 import * as deletePhasesCommon from '../../common/delete-phases-common';
 import * as deployPhaseCommon from '../../common/deploy-phase-common';
 import * as handlebarsUtils from '../../common/handlebars-utils';
-import { DeployContext, PreDeployContext, ServiceConfig, ServiceContext, UnDeployContext } from '../../datatypes';
-import { KmsServiceConfig } from './config-types';
+import {getTags} from '../../common/tagging-common';
+import {DeployContext, PreDeployContext, ServiceConfig, ServiceContext, UnDeployContext} from '../../datatypes';
+import {KmsServiceConfig} from './config-types';
 
 const SERVICE_NAME = 'KMS';
 
@@ -105,7 +106,7 @@ export async function deploy(ownServiceContext: ServiceContext<KmsServiceConfig>
     winston.info(`${SERVICE_NAME} - Deploying KMS Key ${stackName}`);
 
     const compiledTemplate = await getCompiledTemplate(ownServiceContext);
-    const stackTags = deployPhaseCommon.getTags(ownServiceContext);
+    const stackTags = getTags(ownServiceContext);
     const deployedStack = await deployPhaseCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, SERVICE_NAME, stackTags);
     winston.info(`${SERVICE_NAME} - Finished deploying KMS Key ${stackName}`);
     return getDeployContext(ownServiceContext, deployedStack);
@@ -123,3 +124,5 @@ export const producedDeployOutputTypes = [
 ];
 
 export const consumedDeployOutputTypes = [];
+
+export const supportsTagging = true;

--- a/src/services/lambda/index.ts
+++ b/src/services/lambda/index.ts
@@ -26,9 +26,20 @@ import * as handlebarsUtils from '../../common/handlebars-utils';
 import * as iotDeployersCommon from '../../common/iot-deployers-common';
 import * as lifecyclesCommon from '../../common/lifecycles-common';
 import * as preDeployPhaseCommon from '../../common/pre-deploy-phase-common';
+import {getTags} from '../../common/tagging-common';
 import * as util from '../../common/util';
-import { ConsumeEventsContext, DeployContext, EnvironmentVariables, PreDeployContext, ServiceConfig, ServiceContext, ProduceEventsContext, UnPreDeployContext, UnDeployContext } from '../../datatypes';
-import { DynamoDBLambdaConsumer, HandlebarsLambdaTemplate, LambdaServiceConfig } from './config-types';
+import {
+    ConsumeEventsContext,
+    DeployContext,
+    EnvironmentVariables,
+    PreDeployContext,
+    ProduceEventsContext,
+    ServiceConfig,
+    ServiceContext,
+    UnDeployContext,
+    UnPreDeployContext
+} from '../../datatypes';
+import {DynamoDBLambdaConsumer, HandlebarsLambdaTemplate, LambdaServiceConfig} from './config-types';
 
 const SERVICE_NAME = 'Lambda';
 
@@ -66,7 +77,7 @@ function getCompiledLambdaTemplate(stackName: string, ownServiceContext: Service
         memorySize: memorySize,
         timeout: timeout,
         policyStatements,
-        tags: deployPhaseCommon.getTags(ownServiceContext)
+        tags: getTags(ownServiceContext)
     };
 
     // Inject environment variables (if any)
@@ -241,7 +252,7 @@ export async function deploy(ownServiceContext: ServiceContext<LambdaServiceConf
     }
     const s3ArtifactInfo = await uploadDeployableArtifactToS3(ownServiceContext);
     const compiledLambdaTemplate = await getCompiledLambdaTemplate(stackName, ownServiceContext, dependenciesDeployContexts, s3ArtifactInfo, securityGroups);
-    const stackTags = deployPhaseCommon.getTags(ownServiceContext);
+    const stackTags = getTags(ownServiceContext);
     const deployedStack = await deployPhaseCommon.deployCloudFormationStack(stackName, compiledLambdaTemplate, [], true, SERVICE_NAME, stackTags);
     winston.info(`${SERVICE_NAME} - Finished deploying '${stackName}'`);
     return getDeployContext(ownServiceContext, deployedStack);
@@ -281,3 +292,5 @@ export const consumedDeployOutputTypes = [
     'policies',
     'securityGroups'
 ];
+
+export const supportsTagging = true;

--- a/src/services/memcached/index.ts
+++ b/src/services/memcached/index.ts
@@ -22,8 +22,18 @@ import * as deployPhaseCommon from '../../common/deploy-phase-common';
 import * as elasticacheDeployersCommon from '../../common/elasticache-deployers-common';
 import * as handlebarsUtils from '../../common/handlebars-utils';
 import * as preDeployPhaseCommon from '../../common/pre-deploy-phase-common';
-import { BindContext, DeployContext, PreDeployContext, ServiceConfig, ServiceContext, UnBindContext, UnDeployContext, UnPreDeployContext } from '../../datatypes';
-import { HandlebarsMemcachedTemplate, MemcachedServiceConfig } from './config-types';
+import {getTags} from '../../common/tagging-common';
+import {
+    BindContext,
+    DeployContext,
+    PreDeployContext,
+    ServiceConfig,
+    ServiceContext,
+    UnBindContext,
+    UnDeployContext,
+    UnPreDeployContext
+} from '../../datatypes';
+import {HandlebarsMemcachedTemplate, MemcachedServiceConfig} from './config-types';
 
 const SERVICE_NAME = 'Memcached';
 const MEMCACHED_PORT = 11211;
@@ -60,7 +70,7 @@ function getCompiledMemcachedTemplate(stackName: string, ownServiceContext: Serv
         memcachedSecurityGroupId: ownPreDeployContext.securityGroups[0].GroupId!,
         nodeCount: serviceParams.node_count || 1,
         memcachedPort: MEMCACHED_PORT,
-        tags: deployPhaseCommon.getTags(ownServiceContext)
+        tags: getTags(ownServiceContext)
     };
 
     // Either create custom parameter group if params are specified, or just use default
@@ -108,7 +118,7 @@ export async function deploy(ownServiceContext: ServiceContext<MemcachedServiceC
     winston.info(`${SERVICE_NAME} - Deploying cluster '${stackName}'`);
 
     const compiledTemplate = await getCompiledMemcachedTemplate(stackName, ownServiceContext, ownPreDeployContext);
-    const stackTags = deployPhaseCommon.getTags(ownServiceContext);
+    const stackTags = getTags(ownServiceContext);
     const deployedStack = await deployPhaseCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, SERVICE_NAME, stackTags);
     winston.info(`${SERVICE_NAME} - Finished deploying cluster '${stackName}'`);
     return getDeployContext(ownServiceContext, deployedStack);
@@ -134,3 +144,5 @@ export const producedDeployOutputTypes = [
 ];
 
 export const consumedDeployOutputTypes = [];
+
+export const supportsTagging = true;

--- a/src/services/mysql/index.ts
+++ b/src/services/mysql/index.ts
@@ -22,8 +22,18 @@ import * as deployPhaseCommon from '../../common/deploy-phase-common';
 import * as handlebarsUtils from '../../common/handlebars-utils';
 import * as preDeployPhaseCommon from '../../common/pre-deploy-phase-common';
 import * as rdsDeployersCommon from '../../common/rds-deployers-common';
-import { BindContext, DeployContext, PreDeployContext, ServiceConfig, ServiceContext, UnBindContext, UnDeployContext, UnPreDeployContext } from '../../datatypes';
-import { HandlebarsMySqlTemplate, MySQLConfig, MySQLStorageType } from './config-types';
+import {getTags} from '../../common/tagging-common';
+import {
+    BindContext,
+    DeployContext,
+    PreDeployContext,
+    ServiceConfig,
+    ServiceContext,
+    UnBindContext,
+    UnDeployContext,
+    UnPreDeployContext
+} from '../../datatypes';
+import {HandlebarsMySqlTemplate, MySQLConfig, MySQLStorageType} from './config-types';
 
 const SERVICE_NAME = 'MySQL';
 const MYSQL_PORT = 3306;
@@ -61,7 +71,7 @@ function getCompiledMysqlTemplate(stackName: string,
         storageType: serviceParams.storage_type || MySQLStorageType.STANDARD,
         dbSecurityGroupId: ownPreDeployContext.securityGroups[0].GroupId!,
         parameterGroupFamily: getParameterGroupFamily(mysqlVersion),
-        tags: deployPhaseCommon.getTags(ownServiceContext)
+        tags: getTags(ownServiceContext)
     };
 
     // Add parameters to parameter group if specified
@@ -130,7 +140,7 @@ export async function deploy(ownServiceContext: ServiceContext<MySQLConfig>,
             DBUsername: dbUsername,
             DBPassword: dbPassword
         });
-        const stackTags = deployPhaseCommon.getTags(ownServiceContext);
+        const stackTags = getTags(ownServiceContext);
         winston.debug(`${SERVICE_NAME} - Creating CloudFormation stack '${stackName}'`);
         const deployedStack = await cloudFormationCalls.createStack(stackName,
                                                                     compiledTemplate,
@@ -171,3 +181,5 @@ export const producedDeployOutputTypes = [
 ];
 
 export const consumedDeployOutputTypes = [];
+
+export const supportsTagging = true;

--- a/src/services/postgresql/index.ts
+++ b/src/services/postgresql/index.ts
@@ -22,8 +22,18 @@ import * as deployPhaseCommon from '../../common/deploy-phase-common';
 import * as handlebarsUtils from '../../common/handlebars-utils';
 import * as preDeployPhaseCommon from '../../common/pre-deploy-phase-common';
 import * as rdsDeployersCommon from '../../common/rds-deployers-common';
-import { BindContext, DeployContext, PreDeployContext, ServiceConfig, ServiceContext, UnBindContext, UnDeployContext, UnPreDeployContext } from '../../datatypes';
-import { HandlebarsPostgreSQLTemplate, PostgreSQLConfig, PostgreSQLStorageType } from './config-types';
+import {getTags} from '../../common/tagging-common';
+import {
+    BindContext,
+    DeployContext,
+    PreDeployContext,
+    ServiceConfig,
+    ServiceContext,
+    UnBindContext,
+    UnDeployContext,
+    UnPreDeployContext
+} from '../../datatypes';
+import {HandlebarsPostgreSQLTemplate, PostgreSQLConfig, PostgreSQLStorageType} from './config-types';
 
 const SERVICE_NAME = 'PostgreSQL';
 const POSTGRES_PORT = 5432;
@@ -64,7 +74,7 @@ async function getCompiledPostgresTemplate(stackName: string,
         storageType: serviceParams.storage_type || PostgreSQLStorageType.STANDARD,
         dbSecurityGroupId: ownPreDeployContext.securityGroups[0].GroupId!,
         parameterGroupFamily: getParameterGroupFamily(postgresVersion),
-        tags: deployPhaseCommon.getTags(ownServiceContext)
+        tags: getTags(ownServiceContext)
     };
 
     // Add parameters to parameter group if specified
@@ -135,7 +145,7 @@ export async function deploy(ownServiceContext: ServiceContext<PostgreSQLConfig>
             DBUsername: dbUsername,
             DBPassword: dbPassword
         });
-        const stackTags = deployPhaseCommon.getTags(ownServiceContext);
+        const stackTags = getTags(ownServiceContext);
         winston.debug(`${SERVICE_NAME} - Creating CloudFormation stack '${stackName}'`);
         const deployedStack = await cloudFormationCalls.createStack(stackName,
                                                                     compiledTemplate,
@@ -176,3 +186,5 @@ export const producedDeployOutputTypes = [
 ];
 
 export const consumedDeployOutputTypes = [];
+
+export const supportsTagging = true;

--- a/src/services/redis/index.ts
+++ b/src/services/redis/index.ts
@@ -22,8 +22,18 @@ import * as deployPhaseCommon from '../../common/deploy-phase-common';
 import * as elasticacheDeployersCommon from '../../common/elasticache-deployers-common';
 import * as handlebarsUtils from '../../common/handlebars-utils';
 import * as preDeployPhaseCommon from '../../common/pre-deploy-phase-common';
-import { BindContext, DeployContext, PreDeployContext, ServiceConfig, ServiceContext, UnBindContext, UnDeployContext, UnPreDeployContext } from '../../datatypes';
-import { HandlebarsRedisTemplate, RedisServiceConfig } from './config-types';
+import {getTags} from '../../common/tagging-common';
+import {
+    BindContext,
+    DeployContext,
+    PreDeployContext,
+    ServiceConfig,
+    ServiceContext,
+    UnBindContext,
+    UnDeployContext,
+    UnPreDeployContext
+} from '../../datatypes';
+import {HandlebarsRedisTemplate, RedisServiceConfig} from './config-types';
 
 const SERVICE_NAME = 'Redis';
 const REDIS_PORT = 6379;
@@ -92,7 +102,7 @@ function getCompiledRedisTemplate(stackName: string, ownServiceContext: ServiceC
         snapshotWindow: serviceParams.snapshot_window,
         // shards,
         numNodes: readReplicas + 1,
-        tags: deployPhaseCommon.getTags(ownServiceContext)
+        tags: getTags(ownServiceContext)
     };
 
     // Either create custom parameter group if params are specified, or just use default
@@ -167,7 +177,7 @@ export async function deploy(ownServiceContext: ServiceContext<RedisServiceConfi
     winston.info(`${SERVICE_NAME} - Deploying cluster '${stackName}'`);
 
     const compiledTemplate = await getCompiledRedisTemplate(stackName, ownServiceContext, ownPreDeployContext);
-    const stackTags = deployPhaseCommon.getTags(ownServiceContext);
+    const stackTags = getTags(ownServiceContext);
     const deployedStack = await deployPhaseCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, SERVICE_NAME, stackTags);
     winston.info(`${SERVICE_NAME} - Finished deploying cluster '${stackName}'`);
     return getDeployContext(ownServiceContext, deployedStack);
@@ -194,3 +204,5 @@ export const producedDeployOutputTypes = [
 ];
 
 export const consumedDeployOutputTypes = [];
+
+export const supportsTagging = true;

--- a/src/services/route53zone/index.ts
+++ b/src/services/route53zone/index.ts
@@ -20,8 +20,9 @@ import * as route53 from '../../aws/route53-calls';
 import * as deletePhasesCommon from '../../common/delete-phases-common';
 import * as deployPhaseCommon from '../../common/deploy-phase-common';
 import * as handlebarsUtils from '../../common/handlebars-utils';
-import { DeployContext, PreDeployContext, ServiceConfig, ServiceContext, UnDeployContext } from '../../datatypes';
-import { HandlebarsRoute53ZoneTemplate, Route53ZoneServiceConfig } from './config-types';
+import {getTags} from '../../common/tagging-common';
+import {DeployContext, PreDeployContext, ServiceConfig, ServiceContext, UnDeployContext} from '../../datatypes';
+import {HandlebarsRoute53ZoneTemplate, Route53ZoneServiceConfig} from './config-types';
 
 const SERVICE_NAME = 'Route53';
 
@@ -48,7 +49,7 @@ function getCompiledRoute53Template(ownServiceContext: ServiceContext<Route53Zon
 
     const handlebarsParams: HandlebarsRoute53ZoneTemplate = {
         name: serviceParams.name,
-        tags: deployPhaseCommon.getTags(ownServiceContext)
+        tags: getTags(ownServiceContext)
     };
 
     if (serviceParams.private) {
@@ -90,7 +91,7 @@ export async function deploy(ownServiceContext: ServiceContext<Route53ZoneServic
     winston.info(`${SERVICE_NAME} - Deploying Route53 Zone ${stackName}`);
 
     const compiledTemplate = await getCompiledRoute53Template(ownServiceContext);
-    const stackTags = deployPhaseCommon.getTags(ownServiceContext);
+    const stackTags = getTags(ownServiceContext);
     const deployedStack = await deployPhaseCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, SERVICE_NAME, stackTags);
     winston.info(`${SERVICE_NAME} - Finished deploying S3 bucket ${stackName}`);
     return getDeployContext(ownServiceContext, deployedStack);
@@ -107,3 +108,5 @@ export const producedDeployOutputTypes = [
 ];
 
 export const consumedDeployOutputTypes = [];
+
+export const supportsTagging = true;

--- a/src/services/s3/index.ts
+++ b/src/services/s3/index.ts
@@ -20,8 +20,9 @@ import * as deletePhasesCommon from '../../common/delete-phases-common';
 import * as deployPhaseCommon from '../../common/deploy-phase-common';
 import * as handlebarsUtils from '../../common/handlebars-utils';
 import * as s3DeployersCommon from '../../common/s3-deployers-common';
-import { DeployContext, PreDeployContext, ServiceConfig, ServiceContext, UnDeployContext } from '../../datatypes';
-import { HandlebarsS3Template, S3ServiceConfig } from './config-types';
+import {getTags} from '../../common/tagging-common';
+import {DeployContext, PreDeployContext, ServiceConfig, ServiceContext, UnDeployContext} from '../../datatypes';
+import {HandlebarsS3Template, S3ServiceConfig} from './config-types';
 import * as lifecycleSection from './lifecycles';
 
 const SERVICE_NAME = 'S3';
@@ -87,7 +88,7 @@ function getCompiledS3Template(stackName: string, ownServiceContext: ServiceCont
         bucketName: bucketName,
         bucketACL: serviceParams.bucket_acl,
         versioningStatus: versioningStatus,
-        tags: deployPhaseCommon.getTags(ownServiceContext),
+        tags: getTags(ownServiceContext),
         lifecycle_policy: lifecycleSection.getLifecycleConfig(ownServiceContext)
     };
 
@@ -128,7 +129,7 @@ export async function deploy(ownServiceContext: ServiceContext<S3ServiceConfig>,
 
     const loggingBucketName = await s3DeployersCommon.createLoggingBucketIfNotExists(ownServiceContext.accountConfig);
     const compiledTemplate = await getCompiledS3Template(stackName, ownServiceContext, loggingBucketName!);
-    const stackTags = deployPhaseCommon.getTags(ownServiceContext);
+    const stackTags = getTags(ownServiceContext);
     const deployedStack = await deployPhaseCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, SERVICE_NAME, stackTags);
     winston.info(`${SERVICE_NAME} - Finished deploying bucket '${stackName}'`);
     return getDeployContext(ownServiceContext, deployedStack);
@@ -147,3 +148,5 @@ export const producedDeployOutputTypes = [
 ];
 
 export const consumedDeployOutputTypes = [];
+
+export const supportsTagging = true;

--- a/src/services/s3staticsite/index.ts
+++ b/src/services/s3staticsite/index.ts
@@ -23,8 +23,14 @@ import * as deletePhasesCommon from '../../common/delete-phases-common';
 import * as deployPhaseCommon from '../../common/deploy-phase-common';
 import * as handlebarsUtils from '../../common/handlebars-utils';
 import * as s3DeployersCommon from '../../common/s3-deployers-common';
-import { DeployContext, PreDeployContext, ServiceConfig, ServiceContext, UnDeployContext } from '../../datatypes';
-import { CloudFrontConfig, HandlebarsCloudFrontParams, HandlebarsS3StaticSiteTemplate, S3StaticSiteServiceConfig } from './config-types';
+import {getTags} from '../../common/tagging-common';
+import {DeployContext, PreDeployContext, ServiceConfig, ServiceContext, UnDeployContext} from '../../datatypes';
+import {
+    CloudFrontConfig,
+    HandlebarsCloudFrontParams,
+    HandlebarsS3StaticSiteTemplate,
+    S3StaticSiteServiceConfig
+} from './config-types';
 
 const SERVICE_NAME = 'S3 Static Site';
 
@@ -66,7 +72,7 @@ async function getCompiledS3Template(ownServiceContext: ServiceContext<S3StaticS
         logFilePrefix,
         indexDocument,
         errorDocument,
-        tags: deployPhaseCommon.getTags(ownServiceContext),
+        tags: getTags(ownServiceContext),
 
     };
 
@@ -212,7 +218,7 @@ export async function deploy(ownServiceContext: ServiceContext<S3StaticSiteServi
 
     const loggingBucketName = await s3DeployersCommon.createLoggingBucketIfNotExists(ownServiceContext.accountConfig);
     const compiledTemplate = await getCompiledS3Template(ownServiceContext, stackName, loggingBucketName!);
-    const stackTags = deployPhaseCommon.getTags(ownServiceContext);
+    const stackTags = getTags(ownServiceContext);
     const deployedStack = await deployPhaseCommon.deployCloudFormationStack(stackName, compiledTemplate, [], true, SERVICE_NAME, stackTags);
     const bucketName = cloudFormationCalls.getOutput('BucketName', deployedStack)!;
     // Upload files from path_to_website to S3
@@ -232,3 +238,5 @@ export const producedEventsSupportedServices = [];
 export const producedDeployOutputTypes = [];
 
 export const consumedDeployOutputTypes = [];
+
+export const supportsTagging = true;

--- a/src/services/ses/index.ts
+++ b/src/services/ses/index.ts
@@ -85,4 +85,4 @@ export const producedDeployOutputTypes = [
 
 export const consumedDeployOutputTypes = [];
 
-export const supportsTagging = true;
+export const supportsTagging = false;

--- a/src/services/ses/index.ts
+++ b/src/services/ses/index.ts
@@ -84,3 +84,5 @@ export const producedDeployOutputTypes = [
 ];
 
 export const consumedDeployOutputTypes = [];
+
+export const supportsTagging = true;

--- a/src/services/sns/index.ts
+++ b/src/services/sns/index.ts
@@ -20,8 +20,17 @@ import * as snsCalls from '../../aws/sns-calls';
 import * as deletePhasesCommon from '../../common/delete-phases-common';
 import * as deployPhaseCommon from '../../common/deploy-phase-common';
 import * as handlebarsUtils from '../../common/handlebars-utils';
-import { ConsumeEventsContext, DeployContext, PreDeployContext, ProduceEventsContext, ServiceConfig, ServiceContext, UnDeployContext } from '../../datatypes';
-import { SnsServiceConfig } from './config-types';
+import {getTags} from '../../common/tagging-common';
+import {
+    ConsumeEventsContext,
+    DeployContext,
+    PreDeployContext,
+    ProduceEventsContext,
+    ServiceConfig,
+    ServiceContext,
+    UnDeployContext
+} from '../../datatypes';
+import {SnsServiceConfig} from './config-types';
 
 const SERVICE_NAME = 'SNS';
 
@@ -114,7 +123,7 @@ export async function deploy(ownServiceContext: ServiceContext<SnsServiceConfig>
     winston.info(`${SERVICE_NAME} - Deploying topic '${stackName}'`);
 
     const compiledSnsTemplate = await getCompiledSnsTemplate(stackName, ownServiceContext);
-    const stackTags = deployPhaseCommon.getTags(ownServiceContext);
+    const stackTags = getTags(ownServiceContext);
     const deployedStack = await deployPhaseCommon.deployCloudFormationStack(stackName, compiledSnsTemplate, [], true, SERVICE_NAME, stackTags);
     winston.info(`${SERVICE_NAME} - Finished deploying topic '${stackName}'`);
     return getDeployContext(ownServiceContext, deployedStack);
@@ -182,3 +191,5 @@ export const producedDeployOutputTypes = [
 export const consumedDeployOutputTypes = [
     'cloudwatchevent'
 ];
+
+export const supportsTagging = true;

--- a/src/services/sqs/index.ts
+++ b/src/services/sqs/index.ts
@@ -20,8 +20,16 @@ import * as sqsCalls from '../../aws/sqs-calls';
 import * as deletePhasesCommon from '../../common/delete-phases-common';
 import * as deployPhaseCommon from '../../common/deploy-phase-common';
 import * as handlebarsUtils from '../../common/handlebars-utils';
-import { ConsumeEventsContext, DeployContext, PreDeployContext, ServiceConfig, ServiceContext, UnDeployContext } from '../../datatypes';
-import { HandlebarsSqsTemplate, SqsServiceConfig } from './config-types';
+import {getTags} from '../../common/tagging-common';
+import {
+    ConsumeEventsContext,
+    DeployContext,
+    PreDeployContext,
+    ServiceConfig,
+    ServiceContext,
+    UnDeployContext
+} from '../../datatypes';
+import {HandlebarsSqsTemplate, SqsServiceConfig} from './config-types';
 
 const SERVICE_NAME = 'SQS';
 
@@ -191,7 +199,7 @@ export async function deploy(ownServiceContext: ServiceContext<SqsServiceConfig>
     winston.info(`${SERVICE_NAME} - Deploying queue '${stackName}'`);
 
     const sqsTemplate = await getCompiledSqsTemplate(stackName, ownServiceContext);
-    const stackTags = deployPhaseCommon.getTags(ownServiceContext);
+    const stackTags = getTags(ownServiceContext);
     const deployedStack = await deployPhaseCommon.deployCloudFormationStack(stackName, sqsTemplate, [], true, SERVICE_NAME, stackTags);
     winston.info(`${SERVICE_NAME} - Finished deploying queue '${stackName}'`);
     return getDeployContext(ownServiceContext, deployedStack);
@@ -230,3 +238,5 @@ export const producedDeployOutputTypes = [
 ];
 
 export const consumedDeployOutputTypes = [];
+
+export const supportsTagging = true;

--- a/test/common/deploy-phase-common-test.ts
+++ b/test/common/deploy-phase-common-test.ts
@@ -276,5 +276,51 @@ describe('Deploy phase common module', () => {
             expect(returnTags.env).to.equal('FakeEnv');
             expect(returnTags.mytag).to.equal('myvalue');
         });
+
+        it('should include any application-level tags', () => {
+            serviceContext.tags = {
+                aTag: 'a value'
+            };
+            serviceContext.params = {
+                type: 'faketype',
+                tags: {
+                    mytag: 'myvalue'
+                }
+            };
+
+            const returnTags = deployPhaseCommon.getTags(serviceContext);
+            expect(returnTags.mytag).to.equal('myvalue');
+            expect(returnTags.aTag).to.equal('a value');
+        });
+
+        it('should prefer service tags to application tags', () => {
+            serviceContext.tags = {
+                mytag: 'application'
+            };
+            serviceContext.params = {
+                type: 'faketype',
+                tags: {
+                    mytag: 'service'
+                }
+            };
+
+            const returnTags = deployPhaseCommon.getTags(serviceContext);
+            expect(returnTags.mytag).to.equal('service');
+        });
+
+        it('should prefer Handel tags to service or application tags', () => {
+             serviceContext.tags = {
+                env: 'application'
+            };
+            serviceContext.params = {
+                type: 'faketype',
+                tags: {
+                    env: 'service'
+                }
+            };
+
+            const returnTags = deployPhaseCommon.getTags(serviceContext);
+            expect(returnTags.env).to.equal('service');
+        });
     });
 });

--- a/test/common/deploy-phase-common-test.ts
+++ b/test/common/deploy-phase-common-test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
-import { expect } from 'chai';
+import {expect} from 'chai';
 import * as fs from 'fs';
 import * as sinon from 'sinon';
 import config from '../../src/account-config/account-config';
@@ -23,7 +23,7 @@ import * as iamCalls from '../../src/aws/iam-calls';
 import * as s3Calls from '../../src/aws/s3-calls';
 import * as deployPhaseCommon from '../../src/common/deploy-phase-common';
 import * as util from '../../src/common/util';
-import { AccountConfig, DeployContext, ServiceConfig, ServiceContext } from '../../src/datatypes';
+import {AccountConfig, DeployContext, ServiceConfig, ServiceContext} from '../../src/datatypes';
 
 describe('Deploy phase common module', () => {
     let sandbox: sinon.SinonSandbox;
@@ -262,65 +262,4 @@ describe('Deploy phase common module', () => {
         });
     });
 
-    describe('getTags', () => {
-        it('should return the Handel-injected tags, plus any user-defined tags', () => {
-            serviceContext.params = {
-                type: 'faketype',
-                tags: {
-                    mytag: 'myvalue'
-                }
-            };
-
-            const returnTags = deployPhaseCommon.getTags(serviceContext);
-            expect(returnTags.app).to.equal('FakeApp');
-            expect(returnTags.env).to.equal('FakeEnv');
-            expect(returnTags.mytag).to.equal('myvalue');
-        });
-
-        it('should include any application-level tags', () => {
-            serviceContext.tags = {
-                aTag: 'a value'
-            };
-            serviceContext.params = {
-                type: 'faketype',
-                tags: {
-                    mytag: 'myvalue'
-                }
-            };
-
-            const returnTags = deployPhaseCommon.getTags(serviceContext);
-            expect(returnTags.mytag).to.equal('myvalue');
-            expect(returnTags.aTag).to.equal('a value');
-        });
-
-        it('should prefer service tags to application tags', () => {
-            serviceContext.tags = {
-                mytag: 'application'
-            };
-            serviceContext.params = {
-                type: 'faketype',
-                tags: {
-                    mytag: 'service'
-                }
-            };
-
-            const returnTags = deployPhaseCommon.getTags(serviceContext);
-            expect(returnTags.mytag).to.equal('service');
-        });
-
-        it('should prefer Handel tags to service or application tags', () => {
-             serviceContext.tags = {
-                env: 'application'
-            };
-            serviceContext.params = {
-                type: 'faketype',
-                tags: {
-                    env: 'service'
-                }
-            };
-
-            const returnTags = deployPhaseCommon.getTags(serviceContext);
-            expect(returnTags.env).to.equal('service');
-        });
-    });
 });

--- a/test/common/tagging-common-test.ts
+++ b/test/common/tagging-common-test.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2018 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import {expect} from 'chai';
+import * as sinon from 'sinon';
+import config from '../../src/account-config/account-config';
+import {getTags} from '../../src/common/tagging-common';
+import {AccountConfig, ServiceConfig, ServiceContext} from '../../src/datatypes';
+
+describe('Tagging common module', () => {
+    let sandbox: sinon.SinonSandbox;
+    let serviceContext: ServiceContext<ServiceConfig>;
+    let accountConfig: AccountConfig;
+    const appName = 'FakeApp';
+    const envName = 'FakeEnv';
+    const serviceName = 'FakeService';
+
+    beforeEach(async () => {
+        const retAccountConfig = await config(`${__dirname}/../test-account-config.yml`);
+        sandbox = sinon.sandbox.create();
+        accountConfig = retAccountConfig;
+        serviceContext = new ServiceContext(appName, envName, serviceName, 'FakeType', {type: 'FakeType'}, retAccountConfig);
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    describe('getTags', () => {
+        it('should return the Handel-injected tags, plus any user-defined tags', () => {
+            serviceContext.params = {
+                type: 'faketype',
+                tags: {
+                    mytag: 'myvalue'
+                }
+            };
+
+            const returnTags = getTags(serviceContext);
+            expect(returnTags.app).to.equal('FakeApp');
+            expect(returnTags.env).to.equal('FakeEnv');
+            expect(returnTags.mytag).to.equal('myvalue');
+        });
+
+        it('should include any application-level tags', () => {
+            serviceContext.tags = {
+                aTag: 'a value'
+            };
+            serviceContext.params = {
+                type: 'faketype',
+                tags: {
+                    mytag: 'myvalue'
+                }
+            };
+
+            const returnTags = getTags(serviceContext);
+            expect(returnTags.mytag).to.equal('myvalue');
+            expect(returnTags.aTag).to.equal('a value');
+        });
+
+        it('should prefer service tags to application tags', () => {
+            serviceContext.tags = {
+                mytag: 'application'
+            };
+            serviceContext.params = {
+                type: 'faketype',
+                tags: {
+                    mytag: 'service'
+                }
+            };
+
+            const returnTags = getTags(serviceContext);
+            expect(returnTags.mytag).to.equal('service');
+        });
+
+        it('should prefer Handel tags to service or application tags', () => {
+             serviceContext.tags = {
+                env: 'application'
+            };
+            serviceContext.params = {
+                type: 'faketype',
+                tags: {
+                    env: 'service'
+                }
+            };
+
+            const returnTags = getTags(serviceContext);
+            expect(returnTags.env).to.equal('service');
+        });
+    });
+});


### PR DESCRIPTION
Per the discussion in #332, this PR will allow us to add a list of required tags to an account config file. This list will then be enforced during `handel check` and `handel deploy`.

Note: This won't take effect immediately when merged. We'd have to update each account config file, then have all deployers download the new account config file.

Side note: should we explore keeping the account config files in a specially-named S3 bucket or Parameter Store value? Then we could roll out account config file changes more easily.