### PR TITLE
Replace instanceof with Duck checks

### DIFF
--- a/examples/random-secret-extension/package-lock.json
+++ b/examples/random-secret-extension/package-lock.json
@@ -326,12 +326,9 @@
       }
     },
     "handel-extension-api": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/handel-extension-api/-/handel-extension-api-0.25.1.tgz",
-      "integrity": "sha512-3lmQ1mb9u2Lnh88IH2ncoITgZ+p+FJNTb1TBuOkdQNoxI0aFxSoC/2+kOi/C9bD9jvwu462V2p4k65BODxScZg==",
-      "requires": {
-        "aws-sdk": "2.218.1"
-      }
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/handel-extension-api/-/handel-extension-api-0.26.0.tgz",
+      "integrity": "sha512-LvHpJTX1TL7ida0IWur1DBarGi/xm3CB4cd4FFkQVfWhASpmaKnj5iMnuvsWa/OAAjCUYAVAnRSccTzBxjAATw=="
     },
     "has-ansi": {
       "version": "2.0.0",

--- a/examples/random-secret-extension/package.json
+++ b/examples/random-secret-extension/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "aws-sdk": "^2.218.1",
     "constant-case": "^2.0.0",
-    "handel-extension-api": "^0.25.1",
+    "handel-extension-api": "^0.26.0",
     "randomstring": "^1.1.5",
     "winston": "^2.4.1"
   }

--- a/handel/src/common/bind-phase-common.ts
+++ b/handel/src/common/bind-phase-common.ts
@@ -14,15 +14,15 @@
  * limitations under the License.
  *
  */
