### PR TITLE
Transform container names to CFN Logical ID format

### DIFF
--- a/handel/src/services/ecs-fargate/ecs-fargate-template.yml
+++ b/handel/src/services/ecs-fargate/ecs-fargate-template.yml
@@ -332,7 +332,7 @@ Resources:
       DefaultActions:
       - Type: forward
         TargetGroupArn:
-          Ref: AlbTargetGroup{{loadBalancer.defaultRouteContainer.name}}
+          Ref: AlbTargetGroup{{logicalId loadBalancer.defaultRouteContainer.name}}
       LoadBalancerArn:
         Ref: Alb
       {{#if loadBalancer.httpsCertificate}}
@@ -346,16 +346,16 @@ Resources:
       {{/if}}
   {{#each containerConfigs}}
   {{#if routingInfo}}
-  AlbListenerRule{{name}}:
+  AlbListenerRule{{logicalId name}}:
     Type: AWS::ElasticLoadBalancingV2::ListenerRule
     DependsOn:
     - AlbListener
-    - AlbTargetGroup{{name}}
+    - AlbTargetGroup{{logicalId name}}
     Properties:
       Actions:
       - Type: forward
         TargetGroupArn:
-          Ref: AlbTargetGroup{{name}}
+          Ref: AlbTargetGroup{{logicalId name}}
       Conditions:
       - Field: path-pattern
         Values:
@@ -363,7 +363,7 @@ Resources:
       ListenerArn:
         Ref: AlbListener
       Priority: {{routingInfo.albPriority}}
-  AlbTargetGroup{{name}}:
+  AlbTargetGroup{{logicalId name}}:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
       HealthCheckIntervalSeconds: 10


### PR DESCRIPTION
Fixes #320. Fixes #446. We already have a Handlebars helper to turn
anything into a valid CFN logical ID, so I put that into the fargate
template.  We'll probably want to follow up and search for other places
where this would be useful.