### PR TITLE
Change events to use a more well-defined eventOutputs object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage/
 dist/
 lerna-debug.log
 .vscode/
+.handel-extensions/

--- a/examples/apigateway-with-dynamodb/handel.yml
+++ b/examples/apigateway-with-dynamodb/handel.yml
@@ -2,9 +2,6 @@ version: 1
 
 name: apigateway-example
 
-extensions:
-  sns: sns-handel-extension
-
 environments:
   dev:
     webapp:
@@ -14,6 +11,12 @@ environments:
       tags:
         mytag: myvalue
       dependencies:
-      - topic
-    topic:
-      type: sns::sns
+      - table
+    table:
+      type: dynamodb
+      partition_key:
+        name: MyPartionKey
+        type: String
+      provisioned_throughput:
+        read_capacity_units: 2
+        write_capacity_units: 2

--- a/examples/apigateway-with-dynamodb/handel.yml
+++ b/examples/apigateway-with-dynamodb/handel.yml
@@ -2,6 +2,9 @@ version: 1
 
 name: apigateway-example
 
+extensions:
+  sns: sns-handel-extension
+
 environments:
   dev:
     webapp:
@@ -11,12 +14,6 @@ environments:
       tags:
         mytag: myvalue
       dependencies:
-      - table
-    table:
-      type: dynamodb
-      partition_key:
-        name: MyPartionKey
-        type: String
-      provisioned_throughput:
-        read_capacity_units: 2
-        write_capacity_units: 2
+      - topic
+    topic:
+      type: sns::sns

