### PR TITLE
Tag handel account-wide resources

### DIFF
--- a/docs/handel-basics/account-config-file.rst
+++ b/docs/handel-basics/account-config-file.rst
@@ -60,3 +60,6 @@ The account config file is a YAML file that must contain the following informati
   rds_subnet_group: <string> # The name of the RDS subnet group to use when deploying RDS clusters.
   required_tags: # Optional. Allows an organization to enforce rules about tagging resources. This is a list of tag names that must be set on each Handel application or resource.
   - <string>
+  handel_resource_tags: # Optional. Sets tags to be applied to any generic resources, such as lambda functions, that Handel uses internally.
+    <key>: <value>
+    <key>: <value>

--- a/src/account-config/default-account-config.ts
+++ b/src/account-config/default-account-config.ts
@@ -47,7 +47,7 @@ async function getSubnetGroups(vpcId: string, subnetIds: string[]): Promise<AWS.
     const stack = await cloudFormationCalls.getStack(stackName);
     if (!stack) {
         winston.info(`Creating subnet groups for default VPC`);
-        const cfStack = await cloudFormationCalls.createStack(stackName, compiledTemplate, [], []);
+        const cfStack = await cloudFormationCalls.createStack(stackName, compiledTemplate, [], {});
         winston.info(`Created subnet groups for default VPC`);
         return cfStack;
     }

--- a/src/aws/aws-tags.ts
+++ b/src/aws/aws-tags.ts
@@ -1,0 +1,18 @@
+import {Tags} from '../datatypes';
+
+export interface GenericAWSTag {
+    Key: string;
+    Value: string;
+}
+
+export type GenericAWSTagSet = GenericAWSTag[];
+
+export function toAWSTagStyle(tags: Tags): GenericAWSTagSet {
+    return Object.getOwnPropertyNames(tags)
+        .map(name => {
+            return {
+                Key: name,
+                Value: tags[name]
+            };
+        });
+}

--- a/src/aws/aws-wrapper.ts
+++ b/src/aws/aws-wrapper.ts
@@ -125,6 +125,10 @@ const awsWrapper = {
         deleteObjects: (params: AWS.S3.DeleteObjectsRequest) => {
             const s3 = new AWS.S3({apiVersion: '2006-03-01'});
             return s3.deleteObjects(params).promise();
+        },
+        putBucketTagging: (params: AWS.S3.PutBucketTaggingRequest) => {
+            const s3 = new AWS.S3({apiVersion: '2006-03-01'});
+            return s3.putBucketTagging(params).promise();
         }
     },
     ssm: {

--- a/src/common/deploy-phase-common.ts
+++ b/src/common/deploy-phase-common.ts
@@ -143,7 +143,7 @@ export async function uploadFileToHandelBucket(diskFilePath: string, artifactPre
     const bucketName = `handel-${accountConfig.region}-${accountConfig.account_id}`;
 
     const artifactKey = `${artifactPrefix}/${s3FileName}`;
-    const bucket = await s3Calls.createBucketIfNotExists(bucketName, accountConfig.region); // Ensure Handel bucket exists in this region
+    const bucket = await s3Calls.createBucketIfNotExists(bucketName, accountConfig.region, accountConfig.handel_resource_tags); // Ensure Handel bucket exists in this region
     const s3ObjectInfo = await s3Calls.uploadFile(bucketName, artifactKey, diskFilePath);
     await s3Calls.cleanupOldVersionsOfFiles(bucketName, artifactPrefix);
     return s3ObjectInfo;

--- a/src/common/s3-deployers-common.ts
+++ b/src/common/s3-deployers-common.ts
@@ -27,7 +27,7 @@ export async function createLoggingBucketIfNotExists(accountConfig: AccountConfi
     };
 
     const compiledTemplate = await handlebarsUtils.compileTemplate(`${__dirname}/s3-static-site-logging-bucket.yml`, handlebarsParams);
-    const deployedStack = await deployPhaseCommon.deployCloudFormationStack(stackName, compiledTemplate, [], false, 'Logging Bucket for S3 Static Sites', {});
+    const deployedStack = await deployPhaseCommon.deployCloudFormationStack(stackName, compiledTemplate, [], false, 'Logging Bucket for S3 Static Sites', accountConfig.handel_resource_tags || {});
     return cloudFormationCalls.getOutput('BucketName', deployedStack);
 }
 

--- a/src/datatypes/index.ts
+++ b/src/datatypes/index.ts
@@ -31,6 +31,7 @@ export interface AccountConfig {
     rds_subnet_group: string;
     redshift_subnet_group: string;
     required_tags?: string[];
+    handel_resource_tags?: Tags;
     // Allow for account config extensions. Allows future plugins to have their own account-level settings.
     [key: string]: any;
 }

--- a/src/services/ecs/cluster-auto-scaling.ts
+++ b/src/services/ecs/cluster-auto-scaling.ts
@@ -105,7 +105,7 @@ export async function createAutoScalingLambdaIfNotExists(accountConfig: AccountC
         };
         const compiledTemplate = await handlebarsUtils.compileTemplate(`${__dirname}/cluster-scaling-lambda/scaling-lambda-template.yml`, handlebarsParams);
         winston.info(`Creating Lambda for ECS auto-scaling`);
-        return cloudformationCalls.createStack(stackName, compiledTemplate, [], null);
+        return cloudformationCalls.createStack(stackName, compiledTemplate, [], accountConfig.handel_resource_tags);
     }
     else {
         return stack;
@@ -131,7 +131,7 @@ export async function createDrainingLambdaIfNotExists(accountConfig: AccountConf
 
         const compiledTemplate = await handlebarsUtils.compileTemplate(`${__dirname}/cluster-draining-lambda/cluster-draining-template.yml`, handlebarsParams);
         winston.info(`Creating Lambda for ECS draining`);
-        return cloudformationCalls.createStack(stackName, compiledTemplate, [], null);
+        return cloudformationCalls.createStack(stackName, compiledTemplate, [], accountConfig.handel_resource_tags);
     }
     else {
         // Stack already exists

--- a/test/aws/aws-tags-test.ts
+++ b/test/aws/aws-tags-test.ts
@@ -1,0 +1,23 @@
+import { expect } from 'chai';
+import * as tags from '../../src/aws/aws-tags';
+
+describe('aws-tags', () => {
+    describe('toAWSTagStyle', () => {
+        it('should convert simple key-values to an array of AWS tags', () => {
+            const input = {
+                tag: 'value',
+                another: 'another value'
+            };
+            const result = tags.toAWSTagStyle(input);
+            expect(result).to.have.lengthOf(2);
+            expect(result).to.deep.include({
+                Key: 'tag',
+                Value: 'value'
+            });
+            expect(result).to.deep.include({
+                Key: 'another',
+                Value: 'another value'
+            });
+        });
+    });
+});


### PR DESCRIPTION
Fixes #360.

Adds an optional field to the account config file, handel_resource_tags,
which contains tags that Handel will apply to any non-application,
account-wide resources that Handel may create.

This change will not be able to modify any resources that already exist.
Those will either have to be deleted and re-created, or one can manually
add the tags to the cloudformation templates that Handel creates to add
the tags.