-import { BindContext, PreDeployContext, } from 'handel-extension-api';
+import { BindContext, IPreDeployContext, } from 'handel-extension-api';
 import * as winston from 'winston';
 import * as ec2Calls from '../aws/ec2-calls';
 import { ServiceConfig, ServiceContext } from '../datatypes';
 import * as deployPhaseCommon from './deploy-phase-common';
 
 export async function bindDependentSecurityGroupToSelf(
-    ownServiceContext: ServiceContext<ServiceConfig>, ownPreDeployContext: PreDeployContext,
-    dependentOfServiceContext: ServiceContext<ServiceConfig>, dependentOfPreDeployContext: PreDeployContext, protocol: string,
+    ownServiceContext: ServiceContext<ServiceConfig>, ownPreDeployContext: IPreDeployContext,
+    dependentOfServiceContext: ServiceContext<ServiceConfig>, dependentOfPreDeployContext: IPreDeployContext, protocol: string,
     port: number, serviceName: string
 ) {
     const stackName = deployPhaseCommon.getResourceName(ownServiceContext);

--- a/handel/src/datatypes/index.ts
+++ b/handel/src/datatypes/index.ts
@@ -15,7 +15,7 @@
  *
  */
 
-import { codeBlock, source, stripIndent } from 'common-tags';
+import { stripIndent } from 'common-tags';
 import * as api from 'handel-extension-api';
 import { documentationUrl } from '../common/util';
 
@@ -53,7 +53,8 @@ export class ServiceContext<Config extends ServiceConfig> implements api.Service
 }
 
 export class ServiceType implements api.ServiceType {
-    constructor(public prefix: string, public name: string) {}
+    constructor(public prefix: string, public name: string) {
+    }
 
     public matches(prefix: string, name: string): boolean {
         return this.prefix === prefix && this.name === name;
@@ -121,7 +122,7 @@ export class EnvironmentContext {
     constructor(public appName: string,
                 public environmentName: string,
                 public accountConfig: AccountConfig,
-                public options: HandelCoreOptions = { linkExtensions: false },
+                public options: HandelCoreOptions = {linkExtensions: false},
                 public tags: api.Tags = {}) {
         this.serviceContexts = {};
     }
@@ -170,35 +171,35 @@ export interface ServiceContexts {
 }
 
 export interface PreDeployContexts {
-    [serviceName: string]: api.PreDeployContext;
+    [serviceName: string]: api.IPreDeployContext;
 }
 
 export interface BindContexts {
-    [bindContextName: string]: api.BindContext;
+    [bindContextName: string]: api.IBindContext;
 }
 
 export interface DeployContexts {
-    [serviceName: string]: api.DeployContext;
+    [serviceName: string]: api.IDeployContext;
 }
 
 export interface ConsumeEventsContexts {
-    [serviceName: string]: api.ConsumeEventsContext;
+    [serviceName: string]: api.IConsumeEventsContext;
 }
 
 export interface ProduceEventsContexts {
-    [serviceName: string]: api.ProduceEventsContext;
+    [serviceName: string]: api.IProduceEventsContext;
 }
 
 export interface UnBindContexts {
-    [serviceName: string]: api.UnBindContext;
+    [serviceName: string]: api.IUnBindContext;
 }
 
 export interface UnDeployContexts {
-    [serviceName: string]: api.UnDeployContext;
+    [serviceName: string]: api.IUnDeployContext;
 }
 
 export interface UnPreDeployContexts {
-    [serviceName: string]: api.UnPreDeployContext;
+    [serviceName: string]: api.IUnPreDeployContext;
 }
 
 export type DeployOrder = string[][];
@@ -296,6 +297,17 @@ export class ExtensionLoadingError extends Error {
     }
 }
 
+export class DontBlameHandelError extends Error {
+    constructor(message: string, serviceType?: api.ServiceType) {
+        super(stripIndent`
+        ${message}
+
+        !!! THIS IS MOST LIKELY A PROBLEM AN EXTENSION, NOT WITH HANDEL !!!
+        ${!serviceType ? '' : `The error was caused by the '${serviceType.name}' service in extension '${serviceType.prefix}'`}
+        `);
+    }
+}
+
 export type ExtensionList = ExtensionDefinition[];
 
 export class MissingPrefixError extends Error {
@@ -343,7 +355,7 @@ export class ExtensionInstallationError extends Error {
             To help debug, here's the error output from the installation:
 
             ---------------
-        ` + '\n\n' +  output + '\n\n---------------');
+        ` + '\n\n' + output + '\n\n---------------');
     }
 }
 

--- a/handel/src/phases/bind.ts
+++ b/handel/src/phases/bind.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  *
  */
-import { BindContext } from 'handel-extension-api';
+import { isBindContext } from 'handel-extension-api';
 import {ServiceRegistry} from 'handel-extension-api';
 import * as winston from 'winston';
 import * as lifecyclesCommon from '../common/lifecycles-common';
 import * as util from '../common/util';
-import { BindContexts, DeployOrder, EnvironmentContext, PreDeployContexts } from '../datatypes';
+import { BindContexts, DeployOrder, DontBlameHandelError, EnvironmentContext, PreDeployContexts } from '../datatypes';
 
 function getDependentServicesForCurrentBindService(environmentContext: EnvironmentContext, toBindServiceName: string): string[] {
     const dependentServices = [];
@@ -60,8 +60,8 @@ export async function bindServicesInLevel(serviceRegistry: ServiceRegistry, envi
             if (serviceDeployer.bind) {
                 const bindPromise = serviceDeployer.bind(toBindServiceContext, toBindPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext)
                     .then(bindContext => {
-                        if (!(bindContext instanceof BindContext)) {
-                            throw new Error('Expected BindContext back from \'bind\' phase of service deployer');
+                        if (!isBindContext(bindContext)) {
+                            throw new DontBlameHandelError('Expected valid BindContext back from \'bind\' phase of service deployer', toBindServiceContext.serviceType);
                         }
                         levelBindContexts[bindContextName] = bindContext;
                     });

--- a/handel/src/phases/consume-events.ts
+++ b/handel/src/phases/consume-events.ts
@@ -14,18 +14,26 @@
  * limitations under the License.
  *
  */
-import { ConsumeEventsContext, DeployContext } from 'handel-extension-api';
+import { IDeployContext, isConsumeEventsContext } from 'handel-extension-api';
 import {ServiceRegistry} from 'handel-extension-api';
 import * as winston from 'winston';
 import * as util from '../common/util';
-import { ConsumeEventsContexts, DeployContexts, EnvironmentContext, ServiceConfig, ServiceContext, ServiceDeployer } from '../datatypes';
+import {
+    ConsumeEventsContexts,
+    DeployContexts,
+    DontBlameHandelError,
+    EnvironmentContext,
+    ServiceConfig,
+    ServiceContext,
+    ServiceDeployer
+} from '../datatypes';
 
 interface ConsumeEventAction {
     consumerServiceContext: ServiceContext<ServiceConfig>;
-    consumerDeployContext: DeployContext;
+    consumerDeployContext: IDeployContext;
     consumerServiceDeployer: ServiceDeployer;
     producerServiceContext: ServiceContext<ServiceConfig>;
-    producerDeployContext: DeployContext;
+    producerDeployContext: IDeployContext;
 }
 
 export async function consumeEvents(serviceRegistry: ServiceRegistry, environmentContext: EnvironmentContext, deployContexts: DeployContexts) {
@@ -53,8 +61,8 @@ export async function consumeEvents(serviceRegistry: ServiceRegistry, environmen
                     }
 
                     const consumeEventsContext = await consumerServiceDeployer.consumeEvents(consumerServiceContext, consumerDeployContext, producerServiceContext, producerDeployContext);
-                    if (!(consumeEventsContext instanceof ConsumeEventsContext)) {
-                        throw new Error('Expected ConsumeEventsContext back from \'consumeEvents\' phase of service deployer');
+                    if (!isConsumeEventsContext(consumeEventsContext)) {
+                        throw new DontBlameHandelError('Expected ConsumeEventsContext back from \'consumeEvents\' phase of service deployer', consumerServiceContext.serviceType);
                     }
 
                     consumeEventsContexts[consumeEventsContextName] = consumeEventsContext;

--- a/handel/src/phases/pre-deploy.ts
+++ b/handel/src/phases/pre-deploy.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  *
  */
-import { PreDeployContext, ServiceRegistry } from 'handel-extension-api';
+import { isPreDeployContext, ServiceRegistry } from 'handel-extension-api';
 import * as winston from 'winston';
 import * as lifecyclesCommon from '../common/lifecycles-common';
-import { EnvironmentContext, PreDeployContexts } from '../datatypes';
+import { DontBlameHandelError, EnvironmentContext, PreDeployContexts } from '../datatypes';
 
 export async function preDeployServices(serviceRegistry: ServiceRegistry, environmentContext: EnvironmentContext): Promise<PreDeployContexts> {
     winston.info(`Executing pre-deploy phase on services in environment ${environmentContext.environmentName}`);
@@ -32,8 +32,8 @@ export async function preDeployServices(serviceRegistry: ServiceRegistry, enviro
             if (serviceDeployer.preDeploy) {
                 const preDeployPromise = serviceDeployer.preDeploy(serviceContext)
                     .then(preDeployContext => {
-                        if (!(preDeployContext instanceof PreDeployContext)) {
-                            throw new Error('Expected PreDeployContext as result from \'preDeploy\' phase');
+                        if (!isPreDeployContext(preDeployContext)) {
+                            throw new DontBlameHandelError('Expected PreDeployContext as result from \'preDeploy\' phase', serviceContext.serviceType);
                         }
                         preDeployContexts[serviceContext.serviceName] = preDeployContext;
                     });

--- a/handel/src/phases/un-bind.ts
+++ b/handel/src/phases/un-bind.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  *
  */
-import { ServiceRegistry, UnBindContext } from 'handel-extension-api';
+import { isUnBindContext, ServiceRegistry } from 'handel-extension-api';
 import * as winston from 'winston';
 import * as lifecyclesCommon from '../common/lifecycles-common';
-import { DeployOrder, EnvironmentContext, UnBindContexts } from '../datatypes';
+import { DeployOrder, DontBlameHandelError, EnvironmentContext, UnBindContexts } from '../datatypes';
 
 export async function unBindServicesInLevel(serviceRegistry: ServiceRegistry, environmentContext: EnvironmentContext, deployOrder: DeployOrder, level: number): Promise<UnBindContexts> {
     const unBindPromises: Array<Promise<void>> = [];
@@ -33,8 +33,8 @@ export async function unBindServicesInLevel(serviceRegistry: ServiceRegistry, en
         if (serviceDeployer.unBind) {
             const unBindPromise = serviceDeployer.unBind(toUnBindServiceContext)
                 .then(unBindContext => {
-                    if (!(unBindContext instanceof UnBindContext)) {
-                        throw new Error(`Expected UnBindContext back from 'unBind' phase of service deployer`);
+                    if (!isUnBindContext(unBindContext)) {
+                        throw new DontBlameHandelError(`Expected UnBindContext back from 'unBind' phase of service deployer`, toUnBindServiceContext.serviceType);
                     }
                     unBindContexts[toUnBindServiceName] = unBindContext;
                 });

--- a/handel/src/phases/un-deploy.ts
+++ b/handel/src/phases/un-deploy.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  *
  */
-import { ServiceRegistry, UnDeployContext } from 'handel-extension-api';
+import { isUnDeployContext, ServiceRegistry } from 'handel-extension-api';
 import * as winston from 'winston';
 import * as lifecyclesCommon from '../common/lifecycles-common';
-import { DeployOrder, EnvironmentContext, UnDeployContexts} from '../datatypes';
+import { DeployOrder, DontBlameHandelError, EnvironmentContext, UnDeployContexts } from '../datatypes';
 
 export async function unDeployServicesInLevel(serviceRegistry: ServiceRegistry, environmentContext: EnvironmentContext, deployOrder: DeployOrder, level: number): Promise<UnDeployContexts> {
     const serviceUnDeployPromises: Array<Promise<void>> = [];
@@ -34,8 +34,8 @@ export async function unDeployServicesInLevel(serviceRegistry: ServiceRegistry, 
         if (serviceDeployer.unDeploy) {
             const serviceUndeployPromise = serviceDeployer.unDeploy(toUnDeployServiceContext)
                 .then(unDeployContext => {
-                    if (!(unDeployContext instanceof UnDeployContext)) {
-                        throw new Error(`Expected UnDeployContext as result from 'unDeploy' phase`);
+                    if (!isUnDeployContext(unDeployContext)) {
+                        throw new DontBlameHandelError(`Expected UnDeployContext as result from 'unDeploy' phase`, toUnDeployServiceContext.serviceType);
                     }
                     levelUnDeployContexts[toUnDeployServiceName] = unDeployContext;
                 });

--- a/handel/src/phases/un-pre-deploy.ts
+++ b/handel/src/phases/un-pre-deploy.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  *
  */
-import { ServiceRegistry, UnPreDeployContext } from 'handel-extension-api';
+import { isUnPreDeployContext, ServiceRegistry } from 'handel-extension-api';
 import * as winston from 'winston';
 import * as lifecyclesCommon from '../common/lifecycles-common';
-import { EnvironmentContext, UnPreDeployContexts } from '../datatypes';
+import { DontBlameHandelError, EnvironmentContext, UnPreDeployContexts } from '../datatypes';
 
 export async function unPreDeployServices(serviceRegistry: ServiceRegistry, environmentContext: EnvironmentContext): Promise<UnPreDeployContexts> {
     winston.info(`Executing UnPreDeploy on services in environment ${environmentContext.environmentName}`);
@@ -32,8 +32,8 @@ export async function unPreDeployServices(serviceRegistry: ServiceRegistry, envi
             if (serviceDeployer.unPreDeploy) {
                 const unPreDeployPromise = serviceDeployer.unPreDeploy(serviceContext)
                     .then(unPreDeployContext => {
-                        if (!(unPreDeployContext instanceof UnPreDeployContext)) {
-                            throw new Error(`Expected PreDeployContext as result from 'preDeploy' phase`);
+                        if (!isUnPreDeployContext(unPreDeployContext)) {
+                            throw new DontBlameHandelError(`Expected PreDeployContext as result from 'preDeploy' phase`, serviceContext.serviceType);
                         }
                         unPreDeployContexts[serviceContext.serviceName] = unPreDeployContext;
                     });


### PR DESCRIPTION
![Ducks](https://media.giphy.com/media/vIJaz7nMJhTUc/giphy.gif)

Thanks to Node's super fun module resolution weirdness, the extensions
API in an actual extension might be a different instance than the one in
Handel proper. So, we're ditching instanceof in favor of Duck type
checking ("if it quacks like a duck, it must be a duck!"). Yaaaay node.