### PR TITLE
Handel Extensions Episode II: Attack of the CLI

### DIFF
--- a/extension-api/extension-api.ts
+++ b/extension-api/extension-api.ts
@@ -15,6 +15,7 @@
  *
  */
 import { EC2 } from 'aws-sdk';
+import { Tags } from '../handel/src/datatypes';
 
 /***********************************
  * Types for the Extension contract
@@ -200,3 +201,4 @@ export interface UnPreDeployContext {
 export interface Tags {
     [key: string]: string;
 }
+

--- a/handel/gulpfile.js
+++ b/handel/gulpfile.js
@@ -22,3 +22,7 @@ gulp.task('compile', () => {
     )
     .pipe(gulp.dest('dist'));  
 });
+
+gulp.task('watch', ['build'], () => {
+    gulp.watch('src/**/*.ts', ['compile']);
+});

--- a/handel/package-lock.json
+++ b/handel/package-lock.json
@@ -2789,6 +2789,14 @@
         "glogg": "1.0.1"
       }
     },
+    "handel-extension-api": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/handel-extension-api/-/handel-extension-api-0.25.1.tgz",
+      "integrity": "sha512-3lmQ1mb9u2Lnh88IH2ncoITgZ+p+FJNTb1TBuOkdQNoxI0aFxSoC/2+kOi/C9bD9jvwu462V2p4k65BODxScZg==",
+      "requires": {
+        "aws-sdk": "2.217.1"
+      }
+    },
     "handlebars": {
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
@@ -3617,7 +3625,8 @@
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
     },
     "mixin-deep": {
       "version": "1.3.1",

--- a/handel/package-lock.json
+++ b/handel/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "handel",
-  "version": "0.24.1",
+  "version": "0.25.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -841,6 +841,31 @@
         "supports-color": "5.3.0"
       }
     },
+    "change-case": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-3.0.2.tgz",
+      "integrity": "sha512-Mww+SLF6MZ0U6kdg11algyKd5BARbyM4TbFBepwowYSR5ClfQGCGtxNXgykpN0uF/bstWeaGDT4JWaDh8zWAHA==",
+      "requires": {
+        "camel-case": "3.0.0",
+        "constant-case": "2.0.0",
+        "dot-case": "2.1.1",
+        "header-case": "1.0.1",
+        "is-lower-case": "1.1.3",
+        "is-upper-case": "1.1.2",
+        "lower-case": "1.1.4",
+        "lower-case-first": "1.0.2",
+        "no-case": "2.3.2",
+        "param-case": "2.1.1",
+        "pascal-case": "2.0.1",
+        "path-case": "2.1.1",
+        "sentence-case": "2.1.1",
+        "snake-case": "2.1.0",
+        "swap-case": "1.1.2",
+        "title-case": "2.1.1",
+        "upper-case": "1.1.3",
+        "upper-case-first": "1.1.2"
+      }
+    },
     "chardet": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
@@ -1028,10 +1053,9 @@
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
     },
     "commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
-      "dev": true
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
     },
     "common-tags": {
       "version": "1.7.2",
@@ -1073,6 +1097,15 @@
         "inherits": "2.0.3",
         "readable-stream": "2.3.5",
         "typedarray": "0.0.6"
+      }
+    },
+    "constant-case": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz",
+      "integrity": "sha1-QXV2TTidP6nI7NKRhu1gBSQ7akY=",
+      "requires": {
+        "snake-case": "2.1.0",
+        "upper-case": "1.1.3"
       }
     },
     "convert-source-map": {
@@ -1234,6 +1267,14 @@
       "dev": true,
       "requires": {
         "esutils": "2.0.2"
+      }
+    },
+    "dot-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-2.1.1.tgz",
+      "integrity": "sha1-NNzzf1Co6TwrO8qLt/uRVcfaO+4=",
+      "requires": {
+        "no-case": "2.3.2"
       }
     },
     "duplexer2": {
@@ -2748,14 +2789,6 @@
         "glogg": "1.0.1"
       }
     },
-    "handel-extension-api": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/handel-extension-api/-/handel-extension-api-0.25.1.tgz",
-      "integrity": "sha512-3lmQ1mb9u2Lnh88IH2ncoITgZ+p+FJNTb1TBuOkdQNoxI0aFxSoC/2+kOi/C9bD9jvwu462V2p4k65BODxScZg==",
-      "requires": {
-        "aws-sdk": "2.217.1"
-      }
-    },
     "handlebars": {
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
@@ -2842,6 +2875,15 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
+    },
+    "header-case": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-1.0.1.tgz",
+      "integrity": "sha1-lTWXMZfBRLCWE81l0xfvGZY70C0=",
+      "requires": {
+        "no-case": "2.3.2",
+        "upper-case": "1.1.3"
+      }
     },
     "homedir-polyfill": {
       "version": "1.0.1",
@@ -3030,6 +3072,14 @@
         "is-extglob": "2.1.1"
       }
     },
+    "is-lower-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz",
+      "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
+      "requires": {
+        "lower-case": "1.1.4"
+      }
+    },
     "is-my-ip-valid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
@@ -3159,6 +3209,14 @@
       "dev": true,
       "requires": {
         "unc-path-regex": "0.1.2"
+      }
+    },
+    "is-upper-case": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz",
+      "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
+      "requires": {
+        "upper-case": "1.1.3"
       }
     },
     "is-utf8": {
@@ -3461,6 +3519,14 @@
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
       "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
     },
+    "lower-case-first": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz",
+      "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
+      "requires": {
+        "lower-case": "1.1.4"
+      }
+    },
     "lru-cache": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
@@ -3609,6 +3675,12 @@
         "supports-color": "4.4.0"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "dev": true
+        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -6740,6 +6812,14 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
+    "param-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+      "requires": {
+        "no-case": "2.3.2"
+      }
+    },
     "parse-filepath": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
