### PR TITLE
Modify UnBind Phase Contract

### DIFF
--- a/docs/extensions/writing-extensions.rst
+++ b/docs/extensions/writing-extensions.rst
@@ -229,7 +229,7 @@ The following TypeScript interface defines the contract for a service deployer:
         /**
         * In this phase, the service should remove all bindings on preDeploy resources.
         */
-        unBind?(ownServiceContext: ServiceContext<ServiceConfig>): Promise<IUnBindContext>;
+        unBind?(ownServiceContext: ServiceContext<ServiceConfig>, ownPreDeployContext: IPreDeployContext, dependentOfServiceContext: ServiceContext<ServiceConfig>, dependentOfPreDeployContext: IPreDeployContext): Promise<IUnBindContext>;
 
         /**
         * In this phase, the service should delete resources created during the deploy phase.
@@ -271,9 +271,14 @@ Delete Lifecycle
 ~~~~~~~~~~~~~~~~
 The Delete lifecycle executes the following phases in order:
 
-1. UnDeploy
-2. UnBind
-3. UnPreDeploy
+1. PreDeploy
+2. UnDeploy
+3. UnBind
+4. UnPreDeploy
+
+.. NOTE::
+
+    PreDeploy seems a little odd to execute in the Delete lifecycle, but it needs to execute so that the UnBind phase can have the data from PreDeploy passed to it that it needs.
 
 Check Lifecycle
 ~~~~~~~~~~~~~~~

--- a/extension-api/extension-api.ts
+++ b/extension-api/extension-api.ts
@@ -114,7 +114,7 @@ export interface ServiceDeployer {
     /**
      * In this phase, the service should remove all bindings on preDeploy resources.
      */
-    unBind?(ownServiceContext: ServiceContext<ServiceConfig>): Promise<IUnBindContext>;
+    unBind?(ownServiceContext: ServiceContext<ServiceConfig>, ownPreDeployContext: IPreDeployContext, dependentOfServiceContext: ServiceContext<ServiceConfig>, dependentOfPreDeployContext: IPreDeployContext): Promise<IUnBindContext>;
 
     /**
      * In this phase, the service should delete resources created during the deploy phase.

--- a/extension-support/test/common/check-phase-test.ts
+++ b/extension-support/test/common/check-phase-test.ts
@@ -15,7 +15,7 @@
  *
  */
 import { expect } from 'chai';
-import { AccountConfig, ServiceConfig, ServiceContext, ServiceType, UnBindContext, UnDeployContext, UnPreDeployContext } from 'handel-extension-api';
+import { ServiceConfig, ServiceContext, ServiceType } from 'handel-extension-api';
 import 'mocha';
 import * as sinon from 'sinon';
 import * as checkPhase from '../../src/common/check-phase';

--- a/handel/src/lifecycles/delete.ts
+++ b/handel/src/lifecycles/delete.ts
@@ -24,15 +24,17 @@ import {
     EnvironmentDeleteResult,
     HandelFile,
     HandelFileParser,
+    PreDeployContexts,
     UnBindContexts,
     UnDeployContexts
 } from '../datatypes';
 import * as deployOrderCalc from '../deploy/deploy-order-calc';
+import * as preDeployPhase from '../phases/pre-deploy';
 import * as unBindPhase from '../phases/un-bind';
 import * as unDeployPhase from '../phases/un-deploy';
 import * as unPreDeployPhase from '../phases/un-pre-deploy';
 
