### PR TITLE
Add a nicer message when Route53 zones are missing

### DIFF
--- a/handel/src/common/ecs-routing.ts
+++ b/handel/src/common/ecs-routing.ts
@@ -86,9 +86,13 @@ export function getLoadBalancerConfig(serviceParams: EcsServiceConfig, container
         }
         if (loadBalancer.dns_names) {
             loadBalancerConfig.dnsNames = loadBalancer.dns_names.map(name => {
+                const zone = route53.getBestMatchingHostedZone(name, hostedZones);
+                if (!zone) {
+                    throw new Error(`There is no Route53 hosted zone in this account that matches '${name}'`);
+                }
                 return {
                     name: name,
-                    zoneId: route53.getBestMatchingHostedZone(name, hostedZones)!.Id
+                    zoneId: zone.Id
                 };
             });
         }

--- a/handel/src/services/apigateway/common.ts
+++ b/handel/src/services/apigateway/common.ts
@@ -58,7 +58,7 @@ export async function getCustomDomainHandlebarsParams(serviceContext: ServiceCon
         const {dns_name, https_certificate} = domain;
         const hostedZone = route53.getBestMatchingHostedZone(dns_name, zones);
         if (!hostedZone) {
-            throw new Error(`Unable to find hosted zone for DNS name '${dns_name}'`);
+            throw new Error(`There is no Route53 hosted zone in this account that matches '${dns_name}'`);
         }
 
         let cert: string;

--- a/handel/src/services/beanstalk/index.ts
+++ b/handel/src/services/beanstalk/index.ts
@@ -209,7 +209,7 @@ async function getDnsNameEbExtension(ownServiceContext: ServiceContext<Beanstalk
             }
             return {
                 name: name,
-                zoneId: zone.Id, // TODO - I think this is a bug, it can indeed be undefined, causing .Id to fail. We should handle this better
+                zoneId: zone.Id,
             };
         });
 

--- a/handel/src/services/beanstalk/index.ts
+++ b/handel/src/services/beanstalk/index.ts
@@ -203,9 +203,13 @@ async function getDnsNameEbExtension(ownServiceContext: ServiceContext<Beanstalk
 
         const zones = await route53.listHostedZones();
         const namesParam = dnsNames.map(name => {
+            const zone = route53.getBestMatchingHostedZone(name, zones);
+            if (!zone) {
+                throw new Error(`There is no Route53 hosted zone in this account that matches '${name}'`);
+            }
             return {
                 name: name,
-                zoneId: route53.getBestMatchingHostedZone(name, zones)!.Id, // TODO - I think this is a bug, it can indeed be undefined, causing .Id to fail. We should handle this better
+                zoneId: zone.Id, // TODO - I think this is a bug, it can indeed be undefined, causing .Id to fail. We should handle this better
             };
         });
 

--- a/handel/src/services/codedeploy/alb.ts
+++ b/handel/src/services/codedeploy/alb.ts
@@ -33,9 +33,13 @@ export async function getRoutingConfig(stackName: string, ownServiceContext: Ser
         if(params.routing.dns_names) { // Add DNS names if specified
             const hostedZones = await route53Calls.listHostedZones();
             routingConfig.dnsNames = params.routing.dns_names.map(name => {
+                const zone = route53Calls.getBestMatchingHostedZone(name, hostedZones);
+                if (!zone) {
+                    throw new Error(`There is no Route53 hosted zone in this account that matches '${name}'`);
+                }
                 return {
                     name: name,
-                    zoneId: route53Calls.getBestMatchingHostedZone(name, hostedZones)!.Id
+                    zoneId: zone.Id
                 };
             });
         }

--- a/handel/src/services/lambda/config-types.ts
+++ b/handel/src/services/lambda/config-types.ts
@@ -25,6 +25,11 @@ export interface LambdaServiceConfig extends ServiceConfig {
     timeout?: number;
     vpc?: boolean;
     environment_variables?: EnvironmentVariables;
+    keep_warm?: LambdaServiceKeepWarmConfig;
+}
+
+export interface LambdaServiceKeepWarmConfig {
+    cron: string;
 }
 
 export interface HandlebarsLambdaTemplate {

--- a/handel/src/services/s3staticsite/index.ts
+++ b/handel/src/services/s3staticsite/index.ts
@@ -97,7 +97,7 @@ async function getCloudfrontTemplateParameters(ownServiceContext: ServiceContext
         handlebarsParams.dnsNames = dnsNames.map(dnsName => {
             const zone = route53Calls.getBestMatchingHostedZone(dnsName, hostedZones);
             if (!zone) {
-                throw new Error(`No Route53 hosted zone found matching '${dnsName}'`);
+                throw new Error(`There is no Route53 hosted zone in this account that matches '${dnsName}'`);
             }
             return {
                 name: dnsName,


### PR DESCRIPTION
This also unifies the message across all places where we're searching
for a zone ID.

It may make more sense to create another method that wraps the
getBestMatchingHostedZone function, which throws if there isn't one.  I
don't necessarily want to do that inside of getBestMatchingHostedZone,
because I can see cases where we'd want to use the falsy-returning
version.  Perhaps a method named 'requireBestMatchingHostedZone'?