### PR TITLE
not checking resources that don't exist

### DIFF
--- a/handel/src/services/stepfunctions/index.ts
+++ b/handel/src/services/stepfunctions/index.ts
@@ -61,9 +61,9 @@ export function check(serviceContext: ServiceContext<StepFunctionsConfig>, depen
         const startIsString = typeof start == 'string';
         const statesIsObject = states instanceof Object;
         if (statesIsObject) {
-            const dependencies: string[] = serviceContext.params.dependencies || [];
+            const dependencies: string[] = dependenciesServiceContexts.map(context => context.serviceName);
             for (const key in states) {
-                if (states.hasOwnProperty(key) && dependencies.indexOf(states[key].Resource) == -1) {
+                if (states.hasOwnProperty(key) && states[key].hasOwnProperty('Resource') && dependencies.indexOf(states[key].Resource) == -1) {
                     errors.push(`${SERVICE_NAME} - Service '${states[key].Resource}' not found in dependencies.`)
                 }
             }

--- a/handel/test/services/stepfunctions/stepfunctions-test.ts
+++ b/handel/test/services/stepfunctions/stepfunctions-test.ts
@@ -104,7 +104,6 @@ describe('stepfunctions deployer', () => {
             serviceContext.params.dependencies = ['only-lambda'];
             sandbox.stub(util, 'readYamlFileSync').returns(getSimpleMachine());
             const errors = stepfunctions.check(serviceContext, getSimpleDependencies());
-            console.log(errors);
             expect(errors.length).to.equal(0);
         });
 
@@ -134,6 +133,15 @@ describe('stepfunctions deployer', () => {
             const errors = stepfunctions.check(serviceContext, dependencies);
             expect(errors.length).to.equal(1);
             expect(errors[0]).to.contain('not found in dependencies');
+        });
+
+        it('should only check for service dependencies on states with a resource field', () => {
+            const machine = getSimpleMachine();
+            machine.OtherState = {Type: 'Succeed'};
+            serviceContext.params.definition = 'state_machine.yml';
+            sandbox.stub(util, 'readYamlFileSync').returns(machine);
+            const errors = stepfunctions.check(serviceContext, getSimpleDependencies());
+            expect(errors.length).to.equal(0);
         });
     });
 


### PR DESCRIPTION
Without these changes, the stepfunctions service only supports 'Task' state type (expecting all states to have a 'Resource' field with a dependency's name.