### PR TITLE
Allow user to set DynamoDB table names

### DIFF
--- a/docs/supported-services/dynamodb.rst
+++ b/docs/supported-services/dynamodb.rst
@@ -27,6 +27,11 @@ Parameters
      - Yes
      - 
      - This must always be *dynamodb* for this service type.
+   * - table_name
+     - string
+     - No
+     - '<app name>-<environment>-<service name>-dynamodb'
+     - Sets the name of the Dynamod table to be created.
    * - partition_key
      - :ref:`dynamodb-partition-key`
      - Yes

--- a/handel/src/services/dynamodb/config-types.ts
+++ b/handel/src/services/dynamodb/config-types.ts
@@ -23,6 +23,7 @@ export interface DynamoDBServiceEventConsumer extends ServiceEventConsumer {
 }
 
 export interface DynamoDBConfig extends ServiceConfig {
+    table_name?: string;
     partition_key: KeyDefinition;
     sort_key?: KeyDefinition;
     provisioned_throughput?: ProvisionedThroughput;

--- a/handel/src/services/dynamodb/index.ts
+++ b/handel/src/services/dynamodb/index.ts
@@ -210,7 +210,7 @@ async function getCompiledDynamoTemplate(stackName: string, ownServiceContext: S
     const throughputConfig = autoscaling.getThroughputConfig(serviceParams.provisioned_throughput, null);
 
     const handlebarsParams: any = {
-        tableName: stackName,
+        tableName: serviceParams.table_name || stackName,
         attributeDefinitions: getDefinedAttributes(ownServiceContext),
         tablePartitionKeyName: serviceParams.partition_key.name,
         tableReadCapacityUnits: throughputConfig.read.initial,
@@ -236,6 +236,8 @@ async function getCompiledDynamoTemplate(stackName: string, ownServiceContext: S
     return handlebarsUtils.compileTemplate(`${__dirname}/dynamodb-template.yml`, handlebarsParams);
 }
 
+const TABLE_NAME_ALLOWED_PATTERN = /^[a-zA-Z0-9_\-.]{3,255}$/;
+
 /**
  * Service Deployer Contract Methods
  * See https://github.com/byu-oit-appdev/handel/wiki/Creating-a-New-Service-Deployer#service-deployer-contract
@@ -245,6 +247,10 @@ async function getCompiledDynamoTemplate(stackName: string, ownServiceContext: S
 export function check(serviceContext: ServiceContext<DynamoDBConfig>, dependenciesServiceContexts: Array<ServiceContext<ServiceConfig>>): string[] {
     const errors = [];
     const params = serviceContext.params;
+
+    if (params.table_name && !TABLE_NAME_ALLOWED_PATTERN.test(params.table_name)) {
+        errors.push(`${SERVICE_NAME} - The table_name parameter must be between 3 and 255 characters long and may only include alphanumeric characters, underscores (_), hyphens (-), and dots (.)`);
+    }
 
     if (!params.partition_key) {
         errors.push(`${SERVICE_NAME} - The 'partition_key' section is required`);


### PR DESCRIPTION
There may be cases where we need our DDB table to have a specific name.  The specific case I'm dealing with is CAS, which, when integrated with Dynamo, expects tables with certain, non-configurable names to exist.