### PR TITLE
Modify files necessary to start outputting TS declarations in main project

### DIFF
--- a/extension-api/extension-api.ts
+++ b/extension-api/extension-api.ts
@@ -19,7 +19,6 @@ import { EC2 } from 'aws-sdk';
 /***********************************
  * Types for the Extension contract
  ***********************************/
-
 export interface Extension {
     loadHandelExtension(context: ExtensionContext): void | Promise<void>;
 }

--- a/extension-api/tsconfig.json
+++ b/extension-api/tsconfig.json
@@ -1,5 +1,8 @@
 {
     "extends": "../tsconfig",
+    "compilerOptions": {
+      "outDir": "dist"
+    },
     "include": [
       "extension-api.ts"
     ]

--- a/extension-api/tsconfig.json
+++ b/extension-api/tsconfig.json
@@ -1,9 +1,5 @@
 {
     "extends": "../tsconfig",
-    "compilerOptions": {
-        "outDir": "dist",
-        "declaration": true
-    },
     "include": [
       "extension-api.ts"
     ]

--- a/extension-support/tsconfig.json
+++ b/extension-support/tsconfig.json
@@ -1,5 +1,8 @@
 {
     "extends": "../tsconfig",
+    "compilerOptions": {
+      "outDir": "dist"
+    },
     "include": [
       "src/**/*"
     ]

--- a/extension-support/tsconfig.json
+++ b/extension-support/tsconfig.json
@@ -1,10 +1,5 @@
 {
     "extends": "../tsconfig",
-    "compilerOptions": {
-        "outDir": "dist",
-        "allowJs": false,
-        "declaration": true
-    },
     "include": [
       "src/**/*"
     ]

--- a/handel/src/aws/cloudwatch-events-calls.ts
+++ b/handel/src/aws/cloudwatch-events-calls.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  */
+import * as AWS from 'aws-sdk';
 import * as winston from 'winston';
 import awsWrapper from './aws-wrapper';
 

--- a/handel/src/aws/ecs-calls.ts
+++ b/handel/src/aws/ecs-calls.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  */
+import * as AWS from 'aws-sdk';
 import * as winston from 'winston';
 import awsWrapper from './aws-wrapper';
 

--- a/handel/src/aws/iam-calls.ts
+++ b/handel/src/aws/iam-calls.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  */
+import * as AWS from 'aws-sdk';
 import { AccountConfig } from 'handel-extension-api';
 import * as winston from 'winston';
 import awsWrapper from './aws-wrapper';

--- a/handel/src/aws/lambda-calls.ts
+++ b/handel/src/aws/lambda-calls.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  */
+import * as AWS from 'aws-sdk';
 import * as uuid from 'uuid';
 import * as winston from 'winston';
 import awsWrapper from './aws-wrapper';

--- a/handel/src/aws/route53-calls.ts
+++ b/handel/src/aws/route53-calls.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
-import * as winston from 'winston';
+import * as AWS from 'aws-sdk';
 import awsWrapper from './aws-wrapper';
 
 export function listHostedZones(): Promise<AWS.Route53.HostedZone[]> {

--- a/handel/src/aws/s3-calls.ts
+++ b/handel/src/aws/s3-calls.ts
@@ -14,11 +14,9 @@
  * limitations under the License.
  *
  */
+import * as AWS from 'aws-sdk';
 import * as childProcess from 'child_process';
-import * as fs from 'fs';
 import { ServiceEventType } from 'handel-extension-api';
-import { awsCalls } from 'handel-extension-support';
-import * as winston from 'winston';
 import awsWrapper from './aws-wrapper';
 
 /**

--- a/handel/src/aws/ses-calls.ts
+++ b/handel/src/aws/ses-calls.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  *
  */
-import * as SES from 'aws-sdk/clients/ses';
+import * as AWS from 'aws-sdk';
 import * as winston from 'winston';
 import awsWrapper from './aws-wrapper';
 
 export async function verifyEmailAddress(address: string) {
-    const ses = new SES({ apiVersion: '2010-12-01' });
+    const ses = new AWS.SES({ apiVersion: '2010-12-01' });
     winston.verbose(`Verifying ${address} if needed`);
 
     const response = await awsWrapper.ses.getIdentityVerificationAttributes({ Identities: [address] });

--- a/handel/src/aws/sns-calls.ts
+++ b/handel/src/aws/sns-calls.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  */
+import * as AWS from 'aws-sdk';
 import * as winston from 'winston';
 import awsWrapper from './aws-wrapper';
 

--- a/handel/src/aws/sqs-calls.ts
+++ b/handel/src/aws/sqs-calls.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  */
+import * as AWS from 'aws-sdk';
 import * as winston from 'winston';
 import awsWrapper from './aws-wrapper';
 

--- a/handel/src/aws/sts-calls.ts
+++ b/handel/src/aws/sts-calls.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  */
+import * as AWS from 'aws-sdk';
 import awsWrapper from './aws-wrapper';
 
 export async function getAccountId(): Promise<string|null> {

--- a/handel/src/extensions-support/npm-loader.ts
+++ b/handel/src/extensions-support/npm-loader.ts
@@ -29,7 +29,7 @@ import {
 import { CliNpmClient, NpmClient } from './npm';
 import { ExtensionLoader } from './types';
 
-class NpmLoader implements ExtensionLoader {
+export class NpmLoader implements ExtensionLoader {
 
     constructor(private readonly client: NpmClient, private readonly importer: ModuleImporter) {
     }

--- a/handel/src/extensions-support/resolve-extensions.ts
+++ b/handel/src/extensions-support/resolve-extensions.ts
@@ -21,7 +21,7 @@ import { loadStandardLib } from '../services/stdlib';
 import { initNpmLoader } from './npm-loader';
 import { ExtensionLoader } from './types';
 
-type StandardLibLoader = () => Promise<LoadedExtension>;
+export type StandardLibLoader = () => Promise<LoadedExtension>;
 
 export async function resolveExtensions(
     definitions: ExtensionDefinition[],

--- a/handel/src/services/dynamodb/autoscaling.ts
+++ b/handel/src/services/dynamodb/autoscaling.ts
@@ -274,7 +274,7 @@ function getScalingConfig(config: ThroughputCapacity,
     );
 }
 
-class ThroughputCapacity {
+export class ThroughputCapacity {
 
     public target!: number;
 
@@ -292,7 +292,7 @@ class ThroughputCapacity {
     }
 }
 
-class AutoscalingDefinition {
+export class AutoscalingDefinition {
 
     public dependsOn!: string;
     public readonly min: number;

--- a/handel/src/services/dynamodb/index.ts
+++ b/handel/src/services/dynamodb/index.ts
@@ -23,7 +23,8 @@ import {
     ServiceConfig,
     ServiceContext,
     ServiceEventConsumer,
-    ServiceEventType
+    ServiceEventType,
+    UnDeployContext
 } from 'handel-extension-api';
 import { awsCalls, deletePhases, deployPhase, handlebars, tagging } from 'handel-extension-support';
 import * as winston from 'winston';
@@ -327,7 +328,7 @@ export async function produceEvents(ownServiceContext: ServiceContext<DynamoDBCo
     return new ProduceEventsContext(ownServiceContext, consumerServiceContext);
 }
 
-export async function unDeploy(ownServiceContext: ServiceContext<DynamoDBConfig>) {
+export async function unDeploy(ownServiceContext: ServiceContext<DynamoDBConfig>): Promise<UnDeployContext> {
     await autoscaling.undeployAutoscaling(ownServiceContext);
     return deletePhases.unDeployService(ownServiceContext, SERVICE_NAME);
 }

--- a/handel/src/services/ecs-fargate/index.ts
+++ b/handel/src/services/ecs-fargate/index.ts
@@ -19,7 +19,9 @@ import {
     DeployOutputType,
     PreDeployContext,
     ServiceConfig,
-    ServiceContext
+    ServiceContext,
+    UnDeployContext,
+    UnPreDeployContext
 } from 'handel-extension-api';
 import { deletePhases, deployPhase, handlebars, preDeployPhase, tagging } from 'handel-extension-support';
 import * as winston from 'winston';
@@ -148,11 +150,11 @@ export async function deploy(ownServiceContext: ServiceContext<FargateServiceCon
     return new DeployContext(ownServiceContext);
 }
 
-export async function unPreDeploy(ownServiceContext: ServiceContext<FargateServiceConfig>) {
+export async function unPreDeploy(ownServiceContext: ServiceContext<FargateServiceConfig>): Promise<UnPreDeployContext> {
     return deletePhases.unPreDeploySecurityGroup(ownServiceContext, SERVICE_NAME);
 }
 
-export async function unDeploy(ownServiceContext: ServiceContext<FargateServiceConfig>) {
+export async function unDeploy(ownServiceContext: ServiceContext<FargateServiceConfig>): Promise<UnDeployContext> {
     return deletePhases.unDeployService(ownServiceContext, SERVICE_NAME);
 }
 

--- a/handel/src/services/ecs/asg-cycling.ts
+++ b/handel/src/services/ecs/asg-cycling.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  */
+import * as AWS from 'aws-sdk';
 import { ServiceContext } from 'handel-extension-api';
 import * as winston from 'winston';
 import * as autoScalingCalls from '../../aws/auto-scaling-calls';

--- a/handel/src/services/ecs/cluster-auto-scaling.ts
+++ b/handel/src/services/ecs/cluster-auto-scaling.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  */
+import * as AWS from 'aws-sdk';
 import { AccountConfig } from 'handel-extension-api';
 import { awsCalls, deployPhase, handlebars  } from 'handel-extension-support';
 import * as winston from 'winston';
@@ -99,7 +100,7 @@ const EC2_INSTANCE_MEMORY_MAP: Ec2InstanceMemoryMap = {
  * The code for the auto-scaling Lambda can be found in the "cluster-scaling-lambda" directory inside
  * the ECS service deployer directory.
  */
-export async function createAutoScalingLambdaIfNotExists(accountConfig: AccountConfig) {
+export async function createAutoScalingLambdaIfNotExists(accountConfig: AccountConfig): Promise<AWS.CloudFormation.Stack> {
     const stackName = 'HandelEcsAutoScalingLambda';
     const stack = await awsCalls.cloudFormation.getStack(stackName);
     if (!stack) {
@@ -123,7 +124,7 @@ export async function createAutoScalingLambdaIfNotExists(accountConfig: AccountC
  * The code for the draining Lambda can be found in the "cluster-draining-lambda" directory inside
  * the ECS service deployer directory.
  */
-export async function createDrainingLambdaIfNotExists(accountConfig: AccountConfig) {
+export async function createDrainingLambdaIfNotExists(accountConfig: AccountConfig): Promise<AWS.CloudFormation.Stack> {
     const stackName = 'HandelEcsDrainingLambda';
     const stack = await awsCalls.cloudFormation.getStack(stackName);
     if (!stack) {

--- a/handel/src/services/ecs/index.ts
+++ b/handel/src/services/ecs/index.ts
@@ -19,7 +19,9 @@ import {
     DeployOutputType,
     PreDeployContext,
     ServiceConfig,
-    ServiceContext
+    ServiceContext,
+    UnDeployContext,
+    UnPreDeployContext
 } from 'handel-extension-api';
 import { deletePhases, deployPhase, handlebars, preDeployPhase, tagging } from 'handel-extension-support';
 import * as winston from 'winston';
@@ -172,11 +174,11 @@ export async function deploy(ownServiceContext: ServiceContext<EcsServiceConfig>
     return new DeployContext(ownServiceContext);
 }
 
-export async function unPreDeploy(ownServiceContext: ServiceContext<EcsServiceConfig>) {
+export async function unPreDeploy(ownServiceContext: ServiceContext<EcsServiceConfig>): Promise<UnPreDeployContext> {
     return deletePhases.unPreDeploySecurityGroup(ownServiceContext, SERVICE_NAME);
 }
 
-export async function unDeploy(ownServiceContext: ServiceContext<EcsServiceConfig>) {
+export async function unDeploy(ownServiceContext: ServiceContext<EcsServiceConfig>): Promise<UnDeployContext> {
     return deletePhases.unDeployService(ownServiceContext, SERVICE_NAME);
 }
 

--- a/handel/tsconfig.json
+++ b/handel/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../tsconfig",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
   "include": [
     "src/**/*"
   ]

--- a/handel/tsconfig.json
+++ b/handel/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "../tsconfig",
-  "compilerOptions": {
-    "allowJs": true
-  },
   "include": [
     "src/**/*"
   ]

--- a/lerna.json
+++ b/lerna.json
@@ -1,9 +1,9 @@
 {
   "lerna": "2.8.0",
   "packages": [
-    "handel",
     "extension-api",
-    "extension-support"
+    "extension-support",
+    "handel"
   ],
   "version": "0.26.9"
 }

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
 	"scripts": {
 		"postinstall": "lerna bootstrap",
 		"lint": "lerna run lint",
-		"build": "lerna run build",
-		"test": "lerna run build && lerna run test",
+		"build": "lerna run build --concurrency 1",
+		"test": "lerna run build --concurrency 1 && lerna run test",
 		"publish-modules": "lerna publish --cd-version=$cdVersion --force-publish=*"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
 	"scripts": {
 		"postinstall": "lerna bootstrap",
 		"lint": "lerna run lint",
-		"build": "lerna run build --concurrency 1",
-		"test": "lerna run build --concurrency 1 && lerna run test",
+		"build": "lerna run build",
+		"test": "lerna run build && lerna run test",
 		"publish-modules": "lerna publish --cd-version=$cdVersion --force-publish=*"
 	},
 	"devDependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,8 @@
         "removeComments": false,
         "strict": true,
         "strictNullChecks": true,
+        "allowJs": false,
+        "declaration": true,
         "moduleResolution": "node",
         "lib": [
             "es7", "es2017.object"


### PR DESCRIPTION
We were missing some imports and type definitions here and there in order for TypeScript to allow us to turn on the "declaration: true" flag. 

This change adds those and modifies the tsconfig file to start outputting TypeScript declaration files for all the packages in the repository.

Resolves #418 