@@ -6800,6 +6880,14 @@
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
+    },
+    "path-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-2.1.1.tgz",
+      "integrity": "sha1-lLgDfDctP+KQbkZbtF4l0ibo7qU=",
+      "requires": {
+        "no-case": "2.3.2"
+      }
     },
     "path-dirname": {
       "version": "1.0.2",
@@ -6882,6 +6970,11 @@
       "requires": {
         "pinkie": "2.0.4"
       }
+    },
+    "pjson": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/pjson/-/pjson-1.0.9.tgz",
+      "integrity": "sha512-4hRJH3YzkUpOlShRzhyxAmThSNnAaIlWZCAb27hd0pVUAXNUAHAO7XZbsPPvsCYwBFEScTmCCL6DGE8NyZ8BdQ=="
     },
     "plugin-error": {
       "version": "0.1.2",
@@ -7289,6 +7382,15 @@
       "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
       "dev": true
     },
+    "sentence-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-2.1.1.tgz",
+      "integrity": "sha1-H24t2jnBaL+S0T+G1KkYkz9mftQ=",
+      "requires": {
+        "no-case": "2.3.2",
+        "upper-case-first": "1.1.2"
+      }
+    },
     "sequencify": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
@@ -7366,6 +7468,14 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
+    },
+    "snake-case": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-2.1.0.tgz",
+      "integrity": "sha1-Qb2xtz8w7GagTU4srRt2OH1NbZ8=",
+      "requires": {
+        "no-case": "2.3.2"
+      }
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -7722,6 +7832,15 @@
         "has-flag": "3.0.0"
       }
     },
+    "swap-case": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
+      "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
+      "requires": {
+        "lower-case": "1.1.4",
+        "upper-case": "1.1.3"
+      }
+    },
     "table": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
@@ -7850,6 +7969,15 @@
       "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
       "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
       "dev": true
