### PR TITLE
API Gateway Custom Domain Support

### DIFF
--- a/docs/supported-services/apigateway.rst
+++ b/docs/supported-services/apigateway.rst
@@ -10,6 +10,11 @@ No Authorizer Lambdas
 ~~~~~~~~~~~~~~~~~~~~~
 This service doesn't yet support specifying authorizer lambdas.
 
+No Regional Endpoints
+~~~~~~~~~~~~~~~~~~~~~
+
+This service currently supports only edge-optimized API Gateways.
+
 Parameters
 ----------
 
@@ -79,7 +84,7 @@ The Custom Domains section is defined by the following schema:
 
     custom_domains:
     - dns_name: <string> # The DNS name for the API Gateway. Must be a valid DNS name.
-      https_certificate: <arn> # The Amazon Certificate Manager certificate to use. This certificate must be in the same region as the API Gateway instance.
+      https_certificate: <arn> # The Amazon Certificate Manager certificate to use. This certificate must be in the us-east-1 region.
 
 See :ref:`route53zone-records` for more information on how DNS records will be created.
 

--- a/docs/supported-services/apigateway.rst
+++ b/docs/supported-services/apigateway.rst
@@ -51,11 +51,37 @@ Parameters
      - No
      - false
      - If true, your Lambdas will be deployed inside your account's VPC.
+   * - custom_domains
+     - Array of :ref:`apigateway-custom-domains`
+     - No
+     -
+     - An array of custom domains to map to this API Gateway instance.
    * - tags
      - :ref:`tagging-resources`
      - No
      - 
      - Any tags you want to apply to your API Gateway app.
+
+.. _apigateway-custom-domains:
+
+Custom Domain Mappings
+~~~~~~~~~~~~~~~~~~~~~~
+.. NOTE::
+
+    This service does not currently support sharing custom domains between API Gateway instances using Base Path Mappings.
+    At this time, you can only map one API Gateway to one custom domain, with no path mapping.
+
+API Gateway allows for mapping gateways to one or more custom domains. These custom domains are always served via HTTPS.
+
+The Custom Domains section is defined by the following schema:
+
+.. code-block:: yaml
+
+    custom_domains:
+    - dns_name: <string> # The DNS name for the API Gateway. Must be a valid DNS name.
+      https_certificate: <arn> # The Amazon Certificate Manager certificate to use. This certificate must be in the same region as the API Gateway instance.
+
+See :ref:`route53zone-records` for more information on how DNS records will be created.
 
 .. _apigateway-proxy:
 

--- a/docs/supported-services/route53zone.rst
+++ b/docs/supported-services/route53zone.rst
@@ -98,11 +98,13 @@ DNS Records
 
 Certain supported services can create an alias record in this zone.  The currently supported services are:
 
-* Beanstalk
-* ECS
-* S3 Static Site
+* :ref:`API Gateway <apigateway-custom-domains>`
+* :ref:`Beanstalk <beanstalk-routing>`
+* :ref:`ECS <ecs-loadbalancer>`
+* :ref:`ECS (Fargate) <ecs-fargate-loadbalancer>`
+* :ref:`S3 Static Site <s3staticsite-cloudfront>`
 
-Beanstalk and ECS can support multiple DNS entries.
+API Gateway, Beanstalk, ECS, and ECS (Fargate) can support multiple DNS entries.
 
 See the individual service documentation for how to define the DNS names.
 

--- a/handel/package-lock.json
+++ b/handel/package-lock.json
@@ -5589,14 +5589,6 @@
 			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
 			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
 		},
-		"string_decoder": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-			"requires": {
-				"safe-buffer": "5.1.1"
-			}
-		},
 		"string-width": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -5605,6 +5597,14 @@
 				"code-point-at": "1.1.0",
 				"is-fullwidth-code-point": "1.0.0",
 				"strip-ansi": "3.0.1"
