### PR TITLE
Revert "Fix issue with AWS Route53 API incompatible change (#485)"

### DIFF
--- a/handel/src/aws/route53-calls.ts
+++ b/handel/src/aws/route53-calls.ts
@@ -43,15 +43,10 @@ export function getBestMatchingHostedZone(domain: string, zones: AWS.Route53.Hos
         .pop();
 }
 
-const HOSTED_ZONE_ID_PREFIX = '/hostedzone/';
-
 export function requireBestMatchingHostedZone(domain: string, zones: AWS.Route53.HostedZone[]): AWS.Route53.HostedZone {
     const found = getBestMatchingHostedZone(domain, zones);
     if (!found) {
         throw new Error(`There is no Route53 hosted zone in this account that matches '${domain}'`);
-    }
-    if (found.Id.startsWith(HOSTED_ZONE_ID_PREFIX)) {
-        found.Id = found.Id.substring(HOSTED_ZONE_ID_PREFIX.length);
     }
     return found;
 }


### PR DESCRIPTION
This reverts commit aaf1193b216b106e209d3373ffd85028328ac4bb.

Turns out, the Route53 ID stuff was a red herring.  The issue was actually being caused by the fact that the user had deleted the hosted zone that was being referenced manually, so CFN was actually failing when it tried to remove the old record.