### PR TITLE
added support for windows npm

### DIFF
--- a/handel/src/extensions-support/npm/index.ts
+++ b/handel/src/extensions-support/npm/index.ts
@@ -54,7 +54,9 @@ export interface LinkedPackage {
 }
 
 async function run(tag: string, args: string[], quiet: boolean = false, opts?: SpawnOptions) {
-    const promise = spawn('npm', args, opts);
+    const command = /^win/.test(process.platform) ? 'npm.cmd' : 'npm';
+    log.debug('running npm', command, args, opts);
+    const promise = spawn(command, args, opts);
     const proc = promise.child;
 
     if (!quiet) {


### PR DESCRIPTION
When trying to create handel extensions on my windows machine we ran into an error where my machine was trying to run npm the linux way and not the windows way. This should check if you're running on windows, if so then it will use the `npm.cmd` instead of `npm`