+			}
+		},
+		"string_decoder": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"requires": {
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"strip-ansi": {

--- a/handel/src/services/apigateway/common.ts
+++ b/handel/src/services/apigateway/common.ts
@@ -18,13 +18,13 @@ import * as _ from 'lodash';
 import * as cloudformationCalls from '../../aws/cloudformation-calls';
 import * as deployPhaseCommon from '../../common/deploy-phase-common';
 import * as util from '../../common/util';
-import { DeployContext, EnvironmentVariables, PreDeployContext, ServiceContext } from '../../datatypes/index';
+import { DeployContext, EnvironmentVariables, PreDeployContext, ServiceContext } from '../../datatypes';
 import { APIGatewayConfig } from './config-types';
 
 export function getEnvVarsForService(ownEnvironmentVariables: EnvironmentVariables | undefined, ownServiceContext: ServiceContext<APIGatewayConfig>, dependenciesDeployContexts: DeployContext[]) {
     let returnEnvVars = {};
 
-    if(ownEnvironmentVariables) {
+    if (ownEnvironmentVariables) {
         returnEnvVars = _.assign(returnEnvVars, ownEnvironmentVariables);
     }
 

--- a/handel/src/services/apigateway/common.ts
+++ b/handel/src/services/apigateway/common.ts
@@ -16,10 +16,11 @@
  */
 import * as _ from 'lodash';
 import * as cloudformationCalls from '../../aws/cloudformation-calls';
+import * as route53 from '../../aws/route53-calls';
 import * as deployPhaseCommon from '../../common/deploy-phase-common';
 import * as util from '../../common/util';
 import { DeployContext, EnvironmentVariables, PreDeployContext, ServiceContext } from '../../datatypes';
-import { APIGatewayConfig } from './config-types';
+import {APIGatewayConfig, CustomDomain} from './config-types';
 
 export function getEnvVarsForService(ownEnvironmentVariables: EnvironmentVariables | undefined, ownServiceContext: ServiceContext<APIGatewayConfig>, dependenciesDeployContexts: DeployContext[]) {
     let returnEnvVars = {};
@@ -63,4 +64,23 @@ export function getPolicyStatementsForLambdaRole(serviceContext: ServiceContext<
     ownPolicyStatements = ownPolicyStatements.concat(deployPhaseCommon.getAppSecretsAccessPolicyStatements(serviceContext));
 
     return deployPhaseCommon.getAllPolicyStatementsForServiceRole(ownPolicyStatements, dependenciesDeployContexts);
+}
+
+export async function getCustomDomainHandlebarsParams(customDomains?: CustomDomain[]): Promise<any[]> {
+    if (!customDomains) {
+      return [];
+    }
+    const zones = await route53.listHostedZones();
+    return customDomains.map(domain => {
+        const {dns_name, https_certificate} = domain;
+        const hostedZone = route53.getBestMatchingHostedZone(dns_name, zones);
+        if (!hostedZone) {
+            throw new Error(`Unable to find hosted zone for DNS name '${dns_name}'`);
+        }
+        return {
+            name: dns_name,
+            zoneId: hostedZone.Id,
+            certificateArn: https_certificate
+        };
+    });
 }

--- a/handel/src/services/apigateway/config-types.ts
+++ b/handel/src/services/apigateway/config-types.ts
@@ -23,6 +23,7 @@ export interface APIGatewayConfig extends ServiceConfig {
     binary_media_types?: string[];
     environment_variables?: EnvironmentVariables;
     vpc?: boolean;
+    custom_domains?: CustomDomain[];
 }
 
 export interface ProxyPassthroughConfig {
@@ -32,4 +33,10 @@ export interface ProxyPassthroughConfig {
     memory?: number;
     timeout?: number;
     environment_variables?: EnvironmentVariables;
+}
+
+export interface CustomDomain {
+    dns_name: string;
+    https_certificate: string;
+    // We could eventually add a 'path' here, but without allowing shared custom domains, there really isn't a use case for it
 }

--- a/handel/src/services/apigateway/proxy/apigateway-proxy-template.yml
+++ b/handel/src/services/apigateway/proxy/apigateway-proxy-template.yml
@@ -120,6 +120,36 @@ Resources:
               responses: {}
         swagger: '2.0'
 
+  {{#each customDomains}}
+  CustomDomain{{logicalId name}}:
+    Type: AWS::ApiGateway::DomainName
+    Properties:
+      CertificateArn: {{certificateArn}}
+      DomainName: {{name}}
+  CustomDomainBasePath{{logicalId name}}:
+    Type: AWS::ApiGateway::BasePathMapping
+    Properties:
+      DomainName: !Ref CustomDomain{{logicalId name}}
+      RestApiId: !Ref ServerlessRestApi
+      Stage: {{../stageName}}
+  CustomDomainDns{{logicalId name}}:
+    Type: AWS::Route53::RecordSetGroup
+    Properties:
+      HostedZoneId: {{zoneId}}
+      Comment: Handel-created DNS Records for {{name}}
+      RecordSets:
+      - Name: {{name}}
+        Type: A
+        AliasTarget:
+          HostedZoneId: Z2FDTNDATAQYW2 # This is Cloudfront's zone
+          DNSName: !GetAtt CustomDomain{{logicalId name}}.DistributionDomainName
+      - Name: {{name}}
+        Type: AAAA
+        AliasTarget:
+          HostedZoneId: Z2FDTNDATAQYW2 # This is Cloudfront's zone
+          DNSName: !GetAtt CustomDomain{{logicalId name}}.DistributionDomainName
+  {{/each}}
+
 Outputs:
   LambdaArn:
     Value:

--- a/handel/src/services/apigateway/proxy/proxy-passthrough-deploy-type.ts
+++ b/handel/src/services/apigateway/proxy/proxy-passthrough-deploy-type.ts
@@ -19,7 +19,6 @@ import * as winston from 'winston';
 import * as deployPhaseCommon from '../../../common/deploy-phase-common';
 import * as handlebarsUtils from '../../../common/handlebars-utils';
 import {getTags} from '../../../common/tagging-common';
-import * as util from '../../../common/util';
 import {DeployContext, PreDeployContext, ServiceConfig, ServiceContext} from '../../../datatypes';
 import * as apigatewayCommon from '../common';
 import {APIGatewayConfig} from '../config-types';
@@ -102,7 +101,6 @@ function getParam(params: any, oldParamName: string, newParamName: string | unde
 }
 
 export function check(serviceContext: ServiceContext<APIGatewayConfig>, dependenciesServiceContexts: Array<ServiceContext<ServiceConfig>>, serviceName: string): string[] {
-    const serviceDeployers = util.getServiceDeployers();
     const checkErrors: string[] = [];
 
     const params = serviceContext.params;
@@ -110,13 +108,6 @@ export function check(serviceContext: ServiceContext<APIGatewayConfig>, dependen
     checkForParam(params, 'lambda_runtime', 'runtime', checkErrors);
     checkForParam(params, 'handler_function', 'handler', checkErrors);
 
-    if (dependenciesServiceContexts) {
-        dependenciesServiceContexts.forEach((dependencyServiceContext) => {
-            if (serviceDeployers[dependencyServiceContext.serviceType].producedDeployOutputTypes.includes('securityGroups') && !params.vpc) {
-                checkErrors.push(`${serviceName} - The 'vpc' parameter is required and must be true when declaring dependencies of type ${dependencyServiceContext.serviceType}`);
-            }
-        });
-    }
     return checkErrors;
 }
 

--- a/handel/src/services/apigateway/proxy/proxy-passthrough-deploy-type.ts
+++ b/handel/src/services/apigateway/proxy/proxy-passthrough-deploy-type.ts
@@ -32,7 +32,7 @@ async function uploadDeployableArtifactToS3(serviceContext: ServiceContext<APIGa
     return s3ArtifactInfo;
 }
 
-function getCompiledApiGatewayTemplate(stackName: string, ownServiceContext: ServiceContext<APIGatewayConfig>, dependenciesDeployContexts: DeployContext[], s3ObjectInfo: AWS.S3.ManagedUpload.SendData, ownPreDeployContext: PreDeployContext) {
+async function getCompiledApiGatewayTemplate(stackName: string, ownServiceContext: ServiceContext<APIGatewayConfig>, dependenciesDeployContexts: DeployContext[], s3ObjectInfo: AWS.S3.ManagedUpload.SendData, ownPreDeployContext: PreDeployContext) {
     const serviceParams = ownServiceContext.params;
     const accountConfig = ownServiceContext.accountConfig;
 
@@ -72,6 +72,10 @@ function getCompiledApiGatewayTemplate(stackName: string, ownServiceContext: Ser
         handlebarsParams.vpc = true;
         handlebarsParams.vpcSecurityGroupIds = apigatewayCommon.getSecurityGroups(ownPreDeployContext);
         handlebarsParams.vpcSubnetIds = accountConfig.private_subnets;
+    }
+
+    if (serviceParams.custom_domains) {
+        handlebarsParams.customDomains = await apigatewayCommon.getCustomDomainHandlebarsParams(serviceParams.custom_domains);
     }
 
     return handlebarsUtils.compileTemplate(`${__dirname}/apigateway-proxy-template.yml`, handlebarsParams);

--- a/handel/src/services/apigateway/swagger/apigateway-swagger-template.yml
+++ b/handel/src/services/apigateway/swagger/apigateway-swagger-template.yml
@@ -113,6 +113,37 @@ Resources:
         Bucket: {{swaggerS3ArtifactInfo.Bucket}}
         Key: {{swaggerS3ArtifactInfo.Key}}
 
+  {{#each customDomains}}
+  CustomDomain{{logicalId name}}:
+    Type: AWS::ApiGateway::DomainName
+    Properties:
+      CertificateArn: {{certificateArn}}
+      DomainName: {{name}}
+  CustomDomainBasePath{{logicalId name}}:
+    Type: AWS::ApiGateway::BasePathMapping
+    Properties:
+      DomainName: !Ref CustomDomain{{logicalId name}}
+      RestApiId: !Ref RestApi
+      Stage: {{../stageName}}
+  CustomDomainDns{{logicalId name}}:
+    Type: AWS::Route53::RecordSetGroup
+    Properties:
+      HostedZoneId: {{zoneId}}
+      Comment: Handel-created DNS Records for {{name}}
+      RecordSets:
+      - Name: {{name}}
+        Type: A
+        AliasTarget:
+          HostedZoneId: Z2FDTNDATAQYW2 # This is Cloudfront's zone
+          DNSName: !GetAtt CustomDomain{{logicalId name}}.DistributionDomainName
+      - Name: {{name}}
+        Type: AAAA
+        AliasTarget:
+          HostedZoneId: Z2FDTNDATAQYW2 # This is Cloudfront's zone
+          DNSName: !GetAtt CustomDomain{{logicalId name}}.DistributionDomainName
+  {{/each}}
+
+
 Outputs:
   RestApiId:
     Value:

--- a/handel/src/services/apigateway/swagger/swagger-deploy-type.ts
+++ b/handel/src/services/apigateway/swagger/swagger-deploy-type.ts
@@ -91,7 +91,7 @@ function getLambdasToCreate(stackName: string, swagger: any, ownServiceContext: 
     return functionConfigs;
 }
 
-function getCompiledApiGatewayTemplate(stackName: string, ownServiceContext: ServiceContext<APIGatewayConfig>, ownPreDeployContext: PreDeployContext, dependenciesDeployContexts: DeployContext[], lambdasToCreate: any[], swaggerS3ArtifactInfo: AWS.S3.ManagedUpload.SendData, stackTags: Tags): Promise<string> {
+async function getCompiledApiGatewayTemplate(stackName: string, ownServiceContext: ServiceContext<APIGatewayConfig>, ownPreDeployContext: PreDeployContext, dependenciesDeployContexts: DeployContext[], lambdasToCreate: any[], swaggerS3ArtifactInfo: AWS.S3.ManagedUpload.SendData, stackTags: Tags): Promise<string> {
     const params = ownServiceContext.params;
     const accountConfig = ownServiceContext.accountConfig;
 
@@ -119,6 +119,10 @@ function getCompiledApiGatewayTemplate(stackName: string, ownServiceContext: Ser
         handlebarsParams.vpc = true;
         handlebarsParams.vpcSecurityGroupIds = apigatewayCommon.getSecurityGroups(ownPreDeployContext);
         handlebarsParams.vpcSubnetIds = accountConfig.private_subnets;
+    }
+
+    if (params.custom_domains) {
+        handlebarsParams.customDomains = await apigatewayCommon.getCustomDomainHandlebarsParams(params.custom_domains);
     }
 
     return handlebarsUtils.compileTemplate(`${__dirname}/apigateway-swagger-template.yml`, handlebarsParams);

--- a/handel/test/services/apigateway/proxy/proxy-passthrough-deploy-type-test.ts
+++ b/handel/test/services/apigateway/proxy/proxy-passthrough-deploy-type-test.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  *
  */
-import { expect } from 'chai';
+import {expect} from 'chai';
 import 'mocha';
 import * as sinon from 'sinon';
 import config from '../../../../src/account-config/account-config';
 import * as deployPhaseCommon from '../../../../src/common/deploy-phase-common';
-import { AccountConfig, DeployContext, PreDeployContext, ServiceConfig, ServiceContext } from '../../../../src/datatypes';
-import { APIGatewayConfig } from '../../../../src/services/apigateway/config-types';
+import {AccountConfig, DeployContext, PreDeployContext, ServiceConfig, ServiceContext} from '../../../../src/datatypes';
+import {APIGatewayConfig} from '../../../../src/services/apigateway/config-types';
 import * as proxyPassthroughDeployType from '../../../../src/services/apigateway/proxy/proxy-passthrough-deploy-type';
 
 describe('apigateway proxy deploy type', () => {
@@ -48,7 +48,7 @@ describe('apigateway proxy deploy type', () => {
     });
 
     describe('check', () => {
-        it('should require the \'path_to_code\' param', function() {
+        it('should require the \'path_to_code\' param', function () {
             this.timeout(10000);
             delete serviceContext.params.proxy!.path_to_code;
             const errors = proxyPassthroughDeployType.check(serviceContext, [], 'API Gateway');
@@ -56,7 +56,7 @@ describe('apigateway proxy deploy type', () => {
             expect(errors[0]).to.contain('\'path_to_code\' parameter is required');
         });
 
-        it('should require the \'runtime\' param', function() {
+        it('should require the \'runtime\' param', function () {
             this.timeout(10000);
             delete serviceContext.params.proxy!.runtime;
             const errors = proxyPassthroughDeployType.check(serviceContext, [], 'API Gateway');
@@ -64,7 +64,7 @@ describe('apigateway proxy deploy type', () => {
             expect(errors[0]).to.contain('\'runtime\' parameter is required');
         });
 
-        it('should require the \'handler\' param', function() {
+        it('should require the \'handler\' param', function () {
             this.timeout(10000);
             delete serviceContext.params.proxy!.handler;
             const errors = proxyPassthroughDeployType.check(serviceContext, [], 'API Gateway');
@@ -72,26 +72,6 @@ describe('apigateway proxy deploy type', () => {
             expect(errors[0]).to.contain('\'handler\' parameter is required');
         });
 
-        it('should fail if vpc is false and a dependency producing security groups is declared', function() {
-            this.timeout(10000);
-            serviceContext.params = {
-                type: 'apigateway',
-                proxy: {
-                    path_to_code: '.',
-                    handler: 'index.handler',
-                    runtime: 'node.js6.3'
-                },
-                dependencies: [
-                    'FakeDependency'
-                ]
-            };
-            const dependenciesServiceContexts = [
-                new ServiceContext('FakeApp', 'FakeEnv', 'FakeDependency', 'mysql', {type: 'mysql'}, accountConfig)
-            ];
-            const errors = proxyPassthroughDeployType.check(serviceContext, dependenciesServiceContexts, 'API Gateway');
-            expect(errors.length).to.equal(1);
-            expect(errors[0]).to.contain('\'vpc\' parameter is required and must be true when declaring dependencies of type');
-        });
     });
 
     describe('deploy', () => {

--- a/handel/test/services/apigateway/proxy/proxy-passthrough-deploy-type-test.ts
+++ b/handel/test/services/apigateway/proxy/proxy-passthrough-deploy-type-test.ts
@@ -20,7 +20,7 @@ import * as sinon from 'sinon';
 import config from '../../../../src/account-config/account-config';
 import * as route53 from '../../../../src/aws/route53-calls';
 import * as deployPhaseCommon from '../../../../src/common/deploy-phase-common';
-import {AccountConfig, DeployContext, PreDeployContext, ServiceConfig, ServiceContext} from '../../../../src/datatypes';
+import {AccountConfig, DeployContext, PreDeployContext, ServiceContext} from '../../../../src/datatypes';
 import {APIGatewayConfig} from '../../../../src/services/apigateway/config-types';
 import * as proxyPassthroughDeployType from '../../../../src/services/apigateway/proxy/proxy-passthrough-deploy-type';
 
@@ -49,7 +49,7 @@ describe('apigateway proxy deploy type', () => {
     });
 
     describe('check', () => {
-        it('should require the \'path_to_code\' param', function () {
+        it('should require the \'path_to_code\' param', function() {
             this.timeout(10000);
             delete serviceContext.params.proxy!.path_to_code;
             const errors = proxyPassthroughDeployType.check(serviceContext, [], 'API Gateway');
@@ -57,7 +57,7 @@ describe('apigateway proxy deploy type', () => {
             expect(errors[0]).to.contain('\'path_to_code\' parameter is required');
         });
 
-        it('should require the \'runtime\' param', function () {
+        it('should require the \'runtime\' param', function() {
             this.timeout(10000);
             delete serviceContext.params.proxy!.runtime;
             const errors = proxyPassthroughDeployType.check(serviceContext, [], 'API Gateway');
@@ -65,7 +65,7 @@ describe('apigateway proxy deploy type', () => {
             expect(errors[0]).to.contain('\'runtime\' parameter is required');
         });
 
-        it('should require the \'handler\' param', function () {
+        it('should require the \'handler\' param', function() {
             this.timeout(10000);
             delete serviceContext.params.proxy!.handler;
             const errors = proxyPassthroughDeployType.check(serviceContext, [], 'API Gateway');

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,6 +2,16 @@
 	"requires": true,
 	"lockfileVersion": 1,
 	"dependencies": {
+		"JSONStream": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
+			"integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+			"dev": true,
+			"requires": {
+				"jsonparse": "1.3.1",
+				"through": "2.3.8"
+			}
+		},
 		"acorn": {
 			"version": "5.4.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
@@ -642,8 +652,8 @@
 			"integrity": "sha512-8MD05yN0Zb6aRsZnFX1ET+8rHWfWJk+my7ANCJZBU2mhz7TSB1fk2vZhkrwVy/PCllcTYAP/1T1NiWQ7Z01mKw==",
 			"dev": true,
 			"requires": {
-				"is-text-path": "1.0.1",
 				"JSONStream": "1.3.2",
+				"is-text-path": "1.0.1",
 				"lodash": "4.17.4",
 				"meow": "3.7.0",
 				"split2": "2.2.0",
@@ -1579,16 +1589,6 @@
 			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
 			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
 			"dev": true
-		},
-		"JSONStream": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
-			"integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
-			"dev": true,
-			"requires": {
-				"jsonparse": "1.3.1",
-				"through": "2.3.8"
-			}
 		},
 		"kind-of": {
 			"version": "3.2.2",
@@ -2588,15 +2588,6 @@
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
 		},
-		"string_decoder": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "5.1.1"
-			}
-		},
 		"string-width": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -2605,6 +2596,15 @@
 			"requires": {
 				"is-fullwidth-code-point": "2.0.0",
 				"strip-ansi": "4.0.0"
+			}
+		},
+		"string_decoder": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"strip-ansi": {


### PR DESCRIPTION
This resolves #347.

This implements the simplest-possible version of custom domain names.  It only allows for a custom domain name to be used by a single API Gateway, and doesn't allow for path mappings (everything is at /).  If we want to enhance that later, we can.

I also factored some common checking logic between the two API gateway deployers out into the main service file.  