### PR TITLE
Set ALB target group deregistration delay to same as ALB timeout

### DIFF
--- a/handel/src/services/ecs-fargate/ecs-fargate-template.yml
+++ b/handel/src/services/ecs-fargate/ecs-fargate-template.yml
@@ -387,6 +387,9 @@ Resources:
       TargetType: ip
       UnhealthyThresholdCount: 2
       VpcId: {{../vpcId}}
+      TargetGroupAttributes:
+      - Key: deregistration_delay.timeout_seconds
+        Value: 60
   {{/if}}
   {{/each}}
   {{#each loadBalancer.dnsNames}}

--- a/handel/src/services/ecs/ecs-service-template.yml
+++ b/handel/src/services/ecs/ecs-service-template.yml
@@ -533,6 +533,9 @@ Resources:
         Value: {{routingInfo.targetGroupName}}
       UnhealthyThresholdCount: 2
       VpcId: {{../vpcId}}
+      TargetGroupAttributes:
+      - Key: deregistration_delay.timeout_seconds
+        Value: 60
   {{/if}}
   {{/each}}
   {{#each loadBalancer.dnsNames}}


### PR DESCRIPTION
This change sets the target group deregistration delay to the same number of seconds as the ALB timeout. This seems to make sense because we shouldn't wait longer for connection draining than the default timeout.

Resolves #500 