+    },
+    "title-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/title-case/-/title-case-2.1.1.tgz",
+      "integrity": "sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=",
+      "requires": {
+        "no-case": "2.3.2",
+        "upper-case": "1.1.3"
+      }
     },
     "tmp": {
       "version": "0.0.33",

--- a/handel/package.json
+++ b/handel/package.json
@@ -5,7 +5,7 @@
   "main": "./bin/handel",
   "scripts": {
     "lint": "tslint -p tsconfig.json -t stylish",
-    "build": "tsc",
+    "build": "gulp build",
     "test": "./node_modules/mocha/bin/mocha -r ts-node/register 'test/**/*.ts'"
   },
   "bin": {
@@ -18,6 +18,8 @@
     "ajv-errors": "^1.0.0",
     "archiver": "^1.3.0",
     "aws-sdk": "^2.169.0",
+    "change-case": "^3.0.2",
+    "commander": "^2.15.1",
     "common-tags": "^1.7.2",
     "fs-extra": "^5.0.0",
     "handel-extension-api": "^0.25.1",
@@ -28,6 +30,7 @@
     "minimist": "^1.2.0",
     "ncp": "^2.0.0",
     "pascal-case": "^2.0.1",
+    "pjson": "^1.0.9",
     "tmp": "0.0.33",
     "uuid": "^3.0.1",
     "winston": "^2.3.1"

--- a/handel/package.json
+++ b/handel/package.json
@@ -27,7 +27,6 @@
     "inquirer": "^3.3.0",
     "js-yaml": "3.7.0",
     "lodash": "^4.17.4",
-    "minimist": "^1.2.0",
     "ncp": "^2.0.0",
     "pascal-case": "^2.0.1",
     "pjson": "^1.0.9",

--- a/handel/src/cli/index.ts
+++ b/handel/src/cli/index.ts
@@ -16,25 +16,34 @@
  */
 import * as AWS from 'aws-sdk';
 import * as fs from 'fs';
-import {ServiceRegistry} from 'handel-extension-api';
+import { ServiceRegistry } from 'handel-extension-api';
 import * as inquirer from 'inquirer';
 import * as yaml from 'js-yaml';
+import * as _ from 'lodash';
 import * as winston from 'winston';
 import config from '../account-config/account-config';
 import * as stsCalls from '../aws/sts-calls';
-import {TAG_KEY_PATTERN, TAG_VALUE_MAX_LENGTH} from '../common/tagging-common';
+import { TAG_KEY_PATTERN, TAG_KEY_REGEX, TAG_VALUE_MAX_LENGTH } from '../common/tagging-common';
 import * as util from '../common/util';
 import {
-    AccountConfig, EnvironmentResult, HandelFile, HandelFileParser, Tags
+    AccountConfig,
+    CheckOptions,
+    DeleteOptions,
+    DeployOptions,
+    EnvironmentResult,
+    GlobalOptions,
+    HandelFile,
+    HandelFileParser,
+    Tags
 } from '../datatypes';
 import * as checkLifecycle from '../lifecycles/check';
 import * as deleteLifecycle from '../lifecycles/delete';
 import * as deployLifecycle from '../lifecycles/deploy';
-import {initServiceRegistry} from '../service-registry';
+import { initServiceRegistry } from '../service-registry';
 
-function configureLogger(argv: any) {
+function configureLogger(options: GlobalOptions) {
     let level = 'info';
-    if (argv.d) {
+    if (options.debug) {
         level = 'debug';
     }
     winston!.level = level;
@@ -84,7 +93,7 @@ async function validateCredentials(accountConfig: AccountConfig) {
     const deployAccount = accountConfig.account_id;
     winston.debug(`Checking that current credentials match account ${deployAccount}`);
     const discoveredId = await stsCalls.getAccountId();
-    if(!discoveredId) {
+    if (!discoveredId) {
         winston.error(`You are not logged into an AWS account`);
         process.exit(1);
     }
@@ -123,30 +132,24 @@ function validateAccountConfigParam(accountConfigParam: string): string[] {
     return errors;
 }
 
-function validateEnvsInHandelFile(envsToDeploy: string, handelFile: HandelFile) {
-    const errors = [];
-    const envsArray = envsToDeploy.split(',');
-    for (const env of envsArray) {
-        if (!handelFile.environments || !handelFile.environments[env]) {
-            errors.push(`Environment '${env}' was not found in your Handel file`);
-        }
-    }
-    return errors;
+function validateEnvsInHandelFile(envsToDeploy: string[], handelFile: HandelFile) {
+    return envsToDeploy.filter(env => !handelFile.environments || !handelFile.environments[env])
+        .map(env => `Environment '${env}' was not found in your Handel file`);
 }
 
-function parseTagsArg(tagsArg: string | undefined): Tags {
-   if (!tagsArg) {
-       return {};
-   }
-   return tagsArg.split(',')
-       .reduce((tags: Tags, pair: string) => {
-           const matched = pair.match(TAG_PARAM_PATTERN);
-           if (!matched) {
-               throw new Error('Invalid value for -t');
-           }
-           tags[matched[1]] = matched[2];
-           return tags;
-       }, {});
+export function parseTagsArg(tagsArg: string | undefined): Tags {
+    if (!tagsArg) {
+        return {};
+    }
+    return tagsArg.split(',')
+        .reduce((tags: Tags, pair: string) => {
+            const matched = pair.match(TAG_PARAM_PATTERN);
+            if (!matched) {
+                throw new Error('Invalid tag value');
+            }
+            tags[matched[1]] = matched[2];
+            return tags;
+        }, {});
 }
 
 async function confirmDelete(envName: string, forceDelete: boolean): Promise<boolean> {
@@ -193,52 +196,61 @@ PLEASE BACKUP your data sources before deleting this environment just to be safe
 
 const TAG_PARAM_PATTERN = RegExp(`^(${TAG_KEY_PATTERN})=(.{1,${TAG_VALUE_MAX_LENGTH}})$`);
 
-export function validateDeployArgs(argv: any, handelFile: HandelFile): string[] {
+export function validateDeployArgs(handelFile: HandelFile, opts: DeployOptions): string[] {
+    const {accountConfig, environments, tags} = opts;
     let errors: string[] = [];
 
     // Require account config
-    if (!argv.c) {
+    if (!accountConfig) {
         errors.push('The \'-c\' parameter is required');
     }
     else { // Validate that it is either base64 decodable JSON or an account config file
-        errors = errors.concat(validateAccountConfigParam(argv.c));
+        errors = errors.concat(validateAccountConfigParam(accountConfig));
     }
 
     // Require environments to deploy
-    if (!argv.e) {
+    if (!environments) {
         errors.push('The \'-e\' parameter is required');
     }
     else { // Validate that the environments exist in the Handel file
-        errors = errors.concat(validateEnvsInHandelFile(argv.e, handelFile));
+        errors = errors.concat(validateEnvsInHandelFile(environments, handelFile));
     }
 
-    if (argv.t) {
-        const tagErrors = argv.t.split(',')
-            .filter((pair: string) => !pair.match(TAG_PARAM_PATTERN))
-            .map((pair: string) => `The value for -t is invalid: '${pair}'`);
-        errors = errors.concat(tagErrors);
+    if (tags) {
+        for (const [tag, value] of _.entries(tags)) {
+            if (!TAG_KEY_REGEX.test(tag)) {
+                errors.push(`The tag name is invalid: '${tag}'`);
+            }
+            if (value.length === 0) {
+                errors.push(`The value for tag '${tag}' must not be empty`);
+            }
+            if (value.length > TAG_VALUE_MAX_LENGTH) {
+                errors.push(`The value for tag '${tag}' must be less than ${TAG_VALUE_MAX_LENGTH} in length.`);
+            }
+        }
     }
 
     return errors;
 }
 
-export function validateDeleteArgs(argv: any, handelFile: HandelFile): string[] {
+export function validateDeleteArgs(handelFile: HandelFile, opts: DeleteOptions): string[] {
+    const {accountConfig, environments} = opts;
     let errors: string[] = [];
 
     // Require account config
-    if (!argv.c) {
+    if (!accountConfig) {
         errors.push('The \'-c\' parameter is required');
     }
     else { // Validate that it is either base64 decodable JSON or an account config file
-        errors = errors.concat(validateAccountConfigParam(argv.c));
+        errors = errors.concat(validateAccountConfigParam(accountConfig));
     }
 
     // Require environments to deploy
-    if (!argv.e) {
+    if (!environments) {
         errors.push('The \'-e\' parameter is required');
     }
     else { // Validate that the environments exist in the Handel file
-        errors = errors.concat(validateEnvsInHandelFile(argv.e, handelFile));
+        errors = errors.concat(validateEnvsInHandelFile(environments, handelFile));
     }
 
     return errors;
@@ -248,19 +260,16 @@ export function validateDeleteArgs(argv: any, handelFile: HandelFile): string[] 
  * This method is the top-level entry point for the 'deploy' action available in the
  * Handel CLI. It goes and deploys the requested environment(s) to AWS.
  */
-export async function deployAction(handelFile: HandelFile, argv: any): Promise<void> {
-    configureLogger(argv);
+export async function deployAction(handelFile: HandelFile, options: DeployOptions): Promise<void> {
+    configureLogger(options);
 
-    const environmentsToDeploy = argv.e.split(',');
+    const environmentsToDeploy = options.environments;
     try {
         await validateLoggedIn();
-        const accountConfig = await config(argv.c); // Load account config to be consumed by the library
+        const accountConfig = await config(options.accountConfig); // Load account config to be consumed by the library
         await validateCredentials(accountConfig);
         // Set up AWS SDK with any global options
         util.configureAwsSdk(accountConfig);
-
-        // Parse command-line tags
-        const tags = parseTagsArg(argv.t);
 
         // Load Handel file from path and validate it
         winston.debug('Validating and parsing Handel file');
@@ -271,9 +280,9 @@ export async function deployAction(handelFile: HandelFile, argv: any): Promise<v
         await validateHandelFile(handelFileParser, handelFile, serviceRegistry);
 
         // Command-line tags override handelfile tags.
-        handelFile.tags = Object.assign({}, handelFile.tags, tags);
+        handelFile.tags = Object.assign({}, handelFile.tags, options.tags);
 
-        const envDeployResults = await deployLifecycle.deploy(accountConfig, handelFile, environmentsToDeploy, handelFileParser, serviceRegistry);
+        const envDeployResults = await deployLifecycle.deploy(accountConfig, handelFile, environmentsToDeploy, handelFileParser, serviceRegistry, options);
         logFinalResult('deploy', envDeployResults);
     }
     catch (err) {
@@ -287,8 +296,8 @@ export async function deployAction(handelFile: HandelFile, argv: any): Promise<v
  * Handel CLI. It goes and validates the Handel file so you can see if the file looks
  * correct
  */
-export async function checkAction(handelFile: HandelFile, argv: any): Promise<void> {
-    configureLogger(argv); // Don't enable debug on check?
+export async function checkAction(handelFile: HandelFile, options: CheckOptions): Promise<void> {
+    configureLogger(options); // Don't enable debug on check?
 
     // Load Handel file from path and validate it
     winston.debug('Validating and parsing Handel file');
@@ -298,7 +307,7 @@ export async function checkAction(handelFile: HandelFile, argv: any): Promise<vo
 
     await validateHandelFile(handelFileParser, handelFile, serviceRegistry);
 
-    const errors = checkLifecycle.check(handelFile, handelFileParser, serviceRegistry);
+    const errors = checkLifecycle.check(handelFile, handelFileParser, serviceRegistry, options);
     let foundErrors = false;
     for (const env in errors) {
         if (errors.hasOwnProperty(env)) {
@@ -321,16 +330,14 @@ export async function checkAction(handelFile: HandelFile, argv: any): Promise<vo
  * This method is the top-level entry point for the 'delete' action available in the
  * Handel CLI. It asks for a confirmation, then deletes the requested environment.
  */
-export async function deleteAction(handelFile: HandelFile, argv: any): Promise<void> {
-    configureLogger(argv);
+export async function deleteAction(handelFile: HandelFile, options: DeleteOptions): Promise<void> {
+    configureLogger(options);
 
-    const environmentToDelete = argv.e;
     try {
         await validateLoggedIn();
-        const accountConfig = await config(argv.c); // Load account config to be consumed by the library
+        const accountConfig = await config(options.accountConfig); // Load account config to be consumed by the library
         await validateCredentials(accountConfig);
-        const deleteEnvConfirmed = await confirmDelete(environmentToDelete, argv.y);
-        if (deleteEnvConfirmed) {
+        for (const environmentToDelete of options.environments) {
             // Set up AWS SDK with any global options
             util.configureAwsSdk(accountConfig);
 
@@ -342,14 +349,16 @@ export async function deleteAction(handelFile: HandelFile, argv: any): Promise<v
 
             await validateHandelFile(handelFileParser, handelFile, serviceRegistry);
 
-            const envDeleteResult = await deleteLifecycle.deleteEnv(accountConfig, handelFile, environmentToDelete, handelFileParser, serviceRegistry);
-            logFinalResult('delete', [envDeleteResult]);
+            const deleteEnvConfirmed = await confirmDelete(environmentToDelete, options.yes);
+            if (deleteEnvConfirmed) {
+                const envDeleteResult = await deleteLifecycle.deleteEnv(accountConfig, handelFile, environmentToDelete, handelFileParser, serviceRegistry, options);
+                logFinalResult('delete', [envDeleteResult]);
+            }
+            else {
+                winston.info('You did not type \'yes\' to confirm deletion. Will not delete environment.');
+            }
         }
-        else {
-            winston.info('You did not type \'yes\' to confirm deletion. Will not delete environment.');
-        }
-    }
-    catch (err) {
+    } catch (err) {
         logCaughtError('Unexpected error occurred during delete', err);
         process.exit(1);
     }

--- a/handel/src/common/util.ts
+++ b/handel/src/common/util.ts
@@ -24,7 +24,7 @@ import * as os from 'os';
 import pascalCase = require('pascal-case');
 import * as uuid from 'uuid';
 import * as winston from 'winston';
-import { AccountConfig, HandelFile } from '../datatypes';
+import { AccountConfig, GlobalOptions, HandelFile } from '../datatypes';
 
 export function readDirSync(filePath: string) {
     try {
@@ -185,9 +185,9 @@ export function getHandelFileParser(handelFile: HandelFile) {
 /**
  * Gets the App Context from the deploy spec file
  */
-export function createEnvironmentContext(handelFile: HandelFile, handelFileParser: any, environmentName: string, accountConfig: AccountConfig, serviceRegistry: ServiceRegistry) { // TODO - Add type for HandelFileParser
+export function createEnvironmentContext(handelFile: HandelFile, handelFileParser: any, environmentName: string, accountConfig: AccountConfig, serviceRegistry: ServiceRegistry, options: GlobalOptions) { // TODO - Add type for HandelFileParser
     try {
-        return handelFileParser.createEnvironmentContext(handelFile, environmentName, accountConfig, serviceRegistry);
+        return handelFileParser.createEnvironmentContext(handelFile, environmentName, accountConfig, serviceRegistry, options);
     }
     catch (err) {
         winston.error(`Error while parsing deploy spec: ${err.message}`);

--- a/handel/src/datatypes/index.ts
+++ b/handel/src/datatypes/index.ts
@@ -201,7 +201,7 @@ export interface ServiceDeployer extends api.ServiceDeployer {
 export interface HandelFileParser {
     validateHandelFile(handelFile: HandelFile, serviceRegistry: api.ServiceRegistry): Promise<string[]>;
 
-    createEnvironmentContext(handelFile: HandelFile, environmentName: string, accountConfig: AccountConfig, serviceRegistry: api.ServiceRegistry): EnvironmentContext;
+    createEnvironmentContext(handelFile: HandelFile, environmentName: string, accountConfig: AccountConfig, serviceRegistry: api.ServiceRegistry, options: GlobalOptions): EnvironmentContext;
 }
 
 /***********************************
@@ -226,21 +226,14 @@ export interface HandelFileEnvironment {
  * Types for the Environment Deployer framework and lifecycle
  ***********************************/
 export class EnvironmentContext {
-    public appName: string;
-    public environmentName: string;
     public serviceContexts: ServiceContexts;
-    public accountConfig: AccountConfig;
-    public tags: Tags;
 
-    constructor(appName: string,
-                environmentName: string,
-                accountConfig: AccountConfig,
-                tags: Tags = {}) {
-        this.appName = appName;
-        this.environmentName = environmentName;
+    constructor(public appName: string,
+                public environmentName: string,
+                public accountConfig: AccountConfig,
+                public options: GlobalOptions = {debug: false, linkExtensions: false},
+                public tags: Tags = {}) {
         this.serviceContexts = {};
-        this.accountConfig = accountConfig;
-        this.tags = tags;
     }
 }
 
@@ -391,4 +384,25 @@ export interface Tags {
 
 export interface EnvironmentVariables {
     [key: string]: string;
+}
+
+export interface GlobalOptions {
+    debug: boolean;
+    linkExtensions: boolean;
+}
+
+// tslint:disable-next-line:no-empty-interface
+export interface CheckOptions extends GlobalOptions {
+}
+
+export interface DeployOptions extends GlobalOptions {
+    accountConfig: string;
+    environments: string[];
+    tags?: Tags;
+}
+
+export interface DeleteOptions extends GlobalOptions {
+    accountConfig: string;
+    environments: string[];
+    yes: boolean;
 }

--- a/handel/src/handelfile/parser-v1.ts
+++ b/handel/src/handelfile/parser-v1.ts
@@ -18,7 +18,7 @@ import * as Ajv from 'ajv';
 import {ServiceRegistry} from 'handel-extension-api';
 import * as _ from 'lodash';
 import * as util from '../common/util';
-import { AccountConfig, EnvironmentContext, HandelFile, ServiceContext } from '../datatypes';
+import { AccountConfig, EnvironmentContext, GlobalOptions, HandelFile, ServiceContext } from '../datatypes';
 import {DEFAULT_EXTENSION_PREFIX} from '../service-registry';
 
 const APP_ENV_SERVICE_NAME_REGEX = /^[a-zA-Z0-9-]+$/;
@@ -201,15 +201,16 @@ export async function validateHandelFile(handelFile: HandelFile, serviceRegistry
  * @param {String} environmentName - The name of the environment in the deploy spec for which we want the EnvironmentContext
  * @param {AccountConfig} accountConfig - account configuration
  * @param {ServiceRegistry} serviceRegistry - registry of all loaded services
+ * @param {GlobalOptions} options
  * @returns {EnvironmentContext} - The generated EnvironmentContext from the specified environment in the Handel file
  */
-export function createEnvironmentContext(handelFile: HandelFile, environmentName: string, accountConfig: AccountConfig, serviceRegistry: ServiceRegistry): EnvironmentContext {
+export function createEnvironmentContext(handelFile: HandelFile, environmentName: string, accountConfig: AccountConfig, serviceRegistry: ServiceRegistry, options: GlobalOptions): EnvironmentContext {
     const environmentSpec = handelFile.environments[environmentName];
     if (!environmentSpec) {
         throw new Error(`Can't find the requested environment in the deploy spec: ${environmentName}`);
     }
 
-    const environmentContext = new EnvironmentContext(handelFile.name, environmentName, accountConfig, handelFile.tags || {});
+    const environmentContext = new EnvironmentContext(handelFile.name, environmentName, accountConfig, options, handelFile.tags || {});
 
     _.forEach(environmentSpec, (serviceSpec, serviceName) => {
         const serviceType = serviceSpec.type;

--- a/handel/src/lifecycles/check.ts
+++ b/handel/src/lifecycles/check.ts
@@ -16,7 +16,7 @@
  */
 import {ServiceRegistry} from 'handel-extension-api';
 import * as util from '../common/util';
-import { AccountConfig, EnvironmentsCheckResults, HandelFile, HandelFileParser} from '../datatypes';
+import { AccountConfig, CheckOptions, EnvironmentsCheckResults, HandelFile, HandelFileParser } from '../datatypes';
 import * as checkPhase from '../phases/check';
 
 // TODO - This is ugly having to inject a fake account config just to run a check. We should refactor not to have to do this.
@@ -38,11 +38,11 @@ const fakeAccountConfig: AccountConfig = {
     redshift_subnet_group: 'fake-subnet-group'
 };
 
-export function check(handelFile: HandelFile, handelFileParser: HandelFileParser, serviceRegistry: ServiceRegistry): EnvironmentsCheckResults {
+export function check(handelFile: HandelFile, handelFileParser: HandelFileParser, serviceRegistry: ServiceRegistry, options: CheckOptions): EnvironmentsCheckResults {
     const errors: EnvironmentsCheckResults = {};
     for (const environmentToCheck in handelFile.environments) {
         if (handelFile.environments.hasOwnProperty(environmentToCheck)) {
-            const environmentContext = util.createEnvironmentContext(handelFile, handelFileParser, environmentToCheck, fakeAccountConfig, serviceRegistry); // Use fake account config for now during check
+            const environmentContext = util.createEnvironmentContext(handelFile, handelFileParser, environmentToCheck, fakeAccountConfig, serviceRegistry, options); // Use fake account config for now during check
             errors[environmentToCheck] = checkPhase.checkServices(serviceRegistry, environmentContext);
         }
     }

--- a/handel/src/lifecycles/delete.ts
+++ b/handel/src/lifecycles/delete.ts
@@ -17,7 +17,17 @@
 import {ServiceRegistry} from 'handel-extension-api';
 import * as winston from 'winston';
 import * as util from '../common/util';
-import { AccountConfig, DeployOrder, EnvironmentContext, EnvironmentDeleteResult, HandelFile, HandelFileParser, UnBindContexts, UnDeployContexts } from '../datatypes';
+import {
+    AccountConfig,
+    DeleteOptions,
+    DeployOrder,
+    EnvironmentContext,
+    EnvironmentDeleteResult,
+    HandelFile,
+    HandelFileParser,
+    UnBindContexts,
+    UnDeployContexts
+} from '../datatypes';
 import * as deployOrderCalc from '../deploy/deploy-order-calc';
 import * as unBindPhase from '../phases/un-bind';
 import * as unDeployPhase from '../phases/un-deploy';
@@ -69,8 +79,8 @@ async function deleteEnvironment(accountConfig: AccountConfig, serviceRegistry: 
     }
 }
 
-export async function deleteEnv(accountConfig: AccountConfig, handelFile: HandelFile, environmentToDelete: string, handelFileParser: HandelFileParser, serviceRegistry: ServiceRegistry): Promise<EnvironmentDeleteResult> {
+export async function deleteEnv(accountConfig: AccountConfig, handelFile: HandelFile, environmentToDelete: string, handelFileParser: HandelFileParser, serviceRegistry: ServiceRegistry, options: DeleteOptions): Promise<EnvironmentDeleteResult> {
     // Run the delete on the environment specified
-    const environmentContext = util.createEnvironmentContext(handelFile, handelFileParser, environmentToDelete, accountConfig, serviceRegistry);
+    const environmentContext = util.createEnvironmentContext(handelFile, handelFileParser, environmentToDelete, accountConfig, serviceRegistry, options);
     return deleteEnvironment(accountConfig, serviceRegistry, environmentContext);
 }

--- a/handel/src/lifecycles/deploy.ts
+++ b/handel/src/lifecycles/deploy.ts
@@ -17,7 +17,18 @@
 import {ServiceRegistry} from 'handel-extension-api';
 import * as winston from 'winston';
 import * as util from '../common/util';
-import { AccountConfig, BindContexts, DeployContexts, DeployOrder, EnvironmentContext, EnvironmentDeployResult, HandelFile, HandelFileParser, PreDeployContexts} from '../datatypes';
+import {
+    AccountConfig,
+    BindContexts,
+    DeployContexts,
+    DeployOptions,
+    DeployOrder,
+    EnvironmentContext,
+    EnvironmentDeployResult,
+    HandelFile,
+    HandelFileParser,
+    PreDeployContexts
+} from '../datatypes';
 import * as deployOrderCalc from '../deploy/deploy-order-calc';
 import * as bindPhase from '../phases/bind';
 import * as checkPhase from '../phases/check';
@@ -91,11 +102,11 @@ async function deployEnvironment(accountConfig: AccountConfig, serviceRegistry: 
     }
 }
 
-export async function deploy(accountConfig: AccountConfig, handelFile: HandelFile, environmentsToDeploy: string[], handelFileParser: HandelFileParser, serviceRegistry: ServiceRegistry): Promise<EnvironmentDeployResult[]> {
+export async function deploy(accountConfig: AccountConfig, handelFile: HandelFile, environmentsToDeploy: string[], handelFileParser: HandelFileParser, serviceRegistry: ServiceRegistry, options: DeployOptions): Promise<EnvironmentDeployResult[]> {
     // Check current credentials against the accountConfig
     const envDeployPromises: Array<Promise<EnvironmentDeployResult>> = [];
     for (const environmentToDeploy of environmentsToDeploy) {
-        const environmentContext = util.createEnvironmentContext(handelFile, handelFileParser, environmentToDeploy, accountConfig, serviceRegistry);
+        const environmentContext = util.createEnvironmentContext(handelFile, handelFileParser, environmentToDeploy, accountConfig, serviceRegistry, options);
         envDeployPromises.push(deployEnvironment(accountConfig, serviceRegistry, environmentContext));
     }
     return Promise.all(envDeployPromises);

--- a/handel/test/cli/cli-test.ts
+++ b/handel/test/cli/cli-test.ts
@@ -19,6 +19,7 @@ import 'mocha';
 import * as sinon from 'sinon';
 import * as cli from '../../src/cli';
 import * as util from '../../src/common/util';
+import { DeleteOptions, DeployOptions } from '../../src/datatypes';
 
 describe('cli module', () => {
     let sandbox: sinon.SinonSandbox;
@@ -35,43 +36,56 @@ describe('cli module', () => {
         const handelFile = util.readYamlFileSync(`${__dirname}/../test-handel.yml`);
         it('should fail if the -c param is not provided', () => {
             const argv = {
-                e: 'dev,prod'
+                debug: false,
+                linkExtensions: false,
+                environments: ['dev', 'prod'],
+                tags: {},
             };
-            const errors = cli.validateDeployArgs(argv, handelFile);
-            expect(errors.length).to.equal(1);
+            const errors = cli.validateDeployArgs(handelFile, argv as DeployOptions);
+            expect(errors).to.have.lengthOf(1);
             expect(errors[0]).to.contain(`'-c' parameter is required`);
         });
 
         it('should fail if the -e parameter is not provided', () => {
             const argv = {
-                c: `${__dirname}/../test-account-config.yml`
+                debug: false,
+                linkExtensions: false,
+                accountConfig: `${__dirname}/../test-account-config.yml`,
+                tags: {},
             };
-            const errors = cli.validateDeployArgs(argv, handelFile);
+            const errors = cli.validateDeployArgs(handelFile, argv as DeployOptions);
             expect(errors.length).to.equal(1);
             expect(errors[0]).to.contain(`'-e' parameter is required`);
         });
 
         it('should succeed if all params are provided', () => {
             const argv = {
-                e: 'dev,prod',
-                c: `${__dirname}/../test-account-config.yml`,
-                t: 'foo=bar,bar=baz'
+                debug: false,
+                linkExtensions: false,
+                accountConfig: `${__dirname}/../test-account-config.yml`,
+                environments: ['dev', 'prod'],
+                tags: {foo: 'bar', bar: 'baz'},
             };
-            const errors = cli.validateDeployArgs(argv, handelFile);
+            const errors = cli.validateDeployArgs(handelFile, argv);
             expect(errors.length).to.equal(0);
         });
 
         it('should fail if there are invalid tags', () => {
             const argv = {
-                e: 'dev,prod',
-                c: `${__dirname}/../test-account-config.yml`,
-                t: 'foo=bar,bar,baz=,ab{}cd=abc'
+                debug: false,
+                linkExtensions: false,
+                environments: ['dev', 'prod'],
+                accountConfig: `${__dirname}/../test-account-config.yml`,
+                tags: {
+                    foo: 'bar',
+                    'bar': '',
+                    'ab{}cd': 'abc'
+                },
             };
-            const errors = cli.validateDeployArgs(argv, handelFile);
-            expect(errors).to.have.lengthOf(3);
-            expect(errors).to.include(`The value for -t is invalid: 'bar'`);
-            expect(errors).to.include(`The value for -t is invalid: 'baz='`);
-            expect(errors).to.include(`The value for -t is invalid: 'ab{}cd=abc'`);
+            const errors = cli.validateDeployArgs(handelFile, argv);
+            expect(errors).to.have.lengthOf(2);
+            expect(errors).to.include(`The value for tag 'bar' must not be empty`);
+            expect(errors).to.include(`The tag name is invalid: 'ab{}cd'`);
         });
     });
 
@@ -79,28 +93,37 @@ describe('cli module', () => {
         const handelFile = util.readYamlFileSync(`${__dirname}/../test-handel.yml`);
         it('should fail if the -c param is not provided', () => {
             const argv = {
-                e: 'dev,prod'
+                debug: false,
+                linkExtensions: false,
+                environments: ['dev', 'prod'],
+                yes: true
             };
-            const errors = cli.validateDeleteArgs(argv, handelFile);
+            const errors = cli.validateDeleteArgs(handelFile, argv as DeleteOptions);
             expect(errors.length).to.equal(1);
             expect(errors[0]).to.contain(`'-c' parameter is required`);
         });
 
         it('should fail if the -e parameter is not provided', () => {
             const argv = {
-                c: `${__dirname}/../test-account-config.yml`
+                debug: false,
+                linkExtensions: false,
+                accountConfig: `${__dirname}/../test-account-config.yml`,
+                yes: true
             };
-            const errors = cli.validateDeleteArgs(argv, handelFile);
+            const errors = cli.validateDeleteArgs(handelFile, argv as DeleteOptions);
             expect(errors.length).to.equal(1);
             expect(errors[0]).to.contain(`'-e' parameter is required`);
         });
 
         it('should succeed if all params are provided', () => {
             const argv = {
-                e: 'dev,prod',
-                c: `${__dirname}/../test-account-config.yml`
+                debug: false,
+                linkExtensions: false,
+                environments: ['dev', 'prod'],
+                accountConfig: `${__dirname}/../test-account-config.yml`,
+                yes: true
             };
-            const errors = cli.validateDeleteArgs(argv, handelFile);
+            const errors = cli.validateDeleteArgs(handelFile, argv as DeleteOptions);
             expect(errors.length).to.equal(0);
         });
     });

--- a/handel/test/common/util-test.ts
+++ b/handel/test/common/util-test.ts
@@ -19,7 +19,7 @@ import * as fs from 'fs';
 import 'mocha';
 import * as sinon from 'sinon';
 import * as util from '../../src/common/util';
-import { EnvironmentContext } from '../../src/datatypes';
+import { EnvironmentContext, GlobalOptions } from '../../src/datatypes';
 import FakeServiceRegistry from '../service-registry/fake-service-registry';
 
 describe('util module', () => {
@@ -202,7 +202,9 @@ describe('util module', () => {
         const accountConfig = util.readYamlFileSync(`${__dirname}/../test-account-config.yml`);
         const environmentName = 'dev';
 
-        const environmentContext = util.createEnvironmentContext(handelFile, handelFileParser, environmentName, accountConfig, new FakeServiceRegistry());
+        const opts: GlobalOptions = { debug: false, linkExtensions: false };
+
+        const environmentContext = util.createEnvironmentContext(handelFile, handelFileParser, environmentName, accountConfig, new FakeServiceRegistry(), opts);
         expect(environmentContext).to.be.instanceof(EnvironmentContext);
     });
 });

--- a/handel/test/handelfile/parser-v1-test.ts
+++ b/handel/test/handelfile/parser-v1-test.ts
@@ -18,7 +18,7 @@ import { expect } from 'chai';
 import {ServiceRegistry} from 'handel-extension-api';
 import 'mocha';
 import config from '../../src/account-config/account-config';
-import { AccountConfig, HandelFile } from '../../src/datatypes';
+import { AccountConfig, GlobalOptions, HandelFile } from '../../src/datatypes';
 import * as parserV1 from '../../src/handelfile/parser-v1';
 import FakeServiceRegistry from '../service-registry/fake-service-registry';
 
@@ -270,10 +270,14 @@ describe('parser-v1', () => {
                     }
                 }
             };
-            const environmentContext = parserV1.createEnvironmentContext(handelFile, 'dev', accountConfig, new FakeServiceRegistry());
+
+            const opts: GlobalOptions = {debug: false, linkExtensions: false};
+
+            const environmentContext = parserV1.createEnvironmentContext(handelFile, 'dev', accountConfig, new FakeServiceRegistry(), opts);
             expect(environmentContext.appName).to.equal('test');
             expect(environmentContext.environmentName).to.equal('dev');
             expect(environmentContext.serviceContexts.A.serviceType).to.equal('dynamodb');
+            expect(environmentContext.options).to.deep.equal(opts);
         });
     });
 });

--- a/handel/test/lifecycles/check-test.ts
+++ b/handel/test/lifecycles/check-test.ts
@@ -18,6 +18,7 @@ import { expect } from 'chai';
 import 'mocha';
 import * as sinon from 'sinon';
 import * as util from '../../src/common/util';
+import { CheckOptions } from '../../src/datatypes';
 import * as handelFileParser from '../../src/handelfile/parser-v1';
 import * as checkLifecycle from '../../src/lifecycles/check';
 import * as checkPhase from '../../src/phases/check';
@@ -42,7 +43,10 @@ describe('check lifecycle module', () => {
             const serviceRegistry = new FakeServiceRegistry();
             const handelFile = util.readYamlFileSync(`${__dirname}/../test-handel.yml`);
             handelFile.environments.dev.B.database_name = null; // Cause error
-            const errors = checkLifecycle.check(handelFile, handelFileParser, serviceRegistry);
+
+            const options: CheckOptions = { debug: false, linkExtensions: false };
+
+            const errors = checkLifecycle.check(handelFile, handelFileParser, serviceRegistry, options);
             expect(checkServicesStub.callCount).to.equal(2);
             expect(errors.dev.length).to.equal(1);
             expect(errors.dev[0]).to.equal(error);

--- a/handel/test/lifecycles/delete-test.ts
+++ b/handel/test/lifecycles/delete-test.ts
@@ -19,7 +19,7 @@ import 'mocha';
 import * as sinon from 'sinon';
 import config from '../../src/account-config/account-config';
 import * as util from '../../src/common/util';
-import { AccountConfig, HandelFile, ServiceContext, UnPreDeployContext } from '../../src/datatypes';
+import { AccountConfig, DeleteOptions, HandelFile, ServiceContext, UnPreDeployContext } from '../../src/datatypes';
 import * as handelFileParser from '../../src/handelfile/parser-v1';
 import * as deleteLifecycle from '../../src/lifecycles/delete';
 import * as unBindPhase from '../../src/phases/un-bind';
@@ -49,8 +49,9 @@ describe('delete lifecycle module', () => {
                 A: new UnPreDeployContext(serviceContext)
             });
             const serviceRegistry = new FakeServiceRegistry();
+            const opts: DeleteOptions = { debug: false, linkExtensions: false, yes: false, environments: ['dev'], accountConfig: '' };
             const handelFile: HandelFile = util.readYamlFileSync(`${__dirname}/../test-handel.yml`);
-            const results = await deleteLifecycle.deleteEnv(accountConfig, handelFile, 'dev', handelFileParser, serviceRegistry);
+            const results = await deleteLifecycle.deleteEnv(accountConfig, handelFile, 'dev', handelFileParser, serviceRegistry, opts);
             expect(unPreDeployStub.callCount).to.equal(1);
             expect(unBindServicesStub.callCount).to.equal(2);
             expect(unDeployServicesStub.callCount).to.equal(2);

--- a/handel/test/lifecycles/deploy-test.ts
+++ b/handel/test/lifecycles/deploy-test.ts
@@ -19,7 +19,7 @@ import 'mocha';
 import * as sinon from 'sinon';
 import config from '../../src/account-config/account-config';
 import * as util from '../../src/common/util';
-import { AccountConfig, PreDeployContext, ServiceContext } from '../../src/datatypes';
+import { AccountConfig, DeployOptions, PreDeployContext, ServiceContext } from '../../src/datatypes';
 import * as handelFileParser from '../../src/handelfile/parser-v1';
 import * as deployLifecycle from '../../src/lifecycles/deploy';
 import * as bindPhase from '../../src/phases/bind';
@@ -53,7 +53,8 @@ describe('deploy lifecycle module', () => {
             const deployServicesInlevelStub = sandbox.stub(deployPhase, 'deployServicesInLevel').returns({});
             const handelFile = util.readYamlFileSync(`${__dirname}/../test-handel.yml`);
             const serviceRegistry = new FakeServiceRegistry({});
-            const results = await deployLifecycle.deploy(accountConfig, handelFile, ['dev', 'prod'], handelFileParser, serviceRegistry);
+            const opts: DeployOptions = { debug: false, linkExtensions: false, accountConfig: '', environments: ['dev, prod'], tags: {} };
+            const results = await deployLifecycle.deploy(accountConfig, handelFile, ['dev', 'prod'], handelFileParser, serviceRegistry, opts);
             expect(checkServicesStub.callCount).to.equal(2);
             expect(preDeployServicesStub.callCount).to.equal(2);
             expect(bindServicesInLevelStub.callCount).to.equal(4);

--- a/handel/tsconfig.json
+++ b/handel/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../tsconfig",
   "compilerOptions": {
-    "allowJs": true,
-    "rootDir": "./"
+    "allowJs": true
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
This rewrites the CLI interface to use commander.js, which gets rid of a bunch of oddness.  It also now passes the options from the CLI to the Environment Context so we can do things like using CLI feature flags.