### PR TITLE
Better solution for #445.

### DIFF
--- a/handel/src/aws/route53-calls.ts
+++ b/handel/src/aws/route53-calls.ts
@@ -43,6 +43,14 @@ export function getBestMatchingHostedZone(domain: string, zones: AWS.Route53.Hos
         .pop();
 }
 
+export function requireBestMatchingHostedZone(domain: string, zones: AWS.Route53.HostedZone[]): AWS.Route53.HostedZone {
+    const found = getBestMatchingHostedZone(domain, zones);
+    if (!found) {
+        throw new Error(`There is no Route53 hosted zone in this account that matches '${domain}'`);
+    }
+    return found;
+}
+
 const VALID_HOSTNAME_REGEX = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/;
 
 export function isValidHostname(hostname: string): boolean {

--- a/handel/src/common/ecs-routing.ts
+++ b/handel/src/common/ecs-routing.ts
@@ -86,10 +86,7 @@ export function getLoadBalancerConfig(serviceParams: EcsServiceConfig, container
         }
         if (loadBalancer.dns_names) {
             loadBalancerConfig.dnsNames = loadBalancer.dns_names.map(name => {
-                const zone = route53.getBestMatchingHostedZone(name, hostedZones);
-                if (!zone) {
-                    throw new Error(`There is no Route53 hosted zone in this account that matches '${name}'`);
-                }
+                const zone = route53.requireBestMatchingHostedZone(name, hostedZones);
                 return {
                     name: name,
                     zoneId: zone.Id

--- a/handel/src/services/apigateway/common.ts
+++ b/handel/src/services/apigateway/common.ts
@@ -56,10 +56,7 @@ export async function getCustomDomainHandlebarsParams(serviceContext: ServiceCon
     const zones = await route53.listHostedZones();
     return customDomains.map(domain => {
         const {dns_name, https_certificate} = domain;
-        const hostedZone = route53.getBestMatchingHostedZone(dns_name, zones);
-        if (!hostedZone) {
-            throw new Error(`There is no Route53 hosted zone in this account that matches '${dns_name}'`);
-        }
+        const hostedZone = route53.requireBestMatchingHostedZone(dns_name, zones);
 
         let cert: string;
         if (https_certificate.indexOf('arn:') === 0) {

--- a/handel/src/services/beanstalk/index.ts
+++ b/handel/src/services/beanstalk/index.ts
@@ -203,10 +203,7 @@ async function getDnsNameEbExtension(ownServiceContext: ServiceContext<Beanstalk
 
         const zones = await route53.listHostedZones();
         const namesParam = dnsNames.map(name => {
-            const zone = route53.getBestMatchingHostedZone(name, zones);
-            if (!zone) {
-                throw new Error(`There is no Route53 hosted zone in this account that matches '${name}'`);
-            }
+            const zone = route53.requireBestMatchingHostedZone(name, zones);
             return {
                 name: name,
                 zoneId: zone.Id,

--- a/handel/src/services/codedeploy/alb.ts
+++ b/handel/src/services/codedeploy/alb.ts
@@ -33,10 +33,7 @@ export async function getRoutingConfig(stackName: string, ownServiceContext: Ser
         if(params.routing.dns_names) { // Add DNS names if specified
             const hostedZones = await route53Calls.listHostedZones();
             routingConfig.dnsNames = params.routing.dns_names.map(name => {
-                const zone = route53Calls.getBestMatchingHostedZone(name, hostedZones);
-                if (!zone) {
-                    throw new Error(`There is no Route53 hosted zone in this account that matches '${name}'`);
-                }
+                const zone = route53Calls.requireBestMatchingHostedZone(name, hostedZones);
                 return {
                     name: name,
                     zoneId: zone.Id

--- a/handel/src/services/s3staticsite/index.ts
+++ b/handel/src/services/s3staticsite/index.ts
@@ -95,10 +95,7 @@ async function getCloudfrontTemplateParameters(ownServiceContext: ServiceContext
     const dnsNames = cf.dns_names;
     if (dnsNames) {
         handlebarsParams.dnsNames = dnsNames.map(dnsName => {
-            const zone = route53Calls.getBestMatchingHostedZone(dnsName, hostedZones);
-            if (!zone) {
-                throw new Error(`There is no Route53 hosted zone in this account that matches '${dnsName}'`);
-            }
+            const zone = route53Calls.requireBestMatchingHostedZone(dnsName, hostedZones);
             return {
                 name: dnsName,
                 zoneId: zone.Id

--- a/handel/test/services/codedeploy/alb-test.ts
+++ b/handel/test/services/codedeploy/alb-test.ts
@@ -62,7 +62,7 @@ describe('codedeploy alb config module', () => {
             listHostedZonesStub = sandbox.stub(route53Calls, 'listHostedZones').resolves([{
                 Id: 'FakeZoneId'
             }]);
-            getBestZoneStub = sandbox.stub(route53Calls, 'getBestMatchingHostedZone').returns({
+            getBestZoneStub = sandbox.stub(route53Calls, 'requireBestMatchingHostedZone').returns({
                 Id: 'FakeZoneId'
             });
         });


### PR DESCRIPTION
This does what I should have done to start and creates a separate method
in route53-calls which throws a consistent error if there isn't a
matching Hosted Zone.