### PR TITLE
update dynamodb docs

### DIFF
--- a/docs/supported-services/dynamodb.rst
+++ b/docs/supported-services/dynamodb.rst
@@ -45,7 +45,7 @@ Parameters
    * - provisioned_throughput
      - :ref:`dynamodb-provisioned-throughput`
      - No
-     - 5 for read and write
+     - 1 for read and write
      - The ProvisionedThroughput element details how much provisioned IOPS you want on your table for reads and writes.
    * - ttl_attribute
      - string


### PR DESCRIPTION
it appears the actual default throughput if not specified is actual 1 for read and write. I just deployed a project with the thruput not define and the table is 1.