### PR TITLE
fixed typo

### DIFF
--- a/docs/supported-services/redis.rst
+++ b/docs/supported-services/redis.rst
@@ -64,7 +64,7 @@ Parameters
      - Map<string,string>
      - No
      - 
-     - Any cache parameters you wish for your Redis cluster. See `Redis Specific Parameters <http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ParameterGroups.Redis.html>`_ for the list of parameters you can provide.
+     - Any cache parameters you wish for your Redis cluster. See `Redis Specific Parameters <https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/ParameterGroups.Redis.html>`_ for the list of parameters you can provide.
    * - tags
      - :ref:`tagging-resources`
      - No

--- a/handel/src/services/redis/index.ts
+++ b/handel/src/services/redis/index.ts
@@ -74,7 +74,7 @@ function getDefaultCacheParameterGroup(redisVersion: string): string {
         return 'default.redis2.6';
     }
     else if (redisVersion.startsWith('2.8')) {
-        return 'default.redis2.6';
+        return 'default.redis2.8';
     }
     // else if(redisVersion.startsWith('3.2') && numShards > 1) {
     //     return 'default.redis3.2.cluster.on';


### PR DESCRIPTION
Trying to deploy redis 2.8

`error:   Error during environment deploy: Errors while creating stack 'handel-test-dev-cache-redis': 
CREATE_FAILED : AWS::ElastiCache::CacheCluster : Expected a parameter group of family redis2.8 but found one of family redis2.6 (Service: AmazonElastiCache; Status Code: 400; Error Code: InvalidParameterCombination; Request ID: 21df3c82-b78d-11e8-a38f-49c6c30d28ae)`

It was a simple copy/paste error.

I validated that deploying redis 2.8 works after this change.