### PR TITLE
Make static site read-only consumable from other services

### DIFF
--- a/handel/src/services/s3staticsite/index.ts
+++ b/handel/src/services/s3staticsite/index.ts
@@ -194,8 +194,7 @@ function getDeployContext(serviceContext: ServiceContext<S3StaticSiteServiceConf
         REGION_ENDPOINT: `s3-${accountConfig.region}.amazonaws.com`
     });
 
-    // Need two policies for accessing S3. The first allows you to list the contents of the bucket,
-    // and the second allows you to modify objects in that bucket
+    // Need two policies for accessing S3 because the resource is different for object-level vs. bucket-level access
     deployContext.policies.push({
         'Effect': 'Allow',
         'Action': [

--- a/handel/src/services/s3staticsite/index.ts
+++ b/handel/src/services/s3staticsite/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
-import {DeployContext, PreDeployContext, ServiceConfig, ServiceContext, UnDeployContext} from 'handel-extension-api';
+import {DeployContext, DeployOutputType, PreDeployContext, ServiceConfig, ServiceContext, UnDeployContext} from 'handel-extension-api';
 import { awsCalls, deletePhases, deployPhase, handlebars, tagging } from 'handel-extension-support';
 import * as winston from 'winston';
 import * as route53Calls from '../../aws/route53-calls';
@@ -176,6 +176,50 @@ function checkCloudfront(cloudfront: CloudFrontConfig): string[] {
     return errors;
 }
 
+function getDeployContext(serviceContext: ServiceContext<S3StaticSiteServiceConfig>, cfStack: AWS.CloudFormation.Stack): DeployContext {
+    const accountConfig = serviceContext.accountConfig;
+    const bucketName = awsCalls.cloudFormation.getOutput('BucketName', cfStack);
+    const bucketArn = awsCalls.cloudFormation.getOutput('BucketArn', cfStack);
+    if(!bucketName || !bucketArn) {
+        throw new Error('Expected to receive bucket name and ARN from S3 service');
+    }
+
+    const deployContext = new DeployContext(serviceContext);
+
+    // Env variables to inject into consuming services
+    deployContext.addEnvironmentVariables({
+        BUCKET_NAME: bucketName,
+        BUCKET_ARN: bucketArn,
+        BUCKET_URL: `https://${bucketName}.s3.amazonaws.com/`,
+        REGION_ENDPOINT: `s3-${accountConfig.region}.amazonaws.com`
+    });
+
+    // Need two policies for accessing S3. The first allows you to list the contents of the bucket,
+    // and the second allows you to modify objects in that bucket
+    deployContext.policies.push({
+        'Effect': 'Allow',
+        'Action': [
+            's3:ListBucket'
+        ],
+        'Resource': [
+            `arn:aws:s3:::${bucketName}`
+        ]
+    });
+    // Only allow read access to the bucket because the contents are managed by the deployment, re-synced on every deploy
+    deployContext.policies.push({
+        'Effect': 'Allow',
+        'Action': [
+            's3:GetObject',
+            's3:GetObjectAcl',
+        ],
+        'Resource': [
+            `arn:aws:s3:::${bucketName}/*`
+        ]
+    });
+
+    return deployContext;
+}
+
 /**
  * Service Deployer Contract Methods
  * See https://github.com/byu-oit-appdev/handel/wiki/Creating-a-New-Service-Deployer#service-deployer-contract
@@ -216,7 +260,7 @@ export async function deploy(ownServiceContext: ServiceContext<S3StaticSiteServi
     await s3Calls.uploadDirectory(bucketName, '', ownServiceContext.params.path_to_code);
     winston.info(`${SERVICE_NAME} - Finished uploading code files to static site '${stackName}'`);
     winston.info(`${SERVICE_NAME} - Finished deploying static site '${stackName}'`);
-    return new DeployContext(ownServiceContext);
+    return getDeployContext(ownServiceContext, deployedStack);
 }
 
 export async function unDeploy(ownServiceContext: ServiceContext<S3StaticSiteServiceConfig>): Promise<UnDeployContext> {
@@ -225,7 +269,10 @@ export async function unDeploy(ownServiceContext: ServiceContext<S3StaticSiteSer
 
 export const producedEventsSupportedTypes = [];
 
-export const producedDeployOutputTypes = [];
+export const producedDeployOutputTypes = [
+    DeployOutputType.EnvironmentVariables,
+    DeployOutputType.Policies
+];
 
 export const consumedDeployOutputTypes = [];
 

--- a/handel/test/services/s3staticsite/s3staticsite-test.ts
+++ b/handel/test/services/s3staticsite/s3staticsite-test.ts
@@ -176,23 +176,27 @@ describe('s3staticsite deployer', () => {
 
         it('should deploy the static site bucket', async () => {
             const createLoggingBucketStub = sandbox.stub(s3DeployersCommon, 'createLoggingBucketIfNotExists').resolves('FakeBucket');
-            const deployStackStub = sandbox.stub(deployPhase, 'deployCloudFormationStack');
-            deployStackStub.onCall(0).resolves({
+            const bucketName = 'my-static-site-bucket';
+            const bucketArn = 'fake-bucket-arn';
+            const deployStackStub = sandbox.stub(deployPhase, 'deployCloudFormationStack').resolves({
                 Outputs: [{
                     OutputKey: 'BucketName',
-                    OutputValue: 'logging-bucket'
-                }]
-            });
-            deployStackStub.onCall(1).resolves({
-                Outputs: [{
-                    OutputKey: 'BucketName',
-                    OutputValue: 'my-static-site-bucket'
+                    OutputValue: bucketName
+                }, {
+                    OutputKey: 'BucketArn',
+                    OutputValue: bucketArn
                 }]
             });
             const uploadDirectoryStub = sandbox.stub(s3Calls, 'uploadDirectory').resolves({});
 
             const deployContext = await s3StaticSite.deploy(ownServiceContext, ownPreDeployContext, []);
             expect(deployContext).to.be.instanceof(DeployContext);
+            expect(deployContext).to.be.instanceof(DeployContext);
+            expect(deployContext.policies.length).to.equal(2);
+            expect(deployContext.environmentVariables.FAKESERVICE_BUCKET_NAME).to.equal(bucketName);
+            expect(deployContext.environmentVariables.FAKESERVICE_BUCKET_ARN).to.equal(bucketArn);
+            expect(deployContext.environmentVariables.FAKESERVICE_BUCKET_URL).to.contain(bucketName);
+            expect(deployContext.environmentVariables.FAKESERVICE_REGION_ENDPOINT).to.not.equal(null);
             expect(createLoggingBucketStub.callCount).to.equal(1);
             expect(deployStackStub.callCount).to.equal(1);
             expect(uploadDirectoryStub.callCount).to.equal(1);
@@ -207,6 +211,8 @@ describe('s3staticsite deployer', () => {
             let listHostedZonesStub: sinon.SinonStub;
             let deployStackStub: sinon.SinonStub;
             let createLoggingBucketStub: sinon.SinonStub;
+            const bucketName = 'my-static-site-bucket';
+            const bucketArn = 'fake-bucket-arn';
 
             beforeEach(() => {
                 ownServiceContext.params.cloudfront = {};
@@ -214,17 +220,13 @@ describe('s3staticsite deployer', () => {
 
                 createLoggingBucketStub = sandbox.stub(s3DeployersCommon, 'createLoggingBucketIfNotExists').resolves('FakeBucket');
 
-                deployStackStub = sandbox.stub(deployPhase, 'deployCloudFormationStack');
-                deployStackStub.onCall(0).resolves({
+                deployStackStub = sandbox.stub(deployPhase, 'deployCloudFormationStack').resolves({
                     Outputs: [{
                         OutputKey: 'BucketName',
-                        OutputValue: 'logging-bucket'
-                    }]
-                });
-                deployStackStub.onCall(1).resolves({
-                    Outputs: [{
-                        OutputKey: 'BucketName',
-                        OutputValue: 'my-static-site-bucket'
+                        OutputValue: bucketName
+                    }, {
+                        OutputKey: 'BucketArn',
+                        OutputValue: bucketArn
                     }]
                 });
                 sandbox.stub(s3Calls, 'uploadDirectory').resolves({});


### PR DESCRIPTION
The S3 Static Site service is currently not consumable by other services like Beanstalk or Lambda. This change makes it consumable, but only in a read-only manner. This will help prevent frustration with writing changes to the bucket but then having them overwritten during the next deploy, while still allowing other services to read the contents in the static site.