### PR TITLE
Make build/test process work on Windows

### DIFF
--- a/extension-support/npm-scripts.js
+++ b/extension-support/npm-scripts.js
@@ -1,0 +1,39 @@
+const fs = require('fs-extra');
+
+function copyNonTsFiles() {
+    console.log("Copying Non-TS files");
+    const filterFunc = (src, dest) => {
+        if(fs.lstatSync(src).isDirectory()) {
+            return true;
+        }
+        if(!src.endsWith('.ts')) {
+            return true;
+        }
+        return false;
+    }
+    fs.copySync('src', 'dist', { filter: filterFunc })
+    console.log("Finished copy");
+}
+
+function clean() {
+    console.log("Cleaning");
+    fs.removeSync('./dist/')
+    console.log("Finished clean");
+}
+
+
+//---------------------------------
+// Main Script
+//---------------------------------
+const command = process.argv[2];
+switch(command) {
+    case "copyNonTsFiles":
+        copyNonTsFiles();
+        break;
+    case "clean":
+        clean();
+        break;
+    default:
+        throw new Error('Unsupported NPM script command');
+}
+

--- a/extension-support/package.json
+++ b/extension-support/package.json
@@ -6,9 +6,9 @@
   "types": "dist/extension-support.d.ts",
   "scripts": {
     "lint": "tslint -p tsconfig.json -t stylish",
-    "clean": "echo Cleaning && ./node_modules/.bin/del ./dist/ && echo Finished clean",
+    "clean": "node npm-scripts.js clean",
     "compile": "echo Compiling && tsc && echo Finished compile",
-    "copyNonTsFiles": "./node_modules/.bin/cpy '**/*' '!**/*.ts' '../dist/' --cwd=src --parents",
+    "copyNonTsFiles": "node npm-scripts.js copyNonTsFiles",
     "build": "npm run clean && npm run compile && npm run copyNonTsFiles",
     "test": "./node_modules/.bin/mocha -r ts-node/register 'test/**/*.ts'",
     "watch-test": "./node_modules/.bin/mocha --watch --watch-extensions ts --reporter min -r ts-node/register -w 'test/**/*.ts'"

--- a/extension-support/package.json
+++ b/extension-support/package.json
@@ -10,8 +10,8 @@
     "compile": "echo Compiling && tsc && echo Finished compile",
     "copyNonTsFiles": "node npm-scripts.js copyNonTsFiles",
     "build": "npm run clean && npm run compile && npm run copyNonTsFiles",
-    "test": "./node_modules/.bin/mocha -r ts-node/register 'test/**/*.ts'",
-    "watch-test": "./node_modules/.bin/mocha --watch --watch-extensions ts --reporter min -r ts-node/register -w 'test/**/*.ts'"
+    "test": "./node_modules/.bin/mocha -r ts-node/register \"test/**/*.ts\"",
+    "watch-test": "./node_modules/.bin/mocha --watch --watch-extensions ts --reporter min -r ts-node/register -w \"test/**/*.ts\""
   },
   "author": "David Woodruff",
   "license": "Apache-2.0",

--- a/handel/npm-scripts.js
+++ b/handel/npm-scripts.js
@@ -1,0 +1,39 @@
+const fs = require('fs-extra');
+
+function copyNonTsFiles() {
+    console.log("Copying Non-TS files");
+    const filterFunc = (src, dest) => {
+        if(fs.lstatSync(src).isDirectory()) {
+            return true;
+        }
+        if(!src.endsWith('.ts')) {
+            return true;
+        }
+        return false;
+    }
+    fs.copySync('src', 'dist', { filter: filterFunc })
+    console.log("Finished copy");
+}
+
+function clean() {
+    console.log("Cleaning");
+    fs.removeSync('./dist/')
+    console.log("Finished clean");
+}
+
+
+//---------------------------------
+// Main Script
+//---------------------------------
+const command = process.argv[2];
+switch(command) {
+    case "copyNonTsFiles":
+        copyNonTsFiles();
+        break;
+    case "clean":
+        clean();
+        break;
+    default:
+        throw new Error('Unsupported NPM script command');
+}
+

--- a/handel/package.json
+++ b/handel/package.json
@@ -9,8 +9,8 @@
     "compile": "echo Compiling && tsc && echo Finished compile",
     "copyNonTsFiles": "node npm-scripts.js copyNonTsFiles",
     "build": "npm run clean && npm run compile && npm run copyNonTsFiles",
-    "test": "./node_modules/.bin/mocha -r ts-node/register 'test/**/*.ts'",
-    "watch-test": "./node_modules/.bin/mocha --watch --watch-extensions ts --reporter min -r ts-node/register -w 'test/**/*.ts'"
+    "test": "./node_modules/.bin/mocha -r ts-node/register \"test/**/*.ts\"",
+    "watch-test": "./node_modules/.bin/mocha --watch --watch-extensions ts --reporter min -r ts-node/register -w \"test/**/*.ts\""
   },
   "bin": {
     "handel": "./bin/handel"

--- a/handel/package.json
+++ b/handel/package.json
@@ -5,9 +5,9 @@
   "main": "./bin/handel",
   "scripts": {
     "lint": "tslint -p tsconfig.json -t stylish",
-    "clean": "echo Cleaning && ./node_modules/.bin/del ./dist/ && echo Finished clean",
+    "clean": "node npm-scripts.js clean",
     "compile": "echo Compiling && tsc && echo Finished compile",
-    "copyNonTsFiles": "echo Copying Non-TS files && ./node_modules/.bin/cpy '**/*' '!**/*.ts' '../dist/' --cwd=src --parents && echo Finished copy",
+    "copyNonTsFiles": "node npm-scripts.js copyNonTsFiles",
     "build": "npm run clean && npm run compile && npm run copyNonTsFiles",
     "test": "./node_modules/.bin/mocha -r ts-node/register 'test/**/*.ts'",
     "watch-test": "./node_modules/.bin/mocha --watch --watch-extensions ts --reporter min -r ts-node/register -w 'test/**/*.ts'"


### PR DESCRIPTION
The changes away from Gulp made the Windows build process break. This commit makes it work on Windows again.

Resolves https://github.com/byu-oit/handel/issues/504