### PR TITLE
Implement CLI Tag Overrides

### DIFF
--- a/docs/getting-started/cli-reference.rst
+++ b/docs/getting-started/cli-reference.rst
@@ -1,0 +1,101 @@
+.. _cli-reference:
+
+CLI Reference
+=============
+
+The Handel command-line interface should be run in a directory with a `handel.yml` file.
+
+It defines three commands: `check`, `deploy`, and `delete`
+
+.. _cli-check:
+
+`handel check`
+--------------
+
+Validates that a given Handel configuration is valid.
+
+Note that this does not validate against account-level settings, such as :ref:`tagging-requiring-tags`.
+
+Parameters
+~~~~~~~~~~
+
+`handel check` does not accept parameters.
+
+.. _cli-deploy:
+
+`handel deploy`
+---------------
+
+Validates and deploys the resources in a given environment.
+
+Parameters
+~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+
+   * - Parameter
+     - Type
+     - Required
+     - Default
+     - Description
+   * - -c <value>
+     - string
+     - Yes
+     -
+     - Path to account config or base64 encoded JSON string of config
+   * - -e <env>[,<env>]
+     - comma-separated list
+     - Yes
+     -
+     - List of environments from the handelfile to deploy.
+   * - -d
+     - boolean (present or not present)
+     - No
+     - false
+     - If set, turns on debug-level logging.
+   * - -t <key>=<value>[,<key>=<value>]
+     - comma-separated list of key-value pairs
+     - No
+     -
+     - List of tags to apply to all resources in the handelfile. These override any static tags set in the handelfile.
+
+.. _cli-delete:
+
+`handel delete`
+---------------
+
+Deletes all resources in a given environment.
+
+Parameters
+~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+
+   * - Parameter
+     - Type
+     - Required
+     - Default
+     - Description
+   * - -c <value>
+     - string
+     - Yes
+     -
+     - Path to account config or base64 encoded JSON string of config
+   * - -e <env>[,<env>]
+     - comma-separated list
+     - Yes
+     -
+     - List of environments from the handelfile to delete.
+   * - -d
+     - boolean (present or not present)
+     - No
+     - false
+     - If set, turns on debug-level logging.
+   * - -y
+     - boolean (present or not present)
+     - No
+     - false
+     - If set, Handel will *not* prompt for confirmation of the delete action.
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,6 +39,7 @@ including taking care of all the tricky security bits to make the services be ab
    getting-started/handel-vs-cloudformation
    getting-started/installation
    getting-started/tutorial-creating-an-app
+   getting-started/cli-reference
 
 .. _handel-basics:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1928,15 +1928,6 @@
           "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
           "dev": true
         },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -1946,6 +1937,15 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {

--- a/src/common/tagging-common.ts
+++ b/src/common/tagging-common.ts
@@ -1,5 +1,9 @@
 import {ServiceConfig, ServiceContext, Tags} from '../datatypes';
 
+export const TAG_KEY_PATTERN = `[a-zA-Z0-9+\-=._:\\/@]{1,127}`;
+export const TAG_KEY_REGEX = RegExp(`^${TAG_KEY_PATTERN}$`);
+export const TAG_VALUE_MAX_LENGTH = 255;
+
 export function getTags(serviceContext: ServiceContext<ServiceConfig>): Tags {
     const serviceParams = serviceContext.params;
 

--- a/src/handel.ts
+++ b/src/handel.ts
@@ -38,12 +38,13 @@ Each phase has its own unique set of arguments it requires`;
 }
 
 function printDeployUsage(deployErrors: string[]): void {
-    const usageMsg = `Usage: handel deploy -c <accountConfig> -e <envsToDeploy> -v <deployVersion>
+    const usageMsg = `Usage: handel deploy -c <accountConfig> -e <envsToDeploy> -v <deployVersion> -t <key1>=<value1>,<key2>=<value2>
 
 Options:
 -c [required] -- Path to account config or base64 encoded JSON string of config
 -e [required] -- A comma-separated list of environments from your handel file to deploy
 -d -- If this flag is set, verbose debug output will be enabled
+-t -- If this flag is set, specifies a comma-separated list of extra application-level tags to apply to resources.
 
 Errors:
   ${deployErrors.join('\n  ')}`;

--- a/test/cli/cli-test.ts
+++ b/test/cli/cli-test.ts
@@ -50,13 +50,27 @@ describe('cli module', () => {
             expect(errors[0]).to.contain(`'-e' parameter is required`);
         });
 
-        it('should suceed if all params are provided', () => {
+        it('should succeed if all params are provided', () => {
             const argv = {
                 e: 'dev,prod',
-                c: `${__dirname}/../test-account-config.yml`
+                c: `${__dirname}/../test-account-config.yml`,
+                t: 'foo=bar,bar=baz'
             };
             const errors = cli.validateDeployArgs(argv, handelFile);
             expect(errors.length).to.equal(0);
+        });
+
+        it('should fail if there are invalid tags', () => {
+            const argv = {
+                e: 'dev,prod',
+                c: `${__dirname}/../test-account-config.yml`,
+                t: 'foo=bar,bar,baz=,ab{}cd=abc'
+            };
+            const errors = cli.validateDeployArgs(argv, handelFile);
+            expect(errors).to.have.lengthOf(3);
+            expect(errors).to.include(`The value for -t is invalid: 'bar'`);
+            expect(errors).to.include(`The value for -t is invalid: 'baz='`);
+            expect(errors).to.include(`The value for -t is invalid: 'ab{}cd=abc'`);
         });
     });
 


### PR DESCRIPTION
Yet another thing related to #332.

Allows the user to pass a -t flag to `handel deploy` with a list of
key-value pairs. These will augment or override any tags that are
specified in the handelfile.