### PR TITLE
Fix issue with AWS Route53 API incompatible change

### DIFF
--- a/handel/src/aws/route53-calls.ts
+++ b/handel/src/aws/route53-calls.ts
@@ -43,10 +43,15 @@ export function getBestMatchingHostedZone(domain: string, zones: AWS.Route53.Hos
         .pop();
 }
 
+const HOSTED_ZONE_ID_PREFIX = '/hostedzone/';
+
 export function requireBestMatchingHostedZone(domain: string, zones: AWS.Route53.HostedZone[]): AWS.Route53.HostedZone {
     const found = getBestMatchingHostedZone(domain, zones);
     if (!found) {
         throw new Error(`There is no Route53 hosted zone in this account that matches '${domain}'`);
+    }
+    if (found.Id.startsWith(HOSTED_ZONE_ID_PREFIX)) {
+        found.Id = found.Id.substring(HOSTED_ZONE_ID_PREFIX.length);
     }
     return found;
 }


### PR DESCRIPTION
AWS appears to have pushed out a bad update to Route53 in the last 24 hours. In their API responses, they're now prefixing Hosted Zone IDs with '/hostedzone/', which is breaking anything in Handel that tries to use Route53.

This change looks for that prefix and strips it out if it finds it.  That way, if Amazon rolls back this change, we won't be broken.  We'll want to keep an eye on things and, if they change back, remove this fix.  However, we ought to probably release this quickly so that people can get work done.