-async function unDeployAndUnBindServices(serviceRegistry: ServiceRegistry, environmentContext: EnvironmentContext, deployOrder: DeployOrder) {
+async function unDeployAndUnBindServices(serviceRegistry: ServiceRegistry, environmentContext: EnvironmentContext, preDeployContexts: PreDeployContexts, deployOrder: DeployOrder) {
     const unBindContexts: UnBindContexts = {};
     const unDeployContexts: UnDeployContexts = {};
     for (let currentLevel = deployOrder.length - 1; deployOrder[currentLevel]; currentLevel--) {
@@ -45,7 +47,7 @@ async function unDeployAndUnBindServices(serviceRegistry: ServiceRegistry, envir
         }
 
         // Un-bind all services in the current level
-        const levelUnBindResults = await unBindPhase.unBindServicesInLevel(serviceRegistry, environmentContext, deployOrder, currentLevel);
+        const levelUnBindResults = await unBindPhase.unBindServicesInLevel(serviceRegistry, environmentContext, preDeployContexts, deployOrder, currentLevel);
         for (const serviceName in levelUnBindResults) {
             if (levelUnBindResults.hasOwnProperty(serviceName)) {
                 unBindContexts[serviceName] = levelUnBindResults[serviceName];
@@ -70,8 +72,11 @@ async function deleteEnvironment(accountConfig: AccountConfig, serviceRegistry: 
         winston.info(`Starting delete for environment ${environmentContext.environmentName}`);
 
         try {
+            // Run preDeploy first. We do this because the unBind phase needs access to the PreDeployContext in order to properly unbind in some cases
+            const preDeployResults = await preDeployPhase.preDeployServices(serviceRegistry, environmentContext);
+
             const deployOrder = deployOrderCalc.getDeployOrder(environmentContext);
-            const unDeployAndUnBindResults = await unDeployAndUnBindServices(serviceRegistry, environmentContext, deployOrder);
+            const unDeployAndUnBindResults = await unDeployAndUnBindServices(serviceRegistry, environmentContext, preDeployResults, deployOrder);
             const unPreDeployResults = await unPreDeployPhase.unPreDeployServices(serviceRegistry, environmentContext);
             return new EnvironmentDeleteResult(environmentContext.environmentName, startTime, 'success', 'Success');
         }

--- a/handel/src/phases/bind.ts
+++ b/handel/src/phases/bind.ts
@@ -57,11 +57,10 @@ export async function bindServicesInLevel(serviceRegistry: ServiceRegistry, envi
             const dependentOfServiceContext = environmentContext.serviceContexts[dependentOfServiceName];
             const dependentOfPreDeployContext = preDeployContexts[dependentOfServiceName];
 
-            // Run bind on the service combination
+            // Run bind on the service combination (if implemented by the dependency service)
             const bindContextName = getBindContextName(toBindServiceName, dependentOfServiceName);
-            winston.debug(`Binding service ${bindContextName}`);
-
             if (serviceDeployer.bind) {
+                winston.debug(`Binding service ${bindContextName}`);
                 const bindPromise = serviceDeployer.bind(toBindServiceContext, toBindPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext)
                     .then(bindContext => {
                         if (!isBindContext(bindContext)) {

--- a/handel/src/phases/un-bind.ts
+++ b/handel/src/phases/un-bind.ts
@@ -17,35 +17,62 @@
 import { isUnBindContext, ServiceRegistry } from 'handel-extension-api';
 import * as winston from 'winston';
 import * as lifecyclesCommon from '../common/lifecycles-common';
-import { DeployOrder, DontBlameHandelError, EnvironmentContext, UnBindContexts } from '../datatypes';
+import { DeployOrder, DontBlameHandelError, EnvironmentContext, PreDeployContexts, UnBindContexts } from '../datatypes';
 
-export async function unBindServicesInLevel(serviceRegistry: ServiceRegistry, environmentContext: EnvironmentContext, deployOrder: DeployOrder, level: number): Promise<UnBindContexts> {
+function getDependentServicesForCurrentUnBindService(environmentContext: EnvironmentContext, toBindServiceName: string): string[] {
+    const dependentServices = [];
+    for (const currentServiceName in environmentContext.serviceContexts) {
+        if (environmentContext.serviceContexts.hasOwnProperty(currentServiceName)) {
+            const currentService = environmentContext.serviceContexts[currentServiceName];
+            const currentServiceDeps = currentService.params.dependencies;
+            if (currentServiceDeps && currentServiceDeps.includes(toBindServiceName)) {
+                dependentServices.push(currentServiceName);
+            }
+        }
+    }
+    return dependentServices;
+}
+
+function getUnBindContextName(unBindServiceName: string, dependentServiceName: string): string {
+    return `${dependentServiceName}->${unBindServiceName}`;
+}
+
+export async function unBindServicesInLevel(serviceRegistry: ServiceRegistry, environmentContext: EnvironmentContext, preDeployContexts: PreDeployContexts, deployOrder: DeployOrder, level: number): Promise<UnBindContexts> {
     const unBindPromises: Array<Promise<void>> = [];
     const unBindContexts: UnBindContexts = {};
 
     const currentLevelServicesToUnBind = deployOrder[level];
     winston.info(`Executing UnBind phase in level ${level} in environment '${environmentContext.environmentName}' for services ${currentLevelServicesToUnBind.join(', ')}`);
-    for(const toUnBindServiceName of currentLevelServicesToUnBind) {
+    for (const toUnBindServiceName of currentLevelServicesToUnBind) {
         const toUnBindServiceContext = environmentContext.serviceContexts[toUnBindServiceName];
+        const toUnBindPreDeployContext = preDeployContexts[toUnBindServiceName];
         const serviceDeployer = serviceRegistry.getService(toUnBindServiceContext.serviceType);
 
-        if (serviceDeployer.unBind) {
-            winston.info(`UnBinding service ${toUnBindServiceName}`);
-            const unBindPromise = serviceDeployer.unBind(toUnBindServiceContext)
-                .then(unBindContext => {
-                    if (!isUnBindContext(unBindContext)) {
-                        throw new DontBlameHandelError(`Expected UnBindContext back from 'unBind' phase of service deployer`, toUnBindServiceContext.serviceType);
-                    }
-                    unBindContexts[toUnBindServiceName] = unBindContext;
-                });
-            unBindPromises.push(unBindPromise);
-        }
-        else { // If unbind not implemented by deployer, return an empty unbind context
-            const unBindPromise = lifecyclesCommon.unBindNotRequired(toUnBindServiceContext)
-                .then(unBindContext => {
-                    unBindContexts[toUnBindServiceName] = unBindContext;
-                });
-            unBindPromises.push(unBindPromise);
+        for (const dependentOfServiceName of getDependentServicesForCurrentUnBindService(environmentContext, toUnBindServiceName)) {
+            // Get ServiceContext for the dependent service
+            const dependentOfServiceContext = environmentContext.serviceContexts[dependentOfServiceName];
+            const dependentOfPreDeployContext = preDeployContexts[dependentOfServiceName];
+
+            // Run unBind on the service combination (if implemented by the dependency service)
+            const unBindContextName = getUnBindContextName(toUnBindServiceName, dependentOfServiceName);
+            if (serviceDeployer.unBind) {
+                winston.info(`UnBinding service ${toUnBindServiceName}`);
+                const unBindPromise = serviceDeployer.unBind(toUnBindServiceContext, toUnBindPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext)
+                    .then(unBindContext => {
+                        if (!isUnBindContext(unBindContext)) {
+                            throw new DontBlameHandelError(`Expected UnBindContext back from 'unBind' phase of service deployer`, toUnBindServiceContext.serviceType);
+                        }
+                        unBindContexts[unBindContextName] = unBindContext;
+                    });
+                unBindPromises.push(unBindPromise);
+            }
+            else { // If unbind not implemented by deployer, return an empty unbind context
+                const unBindPromise = lifecyclesCommon.unBindNotRequired(toUnBindServiceContext)
+                    .then(unBindContext => {
+                        unBindContexts[unBindContextName] = unBindContext;
+                    });
+                unBindPromises.push(unBindPromise);
+            }
         }
     }
 

--- a/handel/src/services/aurora/index.ts
+++ b/handel/src/services/aurora/index.ts
@@ -225,7 +225,7 @@ export function unPreDeploy(ownServiceContext: ServiceContext<AuroraConfig>): Pr
     return deletePhases.unPreDeploySecurityGroup(ownServiceContext, SERVICE_NAME);
 }
 
-export function unBind(ownServiceContext: ServiceContext<AuroraConfig>): Promise<UnBindContext> {
+export function unBind(ownServiceContext: ServiceContext<AuroraConfig>, ownPreDeployContext: PreDeployContext, dependentOfServiceContext: ServiceContext<ServiceConfig>, dependentOfPreDeployContext: PreDeployContext): Promise<UnBindContext> {
     return deletePhases.unBindSecurityGroups(ownServiceContext, SERVICE_NAME);
 }
 

--- a/handel/src/services/efs/index.ts
+++ b/handel/src/services/efs/index.ts
@@ -153,7 +153,7 @@ export async function unPreDeploy(ownServiceContext: ServiceContext<EfsServiceCo
     return deletePhases.unPreDeploySecurityGroup(ownServiceContext, SERVICE_NAME);
 }
 
-export async function unBind(ownServiceContext: ServiceContext<EfsServiceConfig>): Promise<UnBindContext> {
+export async function unBind(ownServiceContext: ServiceContext<EfsServiceConfig>, ownPreDeployContext: PreDeployContext, dependentOfServiceContext: ServiceContext<ServiceConfig>, dependentOfPreDeployContext: PreDeployContext): Promise<UnBindContext> {
     return deletePhases.unBindSecurityGroups(ownServiceContext, SERVICE_NAME);
 }
 

--- a/handel/src/services/elasticsearch/index.ts
+++ b/handel/src/services/elasticsearch/index.ts
@@ -156,7 +156,10 @@ export function unPreDeploy(ownServiceContext: ServiceContext<ElasticsearchConfi
     return deletePhases.unPreDeploySecurityGroup(ownServiceContext, SERVICE_NAME);
 }
 
-export function unBind(ownServiceContext: ServiceContext<ElasticsearchConfig>): Promise<UnBindContext> {
+export function unBind(ownServiceContext: ServiceContext<ElasticsearchConfig>,
+    ownPreDeployContext: PreDeployContext,
+    dependentOfServiceContext: ServiceContext<ServiceConfig>,
+    dependentOfPreDeployContext: PreDeployContext): Promise<UnBindContext> {
     return deletePhases.unBindSecurityGroups(ownServiceContext, SERVICE_NAME);
 }
 

--- a/handel/src/services/memcached/index.ts
+++ b/handel/src/services/memcached/index.ts
@@ -126,7 +126,7 @@ export async function unPreDeploy(ownServiceContext: ServiceContext<MemcachedSer
     return deletePhases.unPreDeploySecurityGroup(ownServiceContext, SERVICE_NAME);
 }
 
-export async function unBind(ownServiceContext: ServiceContext<MemcachedServiceConfig>): Promise<UnBindContext> {
+export async function unBind(ownServiceContext: ServiceContext<MemcachedServiceConfig>, ownPreDeployContext: PreDeployContext, dependentOfServiceContext: ServiceContext<ServiceConfig>, dependentOfPreDeployContext: PreDeployContext): Promise<UnBindContext> {
     return deletePhases.unBindSecurityGroups(ownServiceContext, SERVICE_NAME);
 }
 

--- a/handel/src/services/mysql/index.ts
+++ b/handel/src/services/mysql/index.ts
@@ -154,7 +154,10 @@ export function unPreDeploy(ownServiceContext: ServiceContext<MySQLConfig>): Pro
     return deletePhases.unPreDeploySecurityGroup(ownServiceContext, SERVICE_NAME);
 }
 
-export function unBind(ownServiceContext: ServiceContext<MySQLConfig>): Promise<UnBindContext> {
+export function unBind(ownServiceContext: ServiceContext<MySQLConfig>,
+    ownPreDeployContext: PreDeployContext,
+    dependentOfServiceContext: ServiceContext<ServiceConfig>,
+    dependentOfPreDeployContext: PreDeployContext): Promise<UnBindContext> {
     return deletePhases.unBindSecurityGroups(ownServiceContext, SERVICE_NAME);
 }
 

--- a/handel/src/services/neptune/index.ts
+++ b/handel/src/services/neptune/index.ts
@@ -171,7 +171,10 @@ export function unPreDeploy(ownServiceContext: ServiceContext<NeptuneConfig>): P
     return deletePhases.unPreDeploySecurityGroup(ownServiceContext, SERVICE_NAME);
 }
 
-export function unBind(ownServiceContext: ServiceContext<NeptuneConfig>): Promise<UnBindContext> {
+export function unBind(ownServiceContext: ServiceContext<NeptuneConfig>,
+    ownPreDeployContext: PreDeployContext,
+    dependentOfServiceContext: ServiceContext<ServiceConfig>,
+    dependentOfPreDeployContext: PreDeployContext): Promise<UnBindContext> {
     return deletePhases.unBindSecurityGroups(ownServiceContext, SERVICE_NAME);
 }
 

--- a/handel/src/services/postgresql/index.ts
+++ b/handel/src/services/postgresql/index.ts
@@ -160,7 +160,10 @@ export function unPreDeploy(ownServiceContext: ServiceContext<PostgreSQLConfig>)
     return deletePhases.unPreDeploySecurityGroup(ownServiceContext, SERVICE_NAME);
 }
 
-export function unBind(ownServiceContext: ServiceContext<PostgreSQLConfig>): Promise<UnBindContext> {
+export function unBind(ownServiceContext: ServiceContext<PostgreSQLConfig>,
+    ownPreDeployContext: PreDeployContext,
+    dependentOfServiceContext: ServiceContext<ServiceConfig>,
+    dependentOfPreDeployContext: PreDeployContext): Promise<UnBindContext> {
     return deletePhases.unBindSecurityGroups(ownServiceContext, SERVICE_NAME);
 }
 

--- a/handel/src/services/redis/index.ts
+++ b/handel/src/services/redis/index.ts
@@ -188,7 +188,7 @@ export async function unPreDeploy(ownServiceContext: ServiceContext<RedisService
     return deletePhases.unPreDeploySecurityGroup(ownServiceContext, SERVICE_NAME);
 }
 
-export async function unBind(ownServiceContext: ServiceContext<RedisServiceConfig>): Promise<UnBindContext> {
+export async function unBind(ownServiceContext: ServiceContext<RedisServiceConfig>, ownPreDeployContext: PreDeployContext, dependentOfServiceContext: ServiceContext<ServiceConfig>, dependentOfPreDeployContext: PreDeployContext): Promise<UnBindContext> {
     return deletePhases.unBindSecurityGroups(ownServiceContext, SERVICE_NAME);
 }
 

--- a/handel/test/lifecycles/delete-test.ts
+++ b/handel/test/lifecycles/delete-test.ts
@@ -23,6 +23,7 @@ import * as util from '../../src/common/util';
 import { DeleteOptions, HandelFile } from '../../src/datatypes';
 import * as handelFileParser from '../../src/handelfile/parser-v1';
 import * as deleteLifecycle from '../../src/lifecycles/delete';
+import * as preDeployPhase from '../../src/phases/pre-deploy';
 import * as unBindPhase from '../../src/phases/un-bind';
 import * as unDeployPhase from '../../src/phases/un-deploy';
 import * as unPreDeployPhase from '../../src/phases/un-pre-deploy';
@@ -45,6 +46,7 @@ describe('delete lifecycle module', () => {
     describe('delete', () => {
         it('should delete the application environment', async () => {
             const serviceContext = new ServiceContext('FakeApp', 'FakeEnv', 'FakeService', new ServiceType(STDLIB_PREFIX, 'FakeType'), {type: 'FakeType'}, accountConfig);
+            const preDeployServicesStub = sandbox.stub(preDeployPhase, 'preDeployServices').returns({});
             const unDeployServicesStub = sandbox.stub(unDeployPhase, 'unDeployServicesInLevel').returns({});
             const unBindServicesStub = sandbox.stub(unBindPhase, 'unBindServicesInLevel').returns({});
             const unPreDeployStub = sandbox.stub(unPreDeployPhase, 'unPreDeployServices').resolves({
@@ -54,6 +56,7 @@ describe('delete lifecycle module', () => {
             const opts: DeleteOptions = { linkExtensions: false, yes: false, environment: 'dev', accountConfig: '' };
             const handelFile: HandelFile = util.readYamlFileSync(`${__dirname}/../test-handel.yml`);
             const results = await deleteLifecycle.deleteEnv(accountConfig, handelFile, 'dev', handelFileParser, serviceRegistry, opts);
+            expect(preDeployServicesStub.callCount).to.equal(1);
             expect(unPreDeployStub.callCount).to.equal(1);
             expect(unBindServicesStub.callCount).to.equal(2);
             expect(unDeployServicesStub.callCount).to.equal(2);

--- a/handel/test/services/aurora/aurora-test.ts
+++ b/handel/test/services/aurora/aurora-test.ts
@@ -20,12 +20,12 @@ import {
     BindContext,
     DeployContext,
     PreDeployContext,
+    ServiceConfig,
     ServiceContext,
     ServiceType,
     UnBindContext,
     UnDeployContext,
-    UnPreDeployContext,
-    ServiceConfig
+    UnPreDeployContext
 } from 'handel-extension-api';
 import { awsCalls, bindPhase, deletePhases, deployPhase, preDeployPhase } from 'handel-extension-support';
 import 'mocha';
@@ -217,8 +217,11 @@ describe('aurora deployer', () => {
         it('should unbind the security group', async () => {
             const unBindStub = sandbox.stub(deletePhases, 'unBindSecurityGroups')
                 .resolves(new UnBindContext(serviceContext));
+            const dependencyPreDeployContext = new PreDeployContext(serviceContext);
+            const dependentOfServiceContext = new ServiceContext(appName, envName, 'FakeService', new ServiceType(STDLIB_PREFIX, 'beanstalk'), {type: 'beanstalk'}, accountConfig);
+            const dependentOfPreDeployContext = new PreDeployContext(dependentOfServiceContext);
 
-            const unBindContext = await aurora.unBind(serviceContext);
+            const unBindContext = await aurora.unBind(serviceContext, dependencyPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext);
             expect(unBindContext).to.be.instanceof(UnBindContext);
             expect(unBindStub.callCount).to.equal(1);
         });

--- a/handel/test/services/efs/efs-test.ts
+++ b/handel/test/services/efs/efs-test.ts
@@ -134,8 +134,11 @@ describe('efs deployer', () => {
     describe('unBind', () => {
         it('should unbind the security group', async () => {
             const unBindStub = sandbox.stub(deletePhases, 'unBindSecurityGroups').resolves(new UnBindContext(serviceContext));
+            const dependencyPreDeployContext = new PreDeployContext(serviceContext);
+            const dependentOfServiceContext = new ServiceContext(appName, envName, 'FakeService', new ServiceType(STDLIB_PREFIX, 'beanstalk'), {type: 'beanstalk'}, accountConfig);
+            const dependentOfPreDeployContext = new PreDeployContext(dependentOfServiceContext);
 
-            const unBindContext = await efs.unBind(serviceContext);
+            const unBindContext = await efs.unBind(serviceContext, dependencyPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext);
             expect(unBindContext).to.be.instanceof(UnBindContext);
             expect(unBindStub.callCount).to.equal(1);
         });

--- a/handel/test/services/elasticsearch/elasticsearch-test.ts
+++ b/handel/test/services/elasticsearch/elasticsearch-test.ts
@@ -149,8 +149,11 @@ describe('elasticsearch deployer', () => {
         it('should unbind the security group', async () => {
             const unBindStub = sandbox.stub(deletePhases, 'unBindSecurityGroups')
                 .resolves(new UnBindContext(serviceContext));
+            const dependencyPreDeployContext = new PreDeployContext(serviceContext);
+            const dependentOfServiceContext = new ServiceContext(appName, envName, 'FakeService', new ServiceType(STDLIB_PREFIX, 'beanstalk'), {type: 'beanstalk'}, accountConfig);
+            const dependentOfPreDeployContext = new PreDeployContext(dependentOfServiceContext);
 
-            const unBindContext = await elasticsearch.unBind(serviceContext);
+            const unBindContext = await elasticsearch.unBind(serviceContext, dependencyPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext);
             expect(unBindContext).to.be.instanceof(UnBindContext);
             expect(unBindStub.callCount).to.equal(1);
         });

--- a/handel/test/services/memcached/memcached-test.ts
+++ b/handel/test/services/memcached/memcached-test.ts
@@ -158,8 +158,11 @@ describe('memcached deployer', () => {
     describe('unBind', () => {
         it('should unbind the security group', async () => {
             const unBindStub = sandbox.stub(deletePhases, 'unBindSecurityGroups').resolves(new UnBindContext(serviceContext));
+            const dependencyPreDeployContext = new PreDeployContext(serviceContext);
+            const dependentOfServiceContext = new ServiceContext(appName, envName, 'FakeService', new ServiceType(STDLIB_PREFIX, 'beanstalk'), {type: 'beanstalk'}, accountConfig);
+            const dependentOfPreDeployContext = new PreDeployContext(dependentOfServiceContext);
 
-            const unBindContext = await memcached.unBind(serviceContext);
+            const unBindContext = await memcached.unBind(serviceContext, dependencyPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext);
             expect(unBindContext).to.be.instanceof(UnBindContext);
             expect(unBindStub.callCount).to.equal(1);
         });

--- a/handel/test/services/mysql/mysql-test.ts
+++ b/handel/test/services/mysql/mysql-test.ts
@@ -191,8 +191,11 @@ describe('mysql deployer', () => {
         it('should unbind the security group', async () => {
             const unBindStub = sandbox.stub(deletePhases, 'unBindSecurityGroups')
                 .resolves(new UnBindContext(serviceContext));
+            const dependencyPreDeployContext = new PreDeployContext(serviceContext);
+            const dependentOfServiceContext = new ServiceContext(appName, envName, 'FakeService', new ServiceType(STDLIB_PREFIX, 'beanstalk'), {type: 'beanstalk'}, accountConfig);
+            const dependentOfPreDeployContext = new PreDeployContext(dependentOfServiceContext);
 
-            const unBindContext = await mysql.unBind(serviceContext);
+            const unBindContext = await mysql.unBind(serviceContext, dependencyPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext);
             expect(unBindContext).to.be.instanceof(UnBindContext);
             expect(unBindStub.callCount).to.equal(1);
         });

--- a/handel/test/services/neptune/neptune-test.ts
+++ b/handel/test/services/neptune/neptune-test.ts
@@ -171,8 +171,11 @@ describe('neptune deployer', () => {
         it('should unbind the security group', async () => {
             const unBindStub = sandbox.stub(deletePhases, 'unBindSecurityGroups')
                 .resolves(new UnBindContext(serviceContext));
+            const dependencyPreDeployContext = new PreDeployContext(serviceContext);
+            const dependentOfServiceContext = new ServiceContext(appName, envName, 'FakeService', new ServiceType(STDLIB_PREFIX, 'beanstalk'), {type: 'beanstalk'}, accountConfig);
+            const dependentOfPreDeployContext = new PreDeployContext(dependentOfServiceContext);
 
-            const unBindContext = await neptune.unBind(serviceContext);
+            const unBindContext = await neptune.unBind(serviceContext, dependencyPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext);
             expect(unBindContext).to.be.instanceof(UnBindContext);
             expect(unBindStub.callCount).to.equal(1);
         });

--- a/handel/test/services/postgresql/postgresql-test.ts
+++ b/handel/test/services/postgresql/postgresql-test.ts
@@ -191,8 +191,11 @@ describe('postgresql deployer', () => {
         it('should unbind the security group', async () => {
             const unBindStub = sandbox.stub(deletePhases, 'unBindSecurityGroups')
                 .resolves(new UnBindContext(serviceContext));
+            const dependencyPreDeployContext = new PreDeployContext(serviceContext);
+            const dependentOfServiceContext = new ServiceContext(appName, envName, 'FakeService', new ServiceType(STDLIB_PREFIX, 'beanstalk'), {type: 'beanstalk'}, accountConfig);
+            const dependentOfPreDeployContext = new PreDeployContext(dependentOfServiceContext);
 
-            const unBindContext = await postgresql.unBind(serviceContext);
+            const unBindContext = await postgresql.unBind(serviceContext, dependencyPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext);
             expect(unBindContext).to.be.instanceof(UnBindContext);
             expect(unBindStub.callCount).to.equal(1);
         });

--- a/handel/test/services/redis/redis-test.ts
+++ b/handel/test/services/redis/redis-test.ts
@@ -168,8 +168,11 @@ describe('redis deployer', () => {
     describe('unBind', () => {
         it('should unbind the security group', async () => {
             const unBindStub = sandbox.stub(deletePhases, 'unBindSecurityGroups').resolves(new UnBindContext(serviceContext));
+            const dependencyPreDeployContext = new PreDeployContext(serviceContext);
+            const dependentOfServiceContext = new ServiceContext(appName, envName, 'FakeService', new ServiceType(STDLIB_PREFIX, 'beanstalk'), {type: 'beanstalk'}, accountConfig);
+            const dependentOfPreDeployContext = new PreDeployContext(dependentOfServiceContext);
 
-            const unBindContext = await redis.unBind(serviceContext);
+            const unBindContext = await redis.unBind(serviceContext, dependencyPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext);
             expect(unBindContext).to.be.instanceof(UnBindContext);
             expect(unBindStub.callCount).to.equal(1);
         });


### PR DESCRIPTION
I had hoped it was sufficient to just pass the ServiceContext to UnBind, and it has been for a while. However, as I write an extension, I find myself needing to UnBind just one service combination at a time, rather than all at once as we have previously been doing. In order to do this, it requires information from the PreDeployContexts of both services.

I can't think of any way to get this information except by running the PreDeploy phase first prior to running the existing delete phases. While this feels a bit odd, it very nicely provides the information from PreDeploy to the delete phases that need it.

This is a breaking extension contract change at compile-time (not at run-time because we only add more parameters onto the end of the UnBind method). Luckily there are few enough extensions out there currently that we can go modify them without having to call this a major version change.

@ThatJoeMoore Let me know if you can think of a better way of doing this.