--- a/examples/random-secret-extension/src/service.ts
+++ b/examples/random-secret-extension/src/service.ts
@@ -41,7 +41,7 @@ export class RandomSecretService implements ServiceDeployer {
 
     public readonly consumedDeployOutputTypes = [];
     public readonly producedDeployOutputTypes = ['environmentVariables'];
-    public readonly producedEventsSupportedServices = [];
+    public readonly producedEventsSupportedTypes = [];
     public readonly supportsTagging = false;
 
     public check(serviceContext: ServiceContext<RandomSecretConfig>, dependenciesServiceContexts: Array<ServiceContext<ServiceConfig>>): string[] {

--- a/handel/src/aws/s3-calls.ts
+++ b/handel/src/aws/s3-calls.ts
@@ -16,6 +16,7 @@
  */
 import * as childProcess from 'child_process';
 import * as fs from 'fs';
+import { ServiceEventType } from 'handel-extension-api';
 import { awsCalls } from 'handel-extension-support';
 import * as winston from 'winston';
 import awsWrapper from './aws-wrapper';
@@ -48,7 +49,7 @@ export function uploadDirectory(bucketName: string, keyPrefix: string, dirToUplo
 }
 
 // TODO - I would like to find a way to reduce duplication in this function. The TS types make it difficult to generalize this the way I would in untyped JS
-export async function configureBucketNotifications(bucketName: string, notificationType: string, notificationArn: string, notificationEvents: AWS.S3.EventList, eventFilters: AWS.S3.FilterRuleList) {
+export async function configureBucketNotifications(bucketName: string, notificationType: ServiceEventType, notificationArn: string, notificationEvents: AWS.S3.EventList, eventFilters: AWS.S3.FilterRuleList) {
     const putNotificationParams: AWS.S3.PutBucketNotificationConfigurationRequest = {
         Bucket: bucketName,
         NotificationConfiguration: {}
@@ -64,7 +65,7 @@ export async function configureBucketNotifications(bucketName: string, notificat
         };
     }
 
-    if (notificationType === 'lambda') {
+    if (notificationType === ServiceEventType.Lambda) {
         putNotificationParams.NotificationConfiguration.LambdaFunctionConfigurations = [{
             LambdaFunctionArn: notificationArn,
             Events: notificationEvents,
@@ -73,7 +74,7 @@ export async function configureBucketNotifications(bucketName: string, notificat
             putNotificationParams.NotificationConfiguration.LambdaFunctionConfigurations[0].Filter = filterConfig;
         }
     }
-    else if (notificationType === 'sns') {
+    else if (notificationType === ServiceEventType.SNS) {
         putNotificationParams.NotificationConfiguration.TopicConfigurations = [{
             TopicArn: notificationArn,
             Events: notificationEvents
@@ -82,7 +83,7 @@ export async function configureBucketNotifications(bucketName: string, notificat
             putNotificationParams.NotificationConfiguration.TopicConfigurations[0].Filter = filterConfig;
         }
     }
-    else if (notificationType === 'sqs') {
+    else if (notificationType === ServiceEventType.SQS) {
         putNotificationParams.NotificationConfiguration.QueueConfigurations = [{
             QueueArn: notificationArn,
             Events: notificationEvents

--- a/handel/src/handelfile/parser-v1.ts
+++ b/handel/src/handelfile/parser-v1.ts
@@ -132,7 +132,7 @@ function checkServiceDependencies(handelFile: HandelFile, serviceRegistry: Servi
  * Checks the event_consumers of each service (if any) to make sure the producers and consumers are
  * compatible with each other
  *
- * This is accomplished via the "producedEventsSupportedServices" list from the
+ * This is accomplished via the "producedEventsSupportedTypes" list from the
  * deployer contract, where the deployers specify what services (if any) can consume events
  * from that service.
  */
@@ -156,10 +156,13 @@ function checkEventConsumers(handelFile: HandelFile, serviceRegistry: ServiceReg
                                 errors.push(`You declared an event consumer '${eventConsumerServiceName}' in the service '${serviceName}' that doesn't exist`);
                             }
                             const eventConsumerServiceDef = environmentDef[eventConsumerServiceName];
+                            const eventConsumerServiceType = parseServiceType(eventConsumerServiceDef.type);
 
-                            const serviceDeployer = serviceRegistry.getService(serviceType);
-                            const supportedConsumerTypes = serviceDeployer.producedEventsSupportedServices;
-                            if (!supportedConsumerTypes.includes(eventConsumerServiceDef.type)) {
+                            const producerServiceDeployer = serviceRegistry.getService(serviceType);
+                            const consumerServiceDeployer = serviceRegistry.getService(eventConsumerServiceType);
+
+                            const supportedConsumerTypes = producerServiceDeployer.producedEventsSupportedTypes;
+                            if (!supportedConsumerTypes.includes(consumerServiceDeployer.providedEventType!)) {
                                 errors.push(`The '${eventConsumerServiceDef.type}' service type can't consume events from the '${serviceDef.type}' service type`);
                             }
                         }
@@ -227,7 +230,7 @@ export function createEnvironmentContext(handelFile: HandelFile, environmentName
         const type = parseServiceType(serviceSpec.type);
         const service = serviceRegistry.getService(type);
         environmentContext.serviceContexts[serviceName] = new ServiceContext(handelFile.name, environmentName, serviceName, type, serviceSpec, accountConfig, handelFile.tags || {}, {
-            producedEventsSupportedServices: service.producedEventsSupportedServices,
+            producedEventsSupportedTypes: service.producedEventsSupportedTypes,
             producedDeployOutputTypes: service.producedDeployOutputTypes,
             consumedDeployOutputTypes: service.consumedDeployOutputTypes,
         });

--- a/handel/src/phases/consume-events.ts
+++ b/handel/src/phases/consume-events.ts
@@ -66,7 +66,7 @@ export async function consumeEvents(serviceRegistry: ServiceRegistry, environmen
                         throw new Error(`Tried to invoke the 'consumeEvents' phase on the '${consumerServiceContext.serviceType}' service, but it does not implement it`);
                     }
 
-                    const consumeEventsContext = await consumerServiceDeployer.consumeEvents(consumerServiceContext, consumerDeployContext, producerServiceContext, producerDeployContext);
+                    const consumeEventsContext = await consumerServiceDeployer.consumeEvents(consumerServiceContext, consumerDeployContext, eventConsumerConfig, producerServiceContext, producerDeployContext);
                     if (!isConsumeEventsContext(consumeEventsContext)) {
                         throw new DontBlameHandelError('Expected ConsumeEventsContext back from \'consumeEvents\' phase of service deployer', consumerServiceContext.serviceType);
                     }

--- a/handel/src/services/alexaskillkit/index.ts
+++ b/handel/src/services/alexaskillkit/index.ts
@@ -14,14 +14,17 @@
  * limitations under the License.
  *
  */
-import { DeployContext, PreDeployContext, ProduceEventsContext, ServiceConfig, ServiceContext, ServiceEventConsumer } from 'handel-extension-api';
+import { DeployContext, PreDeployContext, ProduceEventsContext, ServiceConfig, ServiceContext, ServiceEventConsumer, ServiceEventType } from 'handel-extension-api';
 import * as winston from 'winston';
 
 const SERVICE_NAME = 'Alexa Skill Kit';
 
 function getDeployContext(ownServiceContext: ServiceContext<ServiceConfig>): DeployContext {
     const deployContext = new DeployContext(ownServiceContext);
-    deployContext.eventOutputs.principal = 'alexa-appkit.amazon.com';
+    deployContext.eventOutputs = {
+        resourcePrincipal: 'alexa-appkit.amazon.com',
+        serviceEventType: ServiceEventType.AlexaSkillKit
+    };
     return deployContext;
 }
 
@@ -45,8 +48,10 @@ export function produceEvents(ownServiceContext: ServiceContext<ServiceConfig>, 
     return Promise.resolve(new ProduceEventsContext(ownServiceContext, consumerServiceContext));
 }
 
-export const producedEventsSupportedServices = [
-    'lambda'
+export const providedEventType = ServiceEventType.AlexaSkillKit;
+
+export const producedEventsSupportedTypes = [
+    ServiceEventType.Lambda
 ];
 
 export const producedDeployOutputTypes = [];

--- a/handel/src/services/apiaccess/index.ts
+++ b/handel/src/services/apiaccess/index.ts
@@ -15,7 +15,13 @@
  *
  */
 import * as fs from 'fs';
-import { DeployContext, PreDeployContext, ServiceConfig, ServiceContext } from 'handel-extension-api';
+import {
+    DeployContext,
+    DeployOutputType,
+    PreDeployContext,
+    ServiceConfig,
+    ServiceContext
+} from 'handel-extension-api';
 import * as winston from 'winston';
 import * as util from '../../common/util';
 import { APIAccessConfig } from './config-types';
@@ -69,10 +75,10 @@ export async function deploy(ownServiceContext: ServiceContext<APIAccessConfig>,
     return getDeployContext(ownServiceContext);
 }
 
-export const producedEventsSupportedServices = [];
+export const producedEventsSupportedTypes = [];
 
 export const producedDeployOutputTypes = [
-    'policies'
+    DeployOutputType.Policies
 ];
 
 export const consumedDeployOutputTypes = [];

--- a/handel/src/services/apigateway/index.ts
+++ b/handel/src/services/apigateway/index.ts
@@ -14,7 +14,15 @@
  * limitations under the License.
  *
  */
-import { DeployContext, PreDeployContext, ServiceConfig, ServiceContext, UnDeployContext, UnPreDeployContext } from 'handel-extension-api';
+import {
+    DeployContext,
+    DeployOutputType,
+    PreDeployContext,
+    ServiceConfig,
+    ServiceContext,
+    UnDeployContext,
+    UnPreDeployContext
+} from 'handel-extension-api';
 import { deletePhases, preDeployPhase } from 'handel-extension-support';
 import * as winston from 'winston';
 import {isValidHostname} from '../../aws/route53-calls';
@@ -124,14 +132,14 @@ export function unDeploy(ownServiceContext: ServiceContext<APIGatewayConfig>): P
     return deletePhases.unDeployService(ownServiceContext, SERVICE_NAME);
 }
 
-export const producedEventsSupportedServices = [];
+export const producedEventsSupportedTypes = [];
 
 export const producedDeployOutputTypes = [];
 
 export const consumedDeployOutputTypes = [
-    'environmentVariables',
-    'policies',
-    'securityGroups'
+    DeployOutputType.Policies,
+    DeployOutputType.EnvironmentVariables,
+    DeployOutputType.SecurityGroups
 ];
 
 export const supportsTagging = true;

--- a/handel/src/services/beanstalk/index.ts
+++ b/handel/src/services/beanstalk/index.ts
@@ -16,6 +16,7 @@
  */
 import {
     DeployContext,
+    DeployOutputType,
     EnvironmentVariables,
     PreDeployContext,
     ServiceConfig,
@@ -289,16 +290,16 @@ export async function unDeploy(ownServiceContext: ServiceContext<BeanstalkServic
     return deletePhases.unDeployService(ownServiceContext, SERVICE_NAME);
 }
 
-export const producedEventsSupportedServices = [];
+export const producedEventsSupportedTypes = [];
 
 export const producedDeployOutputTypes = [];
 
 export const consumedDeployOutputTypes = [
-    'environmentVariables',
-    'scripts',
-    'policies',
-    'credentials',
-    'securityGroups'
+    DeployOutputType.EnvironmentVariables,
+    DeployOutputType.Scripts,
+    DeployOutputType.Policies,
+    DeployOutputType.Credentials,
+    DeployOutputType.SecurityGroups
 ];
 
 export const supportsTagging = true;

--- a/handel/src/services/codedeploy/index.ts
+++ b/handel/src/services/codedeploy/index.ts
@@ -14,7 +14,15 @@
  * limitations under the License.
  *
  */
-import { DeployContext, PreDeployContext, ServiceContext, Tags, UnDeployContext, UnPreDeployContext } from 'handel-extension-api';
+import {
+    DeployContext,
+    DeployOutputType,
+    PreDeployContext,
+    ServiceContext,
+    Tags,
+    UnDeployContext,
+    UnPreDeployContext
+} from 'handel-extension-api';
 import { awsCalls, deletePhases, deployPhase, handlebars, preDeployPhase, tagging } from 'handel-extension-support';
 import * as winston from 'winston';
 import * as ec2Calls from '../../aws/ec2-calls';
@@ -108,16 +116,16 @@ export async function unDeploy(ownServiceContext: ServiceContext<CodeDeployServi
     return deletePhases.unDeployService(ownServiceContext, SERVICE_NAME);
 }
 
-exports.producedEventsSupportedServices = [];
+export const producedEventsSupportedTypes = [];
 
-exports.producedDeployOutputTypes = [];
+export const producedDeployOutputTypes = [];
 
-exports.consumedDeployOutputTypes = [
-    'environmentVariables',
-    'scripts',
-    'policies',
-    'credentials',
-    'securityGroups'
+export const consumedDeployOutputTypes = [
+    DeployOutputType.EnvironmentVariables,
+    DeployOutputType.Scripts,
+    DeployOutputType.Policies,
+    DeployOutputType.Credentials,
+    DeployOutputType.SecurityGroups
 ];
 
 export const supportsTagging = true;

--- a/handel/src/services/ecs-fargate/index.ts
+++ b/handel/src/services/ecs-fargate/index.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  *
  */
-import { DeployContext, PreDeployContext, ServiceConfig, ServiceContext } from 'handel-extension-api';
+import {
+    DeployContext,
+    DeployOutputType,
+    PreDeployContext,
+    ServiceConfig,
+    ServiceContext
+} from 'handel-extension-api';
 import { deletePhases, deployPhase, handlebars, preDeployPhase, tagging } from 'handel-extension-support';
 import * as winston from 'winston';
 import * as ec2Calls from '../../aws/ec2-calls';
@@ -150,14 +156,14 @@ export async function unDeploy(ownServiceContext: ServiceContext<FargateServiceC
     return deletePhases.unDeployService(ownServiceContext, SERVICE_NAME);
 }
 
-export const producedEventsSupportedServices = [];
+export const producedEventsSupportedTypes = [];
 
 export const producedDeployOutputTypes = [];
 
 export const consumedDeployOutputTypes = [
-    'environmentVariables',
-    'policies',
-    'securityGroups'
+    DeployOutputType.EnvironmentVariables,
+    DeployOutputType.Policies,
+    DeployOutputType.SecurityGroups
 ];
 
 export const supportsTagging = true;

--- a/handel/src/services/ecs/index.ts
+++ b/handel/src/services/ecs/index.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  *
  */
-import { DeployContext, PreDeployContext, ServiceConfig, ServiceContext } from 'handel-extension-api';
+import {
+    DeployContext,
+    DeployOutputType,
+    PreDeployContext,
+    ServiceConfig,
+    ServiceContext
+} from 'handel-extension-api';
 import { deletePhases, deployPhase, handlebars, preDeployPhase, tagging } from 'handel-extension-support';
 import * as winston from 'winston';
 import * as ec2Calls from '../../aws/ec2-calls';
@@ -174,15 +180,15 @@ export async function unDeploy(ownServiceContext: ServiceContext<EcsServiceConfi
     return deletePhases.unDeployService(ownServiceContext, SERVICE_NAME);
 }
 
-export const producedEventsSupportedServices = [];
+export const producedEventsSupportedTypes = [];
 
 export const producedDeployOutputTypes = [];
 
 export const consumedDeployOutputTypes = [
-    'environmentVariables',
-    'scripts',
-    'policies',
-    'securityGroups'
+    DeployOutputType.EnvironmentVariables,
+    DeployOutputType.Scripts,
+    DeployOutputType.Policies,
+    DeployOutputType.SecurityGroups
 ];
 
 export const supportsTagging = true;

--- a/handel/src/services/efs/index.ts
+++ b/handel/src/services/efs/index.ts
@@ -17,6 +17,7 @@
 import {
     BindContext,
     DeployContext,
+    DeployOutputType,
     PreDeployContext,
     ServiceConfig,
     ServiceContext,
@@ -164,12 +165,12 @@ export async function unDeploy(ownServiceContext: ServiceContext<EfsServiceConfi
     return deletePhases.unDeployService(ownServiceContext, SERVICE_NAME);
 }
 
-export const producedEventsSupportedServices = [];
+export const producedEventsSupportedTypes = [];
 
 export const producedDeployOutputTypes = [
-    'environmentVariables',
-    'scripts',
-    'securityGroups'
+    DeployOutputType.EnvironmentVariables,
+    DeployOutputType.Scripts,
+    DeployOutputType.SecurityGroups
 ];
 
 export const consumedDeployOutputTypes = [];

--- a/handel/src/services/kms/index.ts
+++ b/handel/src/services/kms/index.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  *
  */
-import { DeployContext, PreDeployContext, ServiceConfig, ServiceContext, UnDeployContext } from 'handel-extension-api';
+import {
+    DeployContext,
+    DeployOutputType,
+    PreDeployContext,
+    ServiceConfig,
+    ServiceContext,
+    UnDeployContext
+} from 'handel-extension-api';
 import { awsCalls, deletePhases, deployPhase, handlebars, tagging } from 'handel-extension-support';
 import * as winston from 'winston';
 import {KmsServiceConfig} from './config-types';
@@ -115,11 +122,11 @@ export async function unDeploy(ownServiceContext: ServiceContext<KmsServiceConfi
     return deletePhases.unDeployService(ownServiceContext, SERVICE_NAME);
 }
 
-export const producedEventsSupportedServices = [];
+export const producedEventsSupportedTypes = [];
 
 export const producedDeployOutputTypes = [
-    'environmentVariables',
-    'policies'
+    DeployOutputType.EnvironmentVariables,
+    DeployOutputType.Policies
 ];
 
 export const consumedDeployOutputTypes = [];

--- a/handel/src/services/lambda/config-types.ts
+++ b/handel/src/services/lambda/config-types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
-import { EnvironmentVariables, ServiceConfig, Tags } from 'handel-extension-api';
+import { EnvironmentVariables, ServiceConfig, ServiceEventConsumer, Tags } from 'handel-extension-api';
 
 export interface LambdaServiceConfig extends ServiceConfig {
     path_to_code: string;
@@ -44,7 +44,6 @@ export interface HandlebarsLambdaTemplate {
     vpcSubnetIds?: string[];
 }
 
-export interface DynamoDBLambdaConsumer {
-    serviceName: string;
-    batchSize: number;
+export interface DynamoDBLambdaConsumer extends ServiceEventConsumer {
+    batch_size: number;
 }

--- a/handel/src/services/memcached/index.ts
+++ b/handel/src/services/memcached/index.ts
@@ -17,6 +17,7 @@
 import {
     BindContext,
     DeployContext,
+    DeployOutputType,
     PreDeployContext,
     ServiceConfig,
     ServiceContext,
@@ -141,11 +142,11 @@ export async function unDeploy(ownServiceContext: ServiceContext<MemcachedServic
     return deletePhases.unDeployService(ownServiceContext, SERVICE_NAME);
 }
 
-export const producedEventsSupportedServices = [];
+export const producedEventsSupportedTypes = [];
 
 export const producedDeployOutputTypes = [
-    'environmentVariables',
-    'securityGroups'
+    DeployOutputType.EnvironmentVariables,
+    DeployOutputType.SecurityGroups
 ];
 
 export const consumedDeployOutputTypes = [];

--- a/handel/src/services/mysql/index.ts
+++ b/handel/src/services/mysql/index.ts
@@ -17,6 +17,7 @@
 import {
     BindContext,
     DeployContext,
+    DeployOutputType,
     PreDeployContext,
     ServiceConfig,
     ServiceContext,
@@ -172,11 +173,11 @@ export async function unDeploy(ownServiceContext: ServiceContext<MySQLConfig>): 
     return unDeployContext;
 }
 
-export const producedEventsSupportedServices = [];
+export const producedEventsSupportedTypes = [];
 
 export const producedDeployOutputTypes = [
-    'environmentVariables',
-    'securityGroups'
+    DeployOutputType.EnvironmentVariables,
+    DeployOutputType.SecurityGroups
 ];
 
 export const consumedDeployOutputTypes = [];

--- a/handel/src/services/postgresql/index.ts
+++ b/handel/src/services/postgresql/index.ts
@@ -17,6 +17,7 @@
 import {
     BindContext,
     DeployContext,
+    DeployOutputType,
     PreDeployContext,
     ServiceConfig,
     ServiceContext,
@@ -177,11 +178,11 @@ export async function unDeploy(ownServiceContext: ServiceContext<PostgreSQLConfi
     return unDeployContext;
 }
 
-export const producedEventsSupportedServices = [];
+export const producedEventsSupportedTypes = [];
 
 export const producedDeployOutputTypes = [
-    'environmentVariables',
-    'securityGroups'
+    DeployOutputType.EnvironmentVariables,
+    DeployOutputType.SecurityGroups
 ];
 
 export const consumedDeployOutputTypes = [];

--- a/handel/src/services/redis/index.ts
+++ b/handel/src/services/redis/index.ts
@@ -17,6 +17,7 @@
 import {
     BindContext,
     DeployContext,
+    DeployOutputType,
     PreDeployContext,
     ServiceConfig,
     ServiceContext,
@@ -193,11 +194,11 @@ export async function unDeploy(ownServiceContext: ServiceContext<RedisServiceCon
     return deletePhases.unDeployService(ownServiceContext, SERVICE_NAME);
 }
 
-export const producedEventsSupportedServices = [];
+export const producedEventsSupportedTypes = [];
 
 export const producedDeployOutputTypes = [
-    'environmentVariables',
-    'securityGroups'
+    DeployOutputType.EnvironmentVariables,
+    DeployOutputType.SecurityGroups
 ];
 
 export const consumedDeployOutputTypes = [];

--- a/handel/src/services/route53zone/index.ts
+++ b/handel/src/services/route53zone/index.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  *
  */
-import {DeployContext, PreDeployContext, ServiceConfig, ServiceContext, UnDeployContext} from 'handel-extension-api';
+import {
+    DeployContext,
+    DeployOutputType,
+    PreDeployContext,
+    ServiceConfig,
+    ServiceContext,
+    UnDeployContext
+} from 'handel-extension-api';
 import { awsCalls, deletePhases, deployPhase, handlebars, tagging } from 'handel-extension-support';
 import * as winston from 'winston';
 import * as route53 from '../../aws/route53-calls';
@@ -100,10 +107,10 @@ export async function unDeploy(ownServiceContext: ServiceContext<Route53ZoneServ
     return deletePhases.unDeployService(ownServiceContext, SERVICE_NAME);
 }
 
-export const producedEventsSupportedServices = [];
+export const producedEventsSupportedTypes = [];
 
 export const producedDeployOutputTypes = [
-    'environmentVariables'
+    DeployOutputType.EnvironmentVariables
 ];
 
 export const consumedDeployOutputTypes = [];

--- a/handel/src/services/s3staticsite/index.ts
+++ b/handel/src/services/s3staticsite/index.ts
@@ -223,7 +223,7 @@ export async function unDeploy(ownServiceContext: ServiceContext<S3StaticSiteSer
     return deletePhases.unDeployService(ownServiceContext, SERVICE_NAME);
 }
 
-export const producedEventsSupportedServices = [];
+export const producedEventsSupportedTypes = [];
 
 export const producedDeployOutputTypes = [];
 

--- a/handel/src/services/ses/index.ts
+++ b/handel/src/services/ses/index.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  *
  */
-import { DeployContext, PreDeployContext, ServiceConfig, ServiceContext } from 'handel-extension-api';
+import {
+    DeployContext,
+    DeployOutputType,
+    PreDeployContext,
+    ServiceConfig,
+    ServiceContext
+} from 'handel-extension-api';
 import * as winston from 'winston';
 import * as sesCalls from '../../aws/ses-calls';
 import { SesServiceConfig } from './config-types';
@@ -75,11 +81,11 @@ export async function deploy(ownServiceContext: ServiceContext<SesServiceConfig>
     return getDeployContext(ownServiceContext);
 }
 
-export const producedEventsSupportedServices = [];
+export const producedEventsSupportedTypes = [];
 
 export const producedDeployOutputTypes = [
-    'environmentVariables',
-    'policies'
+    DeployOutputType.EnvironmentVariables,
+    DeployOutputType.Policies
 ];
 
 export const consumedDeployOutputTypes = [];

--- a/handel/src/services/stepfunctions/index.ts
+++ b/handel/src/services/stepfunctions/index.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  *
  */
-import { DeployContext, PreDeployContext, ServiceConfig, ServiceContext, UnDeployContext } from 'handel-extension-api';
+import {
+    DeployContext,
+    DeployOutputType,
+    PreDeployContext,
+    ServiceConfig,
+    ServiceContext,
+    UnDeployContext
+} from 'handel-extension-api';
 import { awsCalls, deletePhases, deployPhase, handlebars, tagging } from 'handel-extension-support';
 import * as _ from 'lodash';
 import * as path from 'path';
@@ -90,21 +97,13 @@ export async function unDeploy(ownServiceContext: ServiceContext<StepFunctionsCo
     return deletePhases.unDeployService(ownServiceContext, SERVICE_NAME);
 }
 
-export const producedEventsSupportedServices = [];
-
-export const producedDeployOutputTypes = ['environmentVariables', 'policies'];
-
-export const consumedDeployOutputTypes = ['environmentVariables', 'policies'];
-
-export const supportsTagging = false;
-
 function generateDefinitionString(filename: string, dependenciesDeployContexts: DeployContext[]): string {
     const readFile = path.extname(filename) === '.json' ? util.readJsonFileSync : util.readYamlFileSync;
     const definitionFile = readFile(filename);
     const dependencyArns: Map<string, string> = new Map();
     // Map service name to ARN
     for (const context of dependenciesDeployContexts) {
-        dependencyArns.set(context.serviceName, context.eventOutputs.lambdaArn);
+        dependencyArns.set(context.serviceName, context.eventOutputs!.resourceArn!);
     }
     // Change 'resource' in each state from service name to ARN
     _.values(definitionFile.States)
@@ -151,3 +150,17 @@ function getDeployContext(serviceContext: ServiceContext<StepFunctionsConfig>, c
 
     return deployContext;
 }
+
+export const producedEventsSupportedTypes = [];
+
+export const producedDeployOutputTypes = [
+    DeployOutputType.EnvironmentVariables,
+    DeployOutputType.Policies
+];
+
+export const consumedDeployOutputTypes = [
+    DeployOutputType.EnvironmentVariables,
+    DeployOutputType.Policies
+];
+
+export const supportsTagging = false;

--- a/handel/test/aws/s3-calls-test.ts
+++ b/handel/test/aws/s3-calls-test.ts
@@ -16,6 +16,7 @@
  */
 import { expect } from 'chai';
 import * as childProcess from 'child_process';
+import { ServiceEventType } from 'handel-extension-api';
 import 'mocha';
 import * as sinon from 'sinon';
 import awsWrapper from '../../src/aws/aws-wrapper';
@@ -70,9 +71,9 @@ describe('s3Calls', () => {
 
     describe('configureBucketNotifications', () => {
         const servicesToTest = [
-            'lambda',
-            'sns',
-            'sqs'
+            ServiceEventType.Lambda,
+            ServiceEventType.SNS,
+            ServiceEventType.SQS
         ];
         servicesToTest.forEach(serviceToTest => {
             it(`should configure bucket notifications for the ${serviceToTest} type`, async () => {
@@ -96,7 +97,7 @@ describe('s3Calls', () => {
 
         it('should throw an error for other service types', async () => {
             const bucketName = 'FakeS3BucketName';
-            const notificationType = 'othertype';
+            const notificationType = ServiceEventType.CloudWatchEvents;
             const notificationArn = 'FakeNotificationArn';
             const notificationEvents: AWS.S3.EventList = [
                 's3:ObjectCreated*'

--- a/handel/test/datatypes/datatypes-test.ts
+++ b/handel/test/datatypes/datatypes-test.ts
@@ -80,7 +80,7 @@ describe('Datatypes Module', () => {
             expect(deployContext.environmentName).to.equal(serviceContext.environmentName);
             expect(deployContext.serviceName).to.equal(serviceContext.serviceName);
             expect(deployContext.serviceType).to.equal(serviceContext.serviceType);
-            expect(deployContext.eventOutputs).to.deep.equal({});
+            expect(deployContext.eventOutputs).to.deep.equal(null);
             expect(deployContext.policies).to.deep.equal([]);
             expect(deployContext.environmentVariables).to.deep.equal({});
             expect(deployContext.scripts).to.deep.equal([]);

--- a/handel/test/handelfile/parser-v1-test.ts
+++ b/handel/test/handelfile/parser-v1-test.ts
@@ -15,7 +15,7 @@
  *
  */
 import { expect } from 'chai';
-import { ServiceRegistry } from 'handel-extension-api';
+import { DeployOutputType, ServiceEventType, ServiceRegistry } from 'handel-extension-api';
 import { AccountConfig, ServiceType } from 'handel-extension-api';
 import 'mocha';
 import config from '../../src/account-config/account-config';
@@ -35,51 +35,53 @@ describe('parser-v1', () => {
             lambda: {
                 producedDeployOutputTypes: [],
                 consumedDeployOutputTypes: [
-                    'environmentVariables',
-                    'policies'
+                    DeployOutputType.EnvironmentVariables,
+                    DeployOutputType.Policies,
                 ],
-                producedEventsSupportedServices: [],
+                providedEventType: ServiceEventType.Lambda,
+                producedEventsSupportedTypes: [],
                 supportsTagging: true,
             },
             dynamodb: {
                 producedDeployOutputTypes: [
-                    'environmentVariables',
-                    'policies'
+                    DeployOutputType.EnvironmentVariables,
+                    DeployOutputType.Policies
                 ],
                 consumedDeployOutputTypes: [],
-                producedEventsSupportedServices: [
-                    'lambda'
+                providedEventType: ServiceEventType.DynamoDB,
+                producedEventsSupportedTypes: [
+                    ServiceEventType.Lambda
                 ],
                 supportsTagging: true,
             },
             ecs: {
                 producedDeployOutputTypes: [],
                 consumedDeployOutputTypes: [
-                    'environmentVariables',
-                    'scripts',
-                    'policies',
-                    'securityGroups'
+                    DeployOutputType.EnvironmentVariables,
+                    DeployOutputType.Scripts,
+                    DeployOutputType.Policies,
+                    DeployOutputType.SecurityGroups
                 ],
-                producedEventsSupportedServices: [],
+                producedEventsSupportedTypes: [],
                 supportsTagging: true,
             },
             efs: {
                 producedDeployOutputTypes: [
-                    'environmentVariables',
-                    'scripts',
-                    'securityGroups'
+                    DeployOutputType.EnvironmentVariables,
+                    DeployOutputType.Scripts,
+                    DeployOutputType.SecurityGroups
                 ],
                 consumedDeployOutputTypes: [],
-                producedEventsSupportedServices: [],
+                producedEventsSupportedTypes: [],
                 supportsTagging: true,
             },
             apigateway: {
                 producedDeployOutputTypes: [],
                 consumedDeployOutputTypes: [
-                    'environmentVariables',
-                    'policies'
+                    DeployOutputType.EnvironmentVariables,
+                    DeployOutputType.Policies
                 ],
-                producedEventsSupportedServices: [],
+                producedEventsSupportedTypes: [],
                 supportsTagging: true,
             }
         });

--- a/handel/test/phases/bind-test.ts
+++ b/handel/test/phases/bind-test.ts
@@ -109,7 +109,7 @@ describe('bind', () => {
         it('should execute bind on all the services in parallel', async () => {
             const serviceRegistry = new FakeServiceRegistry({
                 ecs: {
-                    producedEventsSupportedServices: [],
+                    producedEventsSupportedTypes: [],
                     producedDeployOutputTypes: [],
                     consumedDeployOutputTypes: [],
                     bind: (toBindServiceContext, toBindPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) => {
@@ -118,7 +118,7 @@ describe('bind', () => {
                     supportsTagging: true,
                 },
                 efs: {
-                    producedEventsSupportedServices: [],
+                    producedEventsSupportedTypes: [],
                     producedDeployOutputTypes: [],
                     consumedDeployOutputTypes: [],
                     bind: (toBindServiceContext, toBindPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) => {
@@ -136,14 +136,14 @@ describe('bind', () => {
         it('should return empty BindContexts for services that dont implement bind', async () => {
             const serviceRegistry = new FakeServiceRegistry({
                 ecs: {
-                    producedEventsSupportedServices: [],
+                    producedEventsSupportedTypes: [],
                     producedDeployOutputTypes: [],
                     consumedDeployOutputTypes: [],
                     // Simulating that ECS doesn't implement bind,
                     supportsTagging: true,
                 },
                 efs: {
-                    producedEventsSupportedServices: [],
+                    producedEventsSupportedTypes: [],
                     producedDeployOutputTypes: [],
                     consumedDeployOutputTypes: [],
                     bind: (toBindServiceContext, toBindPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) => {

--- a/handel/test/phases/check-test.ts
+++ b/handel/test/phases/check-test.ts
@@ -15,7 +15,7 @@
  *
  */
 import { expect } from 'chai';
-import { AccountConfig, ServiceConfig, ServiceContext, ServiceType } from 'handel-extension-api';
+import { AccountConfig, DeployOutputType, ServiceConfig, ServiceContext, ServiceType } from 'handel-extension-api';
 import 'mocha';
 import config from '../../src/account-config/account-config';
 import { EnvironmentContext } from '../../src/datatypes';
@@ -34,13 +34,13 @@ describe('check', () => {
         function getServiceRegistry(): FakeServiceRegistry {
             return new FakeServiceRegistry({
                 ecs: {
-                    producedEventsSupportedServices: [],
+                    producedEventsSupportedTypes: [],
                     producedDeployOutputTypes: [],
                     consumedDeployOutputTypes: [
-                        'securityGroups',
-                        'policies',
-                        'scripts',
-                        'environmentVariables',
+                        DeployOutputType.SecurityGroups,
+                        DeployOutputType.Policies,
+                        DeployOutputType.Scripts,
+                        DeployOutputType.EnvironmentVariables
                     ],
                     check: (serviceContext: ServiceContext<ServiceConfig>) => {
                         return [];
@@ -48,11 +48,11 @@ describe('check', () => {
                     supportsTagging: true,
                 },
                 efs: {
-                    producedEventsSupportedServices: [],
+                    producedEventsSupportedTypes: [],
                     producedDeployOutputTypes: [
-                        'environmentVariables',
-                        'scripts',
-                        'securityGroups'
+                        DeployOutputType.EnvironmentVariables,
+                        DeployOutputType.Scripts,
+                        DeployOutputType.SecurityGroups
                     ],
                     consumedDeployOutputTypes: [],
                     supportsTagging: true,

--- a/handel/test/phases/consume-events-test.ts
+++ b/handel/test/phases/consume-events-test.ts
@@ -20,6 +20,7 @@ import {
     ConsumeEventsContext,
     DeployContext,
     ServiceContext,
+    ServiceEventType,
     ServiceType
 } from 'handel-extension-api';
 import 'mocha';
@@ -47,21 +48,21 @@ describe('consumeEvents module', () => {
         it('should execute consumeEvents on all services that are specified as consumers by other services', async () => {
             const serviceRegistry = new FakeServiceRegistry({
                 lambda: {
-                    producedEventsSupportedServices: [],
+                    producedEventsSupportedTypes: [],
                     producedDeployOutputTypes: [],
                     consumedDeployOutputTypes: [],
-                    consumeEvents: (ownServiceContext,  ownDeployContext,  producerServiceContext,  producerDeployContext) => {
+                    consumeEvents: (ownServiceContext,  ownDeployContext, eventConfigConsumer,  producerServiceContext,  producerDeployContext) => {
                         return Promise.resolve(new ConsumeEventsContext(ownServiceContext, producerServiceContext));
                     },
                     supportsTagging: true,
                 },
                 s3: {
-                    producedEventsSupportedServices: [
-                        'lambda'
+                    producedEventsSupportedTypes: [
+                        ServiceEventType.Lambda
                     ],
                     producedDeployOutputTypes: [],
                     consumedDeployOutputTypes: [],
-                    consumeEvents: (ownServiceContext,  ownDeployContext,  producerServiceContext,  producerDeployContext) => {
+                    consumeEvents: (ownServiceContext,  ownDeployContext, eventConfigConsumer,  producerServiceContext,  producerDeployContext) => {
                         return Promise.reject(new Error('S3 doesn\'t consume events'));
                     },
                     supportsTagging: true,

--- a/handel/test/phases/deploy-test.ts
+++ b/handel/test/phases/deploy-test.ts
@@ -18,6 +18,7 @@ import { expect } from 'chai';
 import {
     AccountConfig,
     DeployContext,
+    DeployOutputType,
     PreDeployContext,
     ServiceContext,
     ServiceType
@@ -103,11 +104,11 @@ describe('deploy', () => {
         it('should deploy the services in the given level', async () => {
             const serviceRegistry = new FakeServiceRegistry({
                 efs: {
-                    producedEventsSupportedServices: [],
+                    producedEventsSupportedTypes: [],
                     producedDeployOutputTypes: [
-                        'scripts',
-                        'environmentVariables',
-                        'securityGroups'
+                        DeployOutputType.Scripts,
+                        DeployOutputType.EnvironmentVariables,
+                        DeployOutputType.SecurityGroups
                     ],
                     consumedDeployOutputTypes: [],
                     deploy: async (toDeployServiceContext, toDeployPreDeployContext, dependenciesDeployContexts) => {
@@ -116,13 +117,13 @@ describe('deploy', () => {
                     supportsTagging: true,
                 },
                 ecs: {
-                    producedEventsSupportedServices: [],
+                    producedEventsSupportedTypes: [],
                     producedDeployOutputTypes: [],
                     consumedDeployOutputTypes: [
-                        'scripts',
-                        'environmentVariables',
-                        'securityGroups',
-                        'policies'
+                        DeployOutputType.Scripts,
+                        DeployOutputType.EnvironmentVariables,
+                        DeployOutputType.SecurityGroups,
+                        DeployOutputType.Policies
                     ],
                     deploy: async (toDeployServiceContext, toDeployPreDeployContext, dependenciesDeployContexts) => {
                         return new DeployContext(toDeployServiceContext);
@@ -138,11 +139,11 @@ describe('deploy', () => {
         it('should return empty deploy contexts for the phases that dont implement deploy', async () => {
             const serviceRegistry = new FakeServiceRegistry({
                 efs: {
-                    producedEventsSupportedServices: [],
+                    producedEventsSupportedTypes: [],
                     producedDeployOutputTypes: [
-                        'scripts',
-                        'environmentVariables',
-                        'securityGroups'
+                        DeployOutputType.Scripts,
+                        DeployOutputType.EnvironmentVariables,
+                        DeployOutputType.SecurityGroups
                     ],
                     consumedDeployOutputTypes: [],
                     deploy: async (toDeployServiceContext, toDeployPreDeployContext, dependenciesDeployContexts) => {
@@ -151,13 +152,13 @@ describe('deploy', () => {
                     supportsTagging: true,
                 },
                 ecs: {
-                    producedEventsSupportedServices: [],
+                    producedEventsSupportedTypes: [],
                     producedDeployOutputTypes: [],
                     consumedDeployOutputTypes: [
-                        'scripts',
-                        'environmentVariables',
-                        'securityGroups',
-                        'policies'
+                        DeployOutputType.Scripts,
+                        DeployOutputType.EnvironmentVariables,
+                        DeployOutputType.SecurityGroups,
+                        DeployOutputType.Policies
                     ],
                     supportsTagging: true,
                     // Simulating that ECS doesnt implement deploy

--- a/handel/test/phases/pre-deploy-test.ts
+++ b/handel/test/phases/pre-deploy-test.ts
@@ -15,7 +15,7 @@
  *
  */
 import { expect } from 'chai';
-import { AccountConfig, PreDeployContext, ServiceConfig, ServiceContext, ServiceType } from 'handel-extension-api';
+import { AccountConfig, DeployOutputType, PreDeployContext, ServiceConfig, ServiceContext, ServiceType } from 'handel-extension-api';
 import 'mocha';
 import config from '../../src/account-config/account-config';
 import { EnvironmentContext } from '../../src/datatypes';
@@ -66,11 +66,11 @@ describe('preDeploy', () => {
         it('should execute predeploy on all services, even across levels', async () => {
             const serviceRegistry = new FakeServiceRegistry({
                 efs: {
-                    producedEventsSupportedServices: [],
+                    producedEventsSupportedTypes: [],
                     producedDeployOutputTypes: [
-                        'scripts',
-                        'environmentVariables',
-                        'securityGroups'
+                        DeployOutputType.Scripts,
+                        DeployOutputType.EnvironmentVariables,
+                        DeployOutputType.SecurityGroups
                     ],
                     consumedDeployOutputTypes: [],
                     preDeploy: async (serviceContext: ServiceContext<ServiceConfig>) => {
@@ -79,13 +79,13 @@ describe('preDeploy', () => {
                     supportsTagging: true,
                 },
                 ecs: {
-                    producedEventsSupportedServices: [],
+                    producedEventsSupportedTypes: [],
                     producedDeployOutputTypes: [],
                     consumedDeployOutputTypes: [
-                        'scripts',
-                        'environmentVariables',
-                        'securityGroups',
-                        'policies'
+                        DeployOutputType.Scripts,
+                        DeployOutputType.EnvironmentVariables,
+                        DeployOutputType.SecurityGroups,
+                        DeployOutputType.Policies
                     ],
                     preDeploy: async (serviceContext: ServiceContext<ServiceConfig>) => {
                         return new PreDeployContext(serviceContext);
@@ -102,11 +102,11 @@ describe('preDeploy', () => {
         it('should return empty preDeployContexts for services that dont implement preDeploy', async () => {
             const serviceRegistry = new FakeServiceRegistry({
                 efs: {
-                    producedEventsSupportedServices: [],
+                    producedEventsSupportedTypes: [],
                     producedDeployOutputTypes: [
-                        'scripts',
-                        'environmentVariables',
-                        'securityGroups'
+                        DeployOutputType.Scripts,
+                        DeployOutputType.EnvironmentVariables,
+                        DeployOutputType.SecurityGroups
                     ],
                     consumedDeployOutputTypes: [],
                     preDeploy: async (serviceContext: ServiceContext<ServiceConfig>) => {
@@ -115,13 +115,13 @@ describe('preDeploy', () => {
                     supportsTagging: true,
                 },
                 ecs: {
-                    producedEventsSupportedServices: [],
+                    producedEventsSupportedTypes: [],
                     producedDeployOutputTypes: [],
                     consumedDeployOutputTypes: [
-                        'scripts',
-                        'environmentVariables',
-                        'securityGroups',
-                        'policies'
+                        DeployOutputType.Scripts,
+                        DeployOutputType.EnvironmentVariables,
+                        DeployOutputType.SecurityGroups,
+                        DeployOutputType.Policies
                     ],
                     supportsTagging: true,
                     // We're pretending here that ECS doesn't implement predeploy for the purposes of this test, even though it really does

--- a/handel/test/phases/produce-events-test.ts
+++ b/handel/test/phases/produce-events-test.ts
@@ -20,6 +20,7 @@ import {
     DeployContext,
     ProduceEventsContext,
     ServiceContext,
+    ServiceEventType,
     ServiceType
 } from 'handel-extension-api';
 import 'mocha';
@@ -50,7 +51,7 @@ describe('produceEvents module', () => {
         it('should execute produceEvents on all services that specify themselves as producers for other services', async () => {
             const serviceRegistry = new FakeServiceRegistry({
                 lambda: {
-                    producedEventsSupportedServices: [],
+                    producedEventsSupportedTypes: [],
                     producedDeployOutputTypes: [],
                     consumedDeployOutputTypes: [],
                     produceEvents: async (ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext) => {
@@ -59,8 +60,8 @@ describe('produceEvents module', () => {
                     supportsTagging: true,
                 },
                 s3: {
-                    producedEventsSupportedServices: [
-                        'lambda',
+                    producedEventsSupportedTypes: [
+                        ServiceEventType.Lambda
                     ],
                     producedDeployOutputTypes: [],
                     consumedDeployOutputTypes: [],

--- a/handel/test/phases/un-bind-test.ts
+++ b/handel/test/phases/un-bind-test.ts
@@ -15,7 +15,7 @@
  *
  */
 import { expect } from 'chai';
-import { AccountConfig, ServiceContext, ServiceType, UnBindContext } from 'handel-extension-api';
+import { AccountConfig, DeployOutputType, ServiceContext, ServiceType, UnBindContext } from 'handel-extension-api';
 import 'mocha';
 import * as sinon from 'sinon';
 import config from '../../src/account-config/account-config';
@@ -80,13 +80,13 @@ describe('unBind', () => {
         it('should execute UnBind on all the services in parallel', async () => {
             const serviceRegistry = new FakeServiceRegistry({
                 ecs: {
-                    producedEventsSupportedServices: [],
+                    producedEventsSupportedTypes: [],
                     producedDeployOutputTypes: [],
                     consumedDeployOutputTypes: [
-                        'securityGroups',
-                        'scripts',
-                        'environmentVariables',
-                        'policies'
+                        DeployOutputType.SecurityGroups,
+                        DeployOutputType.Scripts,
+                        DeployOutputType.EnvironmentVariables,
+                        DeployOutputType.Policies
                     ],
                     unBind: (toUnBindServiceContext) => {
                         return Promise.reject(new Error(`Should not have called ECS bind`));
@@ -94,11 +94,11 @@ describe('unBind', () => {
                     supportsTagging: true,
                 },
                 efs: {
-                    producedEventsSupportedServices: [],
+                    producedEventsSupportedTypes: [],
                     producedDeployOutputTypes: [
-                        'securityGroups',
-                        'scripts',
-                        'environmentVariables',
+                        DeployOutputType.SecurityGroups,
+                        DeployOutputType.Scripts,
+                        DeployOutputType.EnvironmentVariables
                     ],
                     consumedDeployOutputTypes: [],
                     unBind: (toUnBindServiceContext) => {
@@ -115,13 +115,13 @@ describe('unBind', () => {
         it('should return emtpy unbind contexts for services that dont implement unbind', async () => {
             const serviceRegistry = new FakeServiceRegistry({
                 ecs: {
-                    producedEventsSupportedServices: [],
+                    producedEventsSupportedTypes: [],
                     producedDeployOutputTypes: [],
                     consumedDeployOutputTypes: [
-                        'securityGroups',
-                        'scripts',
-                        'environmentVariables',
-                        'policies'
+                        DeployOutputType.SecurityGroups,
+                        DeployOutputType.Scripts,
+                        DeployOutputType.EnvironmentVariables,
+                        DeployOutputType.Policies
                     ],
                     unBind: (toUnBindServiceContext) => {
                         return Promise.reject(new Error(`Should not have called ECS bind`));
@@ -129,11 +129,11 @@ describe('unBind', () => {
                     supportsTagging: true,
                 },
                 efs: {
-                    producedEventsSupportedServices: [],
+                    producedEventsSupportedTypes: [],
                     producedDeployOutputTypes: [
-                        'securityGroups',
-                        'scripts',
-                        'environmentVariables',
+                        DeployOutputType.SecurityGroups,
+                        DeployOutputType.Scripts,
+                        DeployOutputType.EnvironmentVariables
                     ],
                     consumedDeployOutputTypes: [],
                     supportsTagging: true,

--- a/handel/test/phases/un-deploy-test.ts
+++ b/handel/test/phases/un-deploy-test.ts
@@ -15,7 +15,7 @@
  *
  */
 import { expect } from 'chai';
-import { AccountConfig, ServiceContext, ServiceType, UnDeployContext } from 'handel-extension-api';
+import { AccountConfig, DeployOutputType, ServiceContext, ServiceType, UnDeployContext } from 'handel-extension-api';
 import 'mocha';
 import * as sinon from 'sinon';
 import config from '../../src/account-config/account-config';
@@ -74,11 +74,11 @@ describe('unDeploy', () => {
         it('should UnDeploy the services in the given level', async () => {
             const serviceRegistry = new FakeServiceRegistry({
                 efs: {
-                    producedEventsSupportedServices: [],
+                    producedEventsSupportedTypes: [],
                     producedDeployOutputTypes: [
-                        'securityGroups',
-                        'scripts',
-                        'environmentVariables',
+                        DeployOutputType.SecurityGroups,
+                        DeployOutputType.Scripts,
+                        DeployOutputType.EnvironmentVariables
                     ],
                     consumedDeployOutputTypes: [],
                     unDeploy: (toUnDeployServiceContext) => {
@@ -87,13 +87,13 @@ describe('unDeploy', () => {
                     supportsTagging: true,
                 },
                 ecs: {
-                    producedEventsSupportedServices: [],
+                    producedEventsSupportedTypes: [],
                     producedDeployOutputTypes: [],
                     consumedDeployOutputTypes: [
-                        'securityGroups',
-                        'scripts',
-                        'environmentVariables',
-                        'policies'
+                        DeployOutputType.SecurityGroups,
+                        DeployOutputType.Scripts,
+                        DeployOutputType.EnvironmentVariables,
+                        DeployOutputType.Policies
                     ],
                     unDeploy: (toUnDeployServiceContext) => {
                         return Promise.resolve(new UnDeployContext(toUnDeployServiceContext));
@@ -109,11 +109,11 @@ describe('unDeploy', () => {
         it('should return emtpy undeploy contexts for services that dont implment undeploy', async () => {
             const serviceRegistry = new FakeServiceRegistry({
                 efs: {
-                    producedEventsSupportedServices: [],
+                    producedEventsSupportedTypes: [],
                     producedDeployOutputTypes: [
-                        'securityGroups',
-                        'scripts',
-                        'environmentVariables',
+                        DeployOutputType.SecurityGroups,
+                        DeployOutputType.Scripts,
+                        DeployOutputType.EnvironmentVariables
                     ],
                     consumedDeployOutputTypes: [],
                     unDeploy: (toUnDeployServiceContext) => {
@@ -122,13 +122,13 @@ describe('unDeploy', () => {
                     supportsTagging: true,
                 },
                 ecs: {
-                    producedEventsSupportedServices: [],
+                    producedEventsSupportedTypes: [],
                     producedDeployOutputTypes: [],
                     consumedDeployOutputTypes: [
-                        'securityGroups',
-                        'scripts',
-                        'environmentVariables',
-                        'policies'
+                        DeployOutputType.SecurityGroups,
+                        DeployOutputType.Scripts,
+                        DeployOutputType.EnvironmentVariables,
+                        DeployOutputType.Policies
                     ],
                     supportsTagging: true,
                     // Simulating that ECS doesn't implement undeploy

--- a/handel/test/phases/un-pre-deploy-test.ts
+++ b/handel/test/phases/un-pre-deploy-test.ts
@@ -15,7 +15,7 @@
  *
  */
 import { expect } from 'chai';
-import { AccountConfig, ServiceContext, ServiceType, UnPreDeployContext } from 'handel-extension-api';
+import { AccountConfig, DeployOutputType, ServiceContext, ServiceType, UnPreDeployContext } from 'handel-extension-api';
 import 'mocha';
 import config from '../../src/account-config/account-config';
 import { EnvironmentContext } from '../../src/datatypes';
@@ -66,11 +66,11 @@ describe('preDeploy', () => {
         it('should execute unpredeploy on all services, even across levels', async () => {
             const serviceRegistry = new FakeServiceRegistry({
                 efs: {
-                    producedEventsSupportedServices: [],
+                    producedEventsSupportedTypes: [],
                     producedDeployOutputTypes: [
-                        'securityGroups',
-                        'scripts',
-                        'environmentVariables',
+                        DeployOutputType.SecurityGroups,
+                        DeployOutputType.Scripts,
+                        DeployOutputType.EnvironmentVariables
                     ],
                     consumedDeployOutputTypes: [],
                     unPreDeploy: (serviceContext) => {
@@ -79,13 +79,13 @@ describe('preDeploy', () => {
                     supportsTagging: true,
                 },
                 ecs: {
-                    producedEventsSupportedServices: [],
+                    producedEventsSupportedTypes: [],
                     producedDeployOutputTypes: [],
                     consumedDeployOutputTypes: [
-                        'securityGroups',
-                        'scripts',
-                        'environmentVariables',
-                        'policies'
+                        DeployOutputType.SecurityGroups,
+                        DeployOutputType.Scripts,
+                        DeployOutputType.EnvironmentVariables,
+                        DeployOutputType.Policies
                     ],
                     unPreDeploy: (serviceContext) => {
                         return Promise.resolve(new UnPreDeployContext(serviceContext));
@@ -102,11 +102,11 @@ describe('preDeploy', () => {
         it('should return empty unpredeploy contexts for deployers that dont implement unpredeploy', async () => {
             const serviceRegistry = new FakeServiceRegistry({
                 efs: {
-                    producedEventsSupportedServices: [],
+                    producedEventsSupportedTypes: [],
                     producedDeployOutputTypes: [
-                        'securityGroups',
-                        'scripts',
-                        'environmentVariables',
+                        DeployOutputType.SecurityGroups,
+                        DeployOutputType.Scripts,
+                        DeployOutputType.EnvironmentVariables
                     ],
                     consumedDeployOutputTypes: [],
                     unPreDeploy: (serviceContext) => {
@@ -115,13 +115,13 @@ describe('preDeploy', () => {
                     supportsTagging: true,
                 },
                 ecs: {
-                    producedEventsSupportedServices: [],
+                    producedEventsSupportedTypes: [],
                     producedDeployOutputTypes: [],
                     consumedDeployOutputTypes: [
-                        'securityGroups',
-                        'scripts',
-                        'environmentVariables',
-                        'policies'
+                        DeployOutputType.SecurityGroups,
+                        DeployOutputType.Scripts,
+                        DeployOutputType.EnvironmentVariables,
+                        DeployOutputType.Policies
                     ],
                     supportsTagging: true,
                     // Simulating that ECS doesn't implement unpredeploy

--- a/handel/test/service-registry/fake-service-registry.ts
+++ b/handel/test/service-registry/fake-service-registry.ts
@@ -34,7 +34,9 @@ export default class FakeServiceRegistry implements ServiceRegistry {
         return this.services[key] as ServiceDeployer || {
             consumedDeployOutputTypes: [],
             producedDeployOutputTypes: [],
-            producedEventsSupportedServices: []
+            producedEventsSupportedTypes: [],
+            providedEventType: null,
+            supportsTagging: true
         };
     }
 

--- a/handel/test/services/apigateway/apigateway-test.ts
+++ b/handel/test/services/apigateway/apigateway-test.ts
@@ -108,7 +108,7 @@ describe('apigateway deployer', () => {
                         {}, {
                             producedDeployOutputTypes: ['securityGroups'],
                             consumedDeployOutputTypes: [],
-                            producedEventsSupportedServices: []
+                            producedEventsSupportedTypes: []
                         }
                     )
                 ];

--- a/handel/test/services/dynamodb/dynamodb-test.ts
+++ b/handel/test/services/dynamodb/dynamodb-test.ts
@@ -272,10 +272,16 @@ describe('dynamodb deployer', () => {
             const tableArn = `arn:aws:dynamodb:us-west-2:123456789012:table/${tableName}`;
 
             const deployStackStub = sandbox.stub(deployPhase, 'deployCloudFormationStack').returns(Promise.resolve({
-                Outputs: [{
-                    OutputKey: 'TableName',
-                    OutputValue: tableName
-                }]
+                Outputs: [
+                    {
+                        OutputKey: 'TableName',
+                        OutputValue: tableName
+                    },
+                    {
+                        OutputKey: 'StreamArn',
+                        OutputValue: 'FakeArn'
+                    }
+                ]
             }));
 
             const deployContext = await dynamodb.deploy(serviceContext, ownPreDeployContext, []);
@@ -295,10 +301,16 @@ describe('dynamodb deployer', () => {
             serviceParams.table_name = tableName;
 
             const deployStackStub = sandbox.stub(deployPhase, 'deployCloudFormationStack').returns(Promise.resolve({
-                Outputs: [{
-                    OutputKey: 'TableName',
-                    OutputValue: tableName
-                }]
+                Outputs: [
+                    {
+                        OutputKey: 'TableName',
+                        OutputValue: tableName
+                    },
+                    {
+                        OutputKey: 'StreamArn',
+                        OutputValue: 'FakeArn'
+                    }
+                ]
             }));
 
             const deployContext = await dynamodb.deploy(serviceContext, ownPreDeployContext, []);
@@ -325,10 +337,16 @@ describe('dynamodb deployer', () => {
                 const tableArn = `arn:aws:dynamodb:us-west-2:123456789012:table/${tableName}`;
 
                 deployStackStub = sandbox.stub(deployPhase, 'deployCloudFormationStack').returns(Promise.resolve({
-                    Outputs: [{
-                        OutputKey: 'TableName',
-                        OutputValue: tableName
-                    }]
+                    Outputs: [
+                        {
+                            OutputKey: 'TableName',
+                            OutputValue: tableName
+                        },
+                        {
+                            OutputKey: 'StreamArn',
+                            OutputValue: 'FakeArn'
+                        }
+                    ]
                 }));
             });
 
@@ -481,7 +499,7 @@ describe('dynamodb deployer', () => {
 
     describe('produceEvents', () => {
         it('should return an empty ProduceEventsContext', async () => {
-            const consumerServiceContext = new ServiceContext(appName, envName, 'fakeservice', new ServiceType(STDLIB_PREFIX, 'faketype'), {type: 'faketype'}, accountConfig);
+            const consumerServiceContext = new ServiceContext(appName, envName, 'fakeservice', new ServiceType(STDLIB_PREFIX, 'faketype'), { type: 'faketype' }, accountConfig);
             const eventConsumerConfig: DynamoDBServiceEventConsumer = {
                 service_name: 'fakeservice',
                 batch_size: 1

--- a/handel/test/services/stepfunctions/stepfunctions-test.ts
+++ b/handel/test/services/stepfunctions/stepfunctions-test.ts
@@ -21,6 +21,7 @@ import {
     PreDeployContext,
     ServiceConfig,
     ServiceContext,
+    ServiceEventType,
     ServiceType,
     UnDeployContext
 } from 'handel-extension-api';
@@ -162,7 +163,11 @@ describe('stepfunctions deployer', () => {
             for (const [serviceName, functionArn] of dependencies) {
                 const otherServiceContext = new ServiceContext(appName, envName, serviceName, new ServiceType(STDLIB_PREFIX, 'lambda'), {type: 'lambda'}, serviceContext.accountConfig);
                 const deployContext = new DeployContext(otherServiceContext);
-                deployContext.eventOutputs.lambdaArn = functionArn;
+                deployContext.eventOutputs = {
+                    resourceArn: functionArn,
+                    resourcePrincipal: 'FakePrincipal',
+                    serviceEventType: ServiceEventType.Lambda
+                };
                 dependenciesDeployContexts.push(deployContext);
             }
 


### PR DESCRIPTION
This change makes the eventOutputs object in the DeployContext a typed object rather than just a bag of data. 

It also changes the event methods to use a ServiceEventType object instead of the service provisioner type. This allows an extension to be written that "provides" a particular service event type and still work with other provisioners that accept that kind of service event.

This change also introduces a DeployOutputType enum so that we don't just use strings for it in the TS code.