### PR TITLE
Use contract classes

### DIFF
--- a/handel/src/services/aiservices/index.ts
+++ b/handel/src/services/aiservices/index.ts
@@ -19,7 +19,8 @@ import {
     DeployOutputType,
     PreDeployContext,
     ServiceConfig,
-    ServiceContext
+    ServiceContext,
+    ServiceDeployer
 } from 'handel-extension-api';
 import { checkPhase, handlebars } from 'handel-extension-support';
 import * as winston from 'winston';
@@ -76,29 +77,23 @@ async function getDeployContext(serviceContext: ServiceContext<AIServicesConfig>
     return deployContext;
 }
 
-/**
- * Service Deployer Contract Methods
- * See https://github.com/byu-oit-appdev/handel/wiki/Creating-a-New-Service-Deployer#service-deployer-contract
- *   for contract method documentation
- */
+export class Service implements ServiceDeployer {
+    public readonly producedEventsSupportedTypes = [];
+    public readonly producedDeployOutputTypes = [
+        DeployOutputType.Policies
+    ];
+    public readonly consumedDeployOutputTypes = [];
+    public readonly providedEventType = null;
+    public readonly supportsTagging = false;
 
-export function check(serviceContext: ServiceContext<AIServicesConfig>, dependenciesServiceContexts: Array<ServiceContext<ServiceConfig>>): string[] {
-    const errors: string[] = checkPhase.checkJsonSchema(`${__dirname}/params-schema.json`, serviceContext);
-    return errors.map(error => `${SERVICE_NAME} - ${error}`);
+    public check(serviceContext: ServiceContext<AIServicesConfig>, dependenciesServiceContexts: Array<ServiceContext<ServiceConfig>>): string[] {
+        const errors: string[] = checkPhase.checkJsonSchema(`${__dirname}/params-schema.json`, serviceContext);
+        return errors.map(error => `${SERVICE_NAME} - ${error}`);
+    }
+
+    public async deploy(ownServiceContext: ServiceContext<AIServicesConfig>, ownPreDeployContext: PreDeployContext, dependenciesDeployContexts: DeployContext[]): Promise<DeployContext> {
+        const stackName = ownServiceContext.stackName();
+        winston.info(`${SERVICE_NAME} - Deploying '${stackName}'`);
+        return getDeployContext(ownServiceContext);
+    }
 }
-
-export async function deploy(ownServiceContext: ServiceContext<AIServicesConfig>, ownPreDeployContext: PreDeployContext, dependenciesDeployContexts: DeployContext[]): Promise<DeployContext> {
-    const stackName = ownServiceContext.stackName();
-    winston.info(`${SERVICE_NAME} - Deploying '${stackName}'`);
-    return getDeployContext(ownServiceContext);
-}
-
-export const producedEventsSupportedTypes = [];
-
-export const producedDeployOutputTypes = [
-    DeployOutputType.Policies
-];
-
-export const consumedDeployOutputTypes = [];
-
-export const supportsTagging = false;

--- a/handel/src/services/alexaskillkit/index.ts
+++ b/handel/src/services/alexaskillkit/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
-import { DeployContext, PreDeployContext, ProduceEventsContext, ServiceConfig, ServiceContext, ServiceEventConsumer, ServiceEventType } from 'handel-extension-api';
+import { DeployContext, PreDeployContext, ProduceEventsContext, ServiceConfig, ServiceContext, ServiceDeployer, ServiceEventConsumer, ServiceEventType } from 'handel-extension-api';
 import * as winston from 'winston';
 
 const SERVICE_NAME = 'Alexa Skill Kit';
@@ -28,34 +28,26 @@ function getDeployContext(ownServiceContext: ServiceContext<ServiceConfig>): Dep
     return deployContext;
 }
 
-/**
- * Service Deployer Contract Methods
- * See https://github.com/byu-oit-appdev/handel/wiki/Creating-a-New-Service-Deployer#service-deployer-contract
- *   for contract method documentation
- */
+export class Service implements ServiceDeployer {
+    public readonly producedDeployOutputTypes = [];
+    public readonly consumedDeployOutputTypes = [];
+    public readonly providedEventType = ServiceEventType.AlexaSkillKit;
+    public readonly producedEventsSupportedTypes = [
+        ServiceEventType.Lambda
+    ];
+    public readonly supportsTagging = false;
 
-export function check(serviceContext: ServiceContext<ServiceConfig>, dependenciesServiceContexts: Array<ServiceContext<ServiceConfig>>): string[] {
-    return [];
+    public check(serviceContext: ServiceContext<ServiceConfig>, dependenciesServiceContexts: Array<ServiceContext<ServiceConfig>>): string[] {
+        return [];
+    }
+
+    public async deploy(ownServiceContext: ServiceContext<ServiceConfig>, ownPreDeployContext: PreDeployContext, dependenciesDeployContexts: DeployContext[]): Promise<DeployContext> {
+        winston.debug(`${SERVICE_NAME} - Deploy not currently required for the Alexa Skill Kit service`);
+        return getDeployContext(ownServiceContext);
+    }
+
+    public async produceEvents(ownServiceContext: ServiceContext<ServiceConfig>, ownDeployContext: DeployContext, eventConsumerConfig: ServiceEventConsumer, consumerServiceContext: ServiceContext<ServiceConfig>, consumerDeployContext: DeployContext): Promise<ProduceEventsContext> {
+        winston.info(`${SERVICE_NAME} - No events to produce from '${ownServiceContext.serviceName}' for consumer ${consumerServiceContext.serviceName}`);
+        return new ProduceEventsContext(ownServiceContext, consumerServiceContext);
+    }
 }
-
-export function deploy(ownServiceContext: ServiceContext<ServiceConfig>, ownPreDeployContext: PreDeployContext, dependenciesDeployContexts: DeployContext[]) {
-    winston.debug(`${SERVICE_NAME} - Deploy not currently required for the Alexa Skill Kit service`);
-    return Promise.resolve(getDeployContext(ownServiceContext));
-}
-
-export function produceEvents(ownServiceContext: ServiceContext<ServiceConfig>, ownDeployContext: DeployContext, eventConsumerConfig: ServiceEventConsumer, consumerServiceContext: ServiceContext<ServiceConfig>, consumerDeployContext: DeployContext) {
-    winston.info(`${SERVICE_NAME} - No events to produce from '${ownServiceContext.serviceName}' for consumer ${consumerServiceContext.serviceName}`);
-    return Promise.resolve(new ProduceEventsContext(ownServiceContext, consumerServiceContext));
-}
-
-export const providedEventType = ServiceEventType.AlexaSkillKit;
-
-export const producedEventsSupportedTypes = [
-    ServiceEventType.Lambda
-];
-
-export const producedDeployOutputTypes = [];
-
-export const consumedDeployOutputTypes = [];
-
-export const supportsTagging = false;

--- a/handel/src/services/cloudwatchevent/index.ts
+++ b/handel/src/services/cloudwatchevent/index.ts
@@ -20,6 +20,7 @@ import {
     ProduceEventsContext,
     ServiceConfig,
     ServiceContext,
+    ServiceDeployer,
     ServiceEventType,
     UnDeployContext
 } from 'handel-extension-api';
@@ -71,79 +72,71 @@ async function getCompiledEventRuleTemplate(stackName: string, serviceContext: S
     return templateStr;
 }
 
-/**
- * Service Deployer Contract Methods
- * See https://github.com/byu-oit-appdev/handel/wiki/Creating-a-New-Service-Deployer#service-deployer-contract
- *   for contract method documentation
- */
+export class Service implements ServiceDeployer {
+    public readonly producedDeployOutputTypes = [];
+    public readonly consumedDeployOutputTypes = [];
+    public readonly providedEventType = ServiceEventType.CloudWatchEvents;
+    public readonly producedEventsSupportedTypes = [
+        ServiceEventType.Lambda,
+        ServiceEventType.SNS
+    ];
+    public readonly supportsTagging = true;
 
-export function check(serviceContext: ServiceContext<CloudWatchEventsConfig>, dependenciesServiceContexts: Array<ServiceContext<ServiceConfig>>): string[] {
-    const errors: string[] = checkPhase.checkJsonSchema(`${__dirname}/params-schema.json`, serviceContext);
-    if(errors.length === 0) {
-        const serviceParams = serviceContext.params;
-        if (!serviceParams.schedule && !serviceParams.event_pattern) {
-            errors.push(`You must specify at least one of the 'schedule' or 'event_pattern' parameters`);
+    public check(serviceContext: ServiceContext<CloudWatchEventsConfig>, dependenciesServiceContexts: Array<ServiceContext<ServiceConfig>>): string[] {
+        const errors: string[] = checkPhase.checkJsonSchema(`${__dirname}/params-schema.json`, serviceContext);
+        if(errors.length === 0) {
+            const serviceParams = serviceContext.params;
+            if (!serviceParams.schedule && !serviceParams.event_pattern) {
+                errors.push(`You must specify at least one of the 'schedule' or 'event_pattern' parameters`);
+            }
         }
+        return errors.map(error => `${SERVICE_NAME} - ${error}`);
     }
-    return errors.map(error => `${SERVICE_NAME} - ${error}`);
+
+    public async deploy(ownServiceContext: ServiceContext<CloudWatchEventsConfig>, ownPreDeployContext: PreDeployContext, dependenciesDeployContexts: DeployContext[]): Promise<DeployContext> {
+        const stackName = ownServiceContext.stackName();
+        winston.info(`${SERVICE_NAME} - Deploying event rule ${stackName}`);
+
+        const eventRuleTemplate = await getCompiledEventRuleTemplate(stackName, ownServiceContext);
+        const stackTags = tagging.getTags(ownServiceContext);
+        const deployedStack = await deployPhase.deployCloudFormationStack(ownServiceContext, stackName, eventRuleTemplate, [], true, 30, stackTags);
+        winston.info(`${SERVICE_NAME} - Finished deploying event rule ${stackName}`);
+        return getDeployContext(ownServiceContext, deployedStack);
+    }
+
+    public async produceEvents(ownServiceContext: ServiceContext<CloudWatchEventsConfig>, ownDeployContext: DeployContext, eventConsumerConfig: CloudWatchEventsServiceEventConsumer, consumerServiceContext: ServiceContext<ServiceConfig>, consumerDeployContext: DeployContext) {
+        winston.info(`${SERVICE_NAME} - Producing events from '${ownServiceContext.serviceName}' for consumer ${consumerServiceContext.serviceName}`);
+        if(!ownDeployContext.eventOutputs || !consumerDeployContext.eventOutputs) {
+            throw new Error(`${SERVICE_NAME} - Both the consumer and producer must return event outputs from their deploy`);
+        }
+
+        const ruleName = ownServiceContext.stackName();
+        const targetId = consumerServiceContext.stackName();
+        const targetArn = consumerDeployContext.eventOutputs.resourceArn;
+        if(!targetArn) {
+            throw new Error(`${SERVICE_NAME} - Consumed service did not return an ARN`);
+        }
+        const input = eventConsumerConfig.event_input;
+
+        const retTargetId = await cloudWatchEventsCalls.addTarget(ruleName, targetArn, targetId, input);
+        winston.info(`${SERVICE_NAME} - Configured production of events from '${ownServiceContext.serviceName}' for consumer '${consumerServiceContext.serviceName}'`);
+        return new ProduceEventsContext(ownServiceContext, consumerServiceContext);
+    }
+
+    public async unDeploy(ownServiceContext: ServiceContext<CloudWatchEventsConfig>): Promise<UnDeployContext> {
+        const stackName = ownServiceContext.stackName();
+        winston.info(`${SERVICE_NAME} - Executing UnDeploy on Events Rule '${stackName}'`);
+
+        const rule = await cloudWatchEventsCalls.getRule(stackName);
+        let success = true;
+        if (rule) {
+            winston.info(`${SERVICE_NAME} - Removing targets from event rule '${stackName}'`);
+            success = await cloudWatchEventsCalls.removeAllTargets(stackName);
+        }
+        else {
+            winston.info(`${SERVICE_NAME} - Rule '${stackName}' has already been deleted`);
+        }
+        await deletePhases.unDeployService(ownServiceContext, SERVICE_NAME);
+        return new UnDeployContext(ownServiceContext);
+    }
 }
-
-export async function deploy(ownServiceContext: ServiceContext<CloudWatchEventsConfig>, ownPreDeployContext: PreDeployContext, dependenciesDeployContexts: DeployContext[]): Promise<DeployContext> {
-    const stackName = ownServiceContext.stackName();
-    winston.info(`${SERVICE_NAME} - Deploying event rule ${stackName}`);
-
-    const eventRuleTemplate = await getCompiledEventRuleTemplate(stackName, ownServiceContext);
-    const stackTags = tagging.getTags(ownServiceContext);
-    const deployedStack = await deployPhase.deployCloudFormationStack(ownServiceContext, stackName, eventRuleTemplate, [], true, 30, stackTags);
-    winston.info(`${SERVICE_NAME} - Finished deploying event rule ${stackName}`);
-    return getDeployContext(ownServiceContext, deployedStack);
-}
-
-export async function produceEvents(ownServiceContext: ServiceContext<CloudWatchEventsConfig>, ownDeployContext: DeployContext, eventConsumerConfig: CloudWatchEventsServiceEventConsumer, consumerServiceContext: ServiceContext<ServiceConfig>, consumerDeployContext: DeployContext) {
-    winston.info(`${SERVICE_NAME} - Producing events from '${ownServiceContext.serviceName}' for consumer ${consumerServiceContext.serviceName}`);
-    if(!ownDeployContext.eventOutputs || !consumerDeployContext.eventOutputs) {
-        throw new Error(`${SERVICE_NAME} - Both the consumer and producer must return event outputs from their deploy`);
-    }
-
-    const ruleName = ownServiceContext.stackName();
-    const targetId = consumerServiceContext.stackName();
-    const targetArn = consumerDeployContext.eventOutputs.resourceArn;
-    if(!targetArn) {
-        throw new Error(`${SERVICE_NAME} - Consumed service did not return an ARN`);
-    }
-    const input = eventConsumerConfig.event_input;
-
-    const retTargetId = await cloudWatchEventsCalls.addTarget(ruleName, targetArn, targetId, input);
-    winston.info(`${SERVICE_NAME} - Configured production of events from '${ownServiceContext.serviceName}' for consumer '${consumerServiceContext.serviceName}'`);
-    return new ProduceEventsContext(ownServiceContext, consumerServiceContext);
-}
-
-export async function unDeploy(ownServiceContext: ServiceContext<CloudWatchEventsConfig>): Promise<UnDeployContext> {
-    const stackName = ownServiceContext.stackName();
-    winston.info(`${SERVICE_NAME} - Executing UnDeploy on Events Rule '${stackName}'`);
-
-    const rule = await cloudWatchEventsCalls.getRule(stackName);
-    let success = true;
-    if (rule) {
-        winston.info(`${SERVICE_NAME} - Removing targets from event rule '${stackName}'`);
-        success = await cloudWatchEventsCalls.removeAllTargets(stackName);
-    }
-    else {
-        winston.info(`${SERVICE_NAME} - Rule '${stackName}' has already been deleted`);
-    }
-    await deletePhases.unDeployService(ownServiceContext, SERVICE_NAME);
-    return new UnDeployContext(ownServiceContext);
-}
-
-export const providedEventType = ServiceEventType.CloudWatchEvents;
-
-export const producedEventsSupportedTypes = [
-    ServiceEventType.Lambda,
-    ServiceEventType.SNS
-];
-
-export const producedDeployOutputTypes = [];
-
-export const consumedDeployOutputTypes = [];
-
-export const supportsTagging = true;

--- a/handel/src/services/neptune/index.ts
+++ b/handel/src/services/neptune/index.ts
@@ -21,6 +21,7 @@ import {
     PreDeployContext,
     ServiceConfig,
     ServiceContext,
+    ServiceDeployer,
     Tags,
     UnBindContext,
     UnDeployContext,
@@ -112,80 +113,74 @@ function getDeployContext(serviceContext: ServiceContext<NeptuneConfig>,
     return deployContext;
 }
 
-/**
- * Service Deployer Contract Methods
- * See https://github.com/byu-oit-appdev/handel/wiki/Creating-a-New-Service-Deployer#service-deployer-contract
- *   for contract method documentation
- */
+export class Service implements ServiceDeployer {
+    public readonly producedEventsSupportedTypes = [];
+    public readonly producedDeployOutputTypes = [
+        DeployOutputType.EnvironmentVariables,
+        DeployOutputType.SecurityGroups
+    ];
+    public readonly consumedDeployOutputTypes = [];
+    public readonly providedEventType = null;
+    public readonly supportsTagging = true;
 
-export function check(serviceContext: ServiceContext<NeptuneConfig>,
-    dependenciesServiceContext: Array<ServiceContext<ServiceConfig>>): string[] {
-    const errors: string[] = checkPhase.checkJsonSchema(`${__dirname}/params-schema.json`, serviceContext);
-    return errors.map(error => `${SERVICE_NAME} - ${error}`);
-}
-
-export function preDeploy(serviceContext: ServiceContext<NeptuneConfig>): Promise<PreDeployContext> {
-    return preDeployPhase.preDeployCreateSecurityGroup(serviceContext, NEPTUNE_PORT, SERVICE_NAME);
-}
-
-export function bind(ownServiceContext: ServiceContext<NeptuneConfig>,
-    ownPreDeployContext: PreDeployContext,
-    dependentOfServiceContext: ServiceContext<ServiceConfig>,
-    dependentOfPreDeployContext: PreDeployContext): Promise<BindContext> {
-    return bindPhase.bindDependentSecurityGroup(ownServiceContext,
-        ownPreDeployContext,
-        dependentOfServiceContext,
-        dependentOfPreDeployContext,
-        NEPTUNE_PROTOCOL,
-        NEPTUNE_PORT,
-        SERVICE_NAME);
-}
-
-export async function deploy(ownServiceContext: ServiceContext<NeptuneConfig>,
-    ownPreDeployContext: PreDeployContext,
-    dependenciesDeployContexts: DeployContext[]): Promise<DeployContext> {
-    const stackName = ownServiceContext.stackName();
-    winston.info(`${SERVICE_NAME} - Deploying database '${stackName}'`);
-
-    const stack = await awsCalls.cloudFormation.getStack(stackName);
-    if (!stack) {
-        const stackTags = tagging.getTags(ownServiceContext);
-        const compiledTemplate = await getCompiledTemplate(stackName, ownServiceContext, ownPreDeployContext, stackTags);
-        winston.debug(`${SERVICE_NAME} - Creating CloudFormation stack '${stackName}'`);
-        const deployedStack = await awsCalls.cloudFormation.createStack(stackName,
-            compiledTemplate,
-            [],
-            30,
-            stackTags);
-        winston.debug(`${SERVICE_NAME} - Finished creating CloudFormation stack '${stackName}`);
-        winston.info(`${SERVICE_NAME} - Finished deploying database '${stackName}'`);
-        return getDeployContext(ownServiceContext, deployedStack);
+    public check(serviceContext: ServiceContext<NeptuneConfig>,
+        dependenciesServiceContext: Array<ServiceContext<ServiceConfig>>): string[] {
+        const errors: string[] = checkPhase.checkJsonSchema(`${__dirname}/params-schema.json`, serviceContext);
+        return errors.map(error => `${SERVICE_NAME} - ${error}`);
     }
-    else {
-        winston.info(`${SERVICE_NAME} - Updates are not supported for this service.`);
-        return getDeployContext(ownServiceContext, stack);
+
+    public async preDeploy(serviceContext: ServiceContext<NeptuneConfig>): Promise<PreDeployContext> {
+        return preDeployPhase.preDeployCreateSecurityGroup(serviceContext, NEPTUNE_PORT, SERVICE_NAME);
+    }
+
+    public async bind(ownServiceContext: ServiceContext<NeptuneConfig>,
+        ownPreDeployContext: PreDeployContext,
+        dependentOfServiceContext: ServiceContext<ServiceConfig>,
+        dependentOfPreDeployContext: PreDeployContext): Promise<BindContext> {
+        return bindPhase.bindDependentSecurityGroup(ownServiceContext,
+            ownPreDeployContext,
+            dependentOfServiceContext,
+            dependentOfPreDeployContext,
+            NEPTUNE_PROTOCOL,
+            NEPTUNE_PORT,
+            SERVICE_NAME);
+    }
+
+    public async deploy(ownServiceContext: ServiceContext<NeptuneConfig>,
+        ownPreDeployContext: PreDeployContext,
+        dependenciesDeployContexts: DeployContext[]): Promise<DeployContext> {
+        const stackName = ownServiceContext.stackName();
+        winston.info(`${SERVICE_NAME} - Deploying database '${stackName}'`);
+
+        const stack = await awsCalls.cloudFormation.getStack(stackName);
+        if (!stack) {
+            const stackTags = tagging.getTags(ownServiceContext);
+            const compiledTemplate = await getCompiledTemplate(stackName, ownServiceContext, ownPreDeployContext, stackTags);
+            winston.debug(`${SERVICE_NAME} - Creating CloudFormation stack '${stackName}'`);
+            const deployedStack = await awsCalls.cloudFormation.createStack(stackName,
+                compiledTemplate,
+                [],
+                30,
+                stackTags);
+            winston.debug(`${SERVICE_NAME} - Finished creating CloudFormation stack '${stackName}`);
+            winston.info(`${SERVICE_NAME} - Finished deploying database '${stackName}'`);
+            return getDeployContext(ownServiceContext, deployedStack);
+        }
+        else {
+            winston.info(`${SERVICE_NAME} - Updates are not supported for this service.`);
+            return getDeployContext(ownServiceContext, stack);
+        }
+    }
+
+    public async unPreDeploy(ownServiceContext: ServiceContext<NeptuneConfig>): Promise<UnPreDeployContext> {
+        return deletePhases.unPreDeploySecurityGroup(ownServiceContext, SERVICE_NAME);
+    }
+
+    public async unBind(ownServiceContext: ServiceContext<NeptuneConfig>): Promise<UnBindContext> {
+        return deletePhases.unBindSecurityGroups(ownServiceContext, SERVICE_NAME);
+    }
+
+    public async unDeploy(ownServiceContext: ServiceContext<NeptuneConfig>): Promise<UnDeployContext> {
+        return deletePhases.unDeployService(ownServiceContext, SERVICE_NAME);
     }
 }
-
-export function unPreDeploy(ownServiceContext: ServiceContext<NeptuneConfig>): Promise<UnPreDeployContext> {
-    return deletePhases.unPreDeploySecurityGroup(ownServiceContext, SERVICE_NAME);
-}
-
-export function unBind(ownServiceContext: ServiceContext<NeptuneConfig>): Promise<UnBindContext> {
-    return deletePhases.unBindSecurityGroups(ownServiceContext, SERVICE_NAME);
-}
-
-export async function unDeploy(ownServiceContext: ServiceContext<NeptuneConfig>): Promise<UnDeployContext> {
-    return deletePhases.unDeployService(ownServiceContext, SERVICE_NAME);
-}
-
-export const producedEventsSupportedTypes = [];
-
-export const producedDeployOutputTypes = [
-    DeployOutputType.EnvironmentVariables,
-    DeployOutputType.SecurityGroups
-];
-
-export const consumedDeployOutputTypes = [];
-
-export const supportsTagging = true;

--- a/handel/src/services/sns/index.ts
+++ b/handel/src/services/sns/index.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  *
  */
-import { DeployOutputType, ServiceEventConsumer, ServiceEventType } from 'handel-extension-api';
+import {
+    DeployOutputType,
+    ServiceDeployer,
+    ServiceEventConsumer,
+    ServiceEventType
+} from 'handel-extension-api';
 import {
     ConsumeEventsContext,
     DeployContext,
@@ -24,7 +29,14 @@ import {
     ServiceContext,
     UnDeployContext
 } from 'handel-extension-api';
-import { awsCalls, checkPhase, deletePhases, deployPhase, handlebars, tagging } from 'handel-extension-support';
+import {
+    awsCalls,
+    checkPhase,
+    deletePhases,
+    deployPhase,
+    handlebars,
+    tagging
+} from 'handel-extension-support';
 import * as winston from 'winston';
 import * as snsCalls from '../../aws/sns-calls';
 import {SnsServiceConfig} from './config-types';
@@ -101,102 +113,92 @@ function getPolicyStatementForEventConsumption(topicArn: string, trustedService:
     };
 }
 
-/**
- * Service Deployer Contract Methods
- * See https://github.com/byu-oit-appdev/handel/wiki/Creating-a-New-Service-Deployer#service-deployer-contract
- *   for contract method documentation
- */
+export class Service implements ServiceDeployer {
+    public readonly providedEventType = ServiceEventType.SNS;
+    public readonly producedEventsSupportedTypes = [
+        ServiceEventType.Lambda,
+        ServiceEventType.SQS
+    ];
+    public readonly producedDeployOutputTypes = [
+        DeployOutputType.EnvironmentVariables,
+        DeployOutputType.Policies
+    ];
+    public readonly consumedDeployOutputTypes = [];
+    public readonly supportsTagging = true;
 
-export function check(serviceContext: ServiceContext<SnsServiceConfig>, dependenciesServiceContexts: Array<ServiceContext<ServiceConfig>>): string[] {
-    const errors: string[] = checkPhase.checkJsonSchema(`${__dirname}/params-schema.json`, serviceContext);
-    return errors.map(error => `${SERVICE_NAME} - ${error}`);
+    private readonly consumedEventsSupportedServices = [
+        ServiceEventType.CloudWatchEvents,
+        ServiceEventType.S3
+    ];
+
+    public check(serviceContext: ServiceContext<SnsServiceConfig>, dependenciesServiceContexts: Array<ServiceContext<ServiceConfig>>): string[] {
+        const errors: string[] = checkPhase.checkJsonSchema(`${__dirname}/params-schema.json`, serviceContext);
+        return errors.map(error => `${SERVICE_NAME} - ${error}`);
+    }
+
+    public async deploy(ownServiceContext: ServiceContext<SnsServiceConfig>, ownPreDeployContext: PreDeployContext, dependenciesDeployContexts: DeployContext[]): Promise<DeployContext> {
+        const stackName = ownServiceContext.stackName();
+        winston.info(`${SERVICE_NAME} - Deploying topic '${stackName}'`);
+        const compiledSnsTemplate = await getCompiledSnsTemplate(stackName, ownServiceContext);
+        const stackTags = tagging.getTags(ownServiceContext);
+        const deployedStack = await deployPhase.deployCloudFormationStack(ownServiceContext, stackName, compiledSnsTemplate, [], true, 30, stackTags);
+        winston.info(`${SERVICE_NAME} - Finished deploying topic '${stackName}'`);
+        return getDeployContext(ownServiceContext, deployedStack);
+    }
+
+    public async produceEvents(ownServiceContext: ServiceContext<SnsServiceConfig>, ownDeployContext: DeployContext, eventConsumerConfig: ServiceEventConsumer, consumerServiceContext: ServiceContext<ServiceConfig>, consumerDeployContext: DeployContext): Promise<ProduceEventsContext> {
+        winston.info(`${SERVICE_NAME} - Producing events from '${ownServiceContext.serviceName}' for consumer '${consumerServiceContext.serviceName}'`);
+        if(!ownDeployContext.eventOutputs || !consumerDeployContext.eventOutputs) {
+            throw new Error(`${SERVICE_NAME} - Both the consumer and producer must return event outputs from their deploy`);
+        }
+        // Add subscription to sns service
+        const topicArn = ownDeployContext.eventOutputs.resourceArn;
+        const endpoint = consumerDeployContext.eventOutputs.resourceArn;
+        if(!topicArn || !endpoint) {
+            throw new Error(`${SERVICE_NAME} - Expected topic ARN and endpoint from event outputs`);
+        }
+        const consumerServiceType = consumerDeployContext.eventOutputs.serviceEventType;
+        let protocol;
+        if (consumerServiceType === ServiceEventType.Lambda) {
+            protocol = 'lambda';
+        }
+        else if (consumerServiceType === ServiceEventType.SQS) {
+            protocol = 'sqs';
+        }
+        else {
+            throw new Error(`${SERVICE_NAME} - Unsupported event consumer type given: ${consumerServiceType}`);
+        }
+        const subscriptionArn = await snsCalls.subscribeToTopic(topicArn, protocol, endpoint);
+        winston.info(`${SERVICE_NAME} - Configured production of events from '${ownServiceContext.serviceName}' for consumer '${consumerServiceContext.serviceName}'`);
+        return new ProduceEventsContext(ownServiceContext, consumerServiceContext);
+    }
+
+    public async consumeEvents(ownServiceContext: ServiceContext<SnsServiceConfig>, ownDeployContext: DeployContext, eventConsumerConfig: ServiceEventConsumer, producerServiceContext: ServiceContext<ServiceConfig>, producerDeployContext: DeployContext): Promise<ConsumeEventsContext> {
+        winston.info(`${SERVICE_NAME} - Consuming events from service '${producerServiceContext.serviceName}' for service '${ownServiceContext.serviceName}'`);
+        if(!ownDeployContext.eventOutputs || !producerDeployContext.eventOutputs) {
+            throw new Error(`${SERVICE_NAME} - Both the consumer and producer must return event outputs from their deploy`);
+        }
+
+        const topicArn = ownDeployContext.eventOutputs.resourceArn;
+        const producerArn = producerDeployContext.eventOutputs.resourceArn;
+        if(!topicArn || !producerArn) {
+            throw new Error(`${SERVICE_NAME} - Expected topic ARN and producer ARN from event outputs`);
+        }
+
+        const producerServiceType = producerDeployContext.eventOutputs.serviceEventType;
+        const principalService = producerDeployContext.eventOutputs.resourcePrincipal;
+        if(!this.consumedEventsSupportedServices.includes(producerServiceType)) {
+            throw new Error('${SERVICE_NAME} - Unsupported event producer type given: ${consumerEventType}');
+        }
+        const policyStatement = getPolicyStatementForEventConsumption(topicArn, principalService);
+
+        // Add SNS permission
+        const permissionStatement = await snsCalls.addSnsPermissionIfNotExists(topicArn, producerArn, policyStatement);
+        winston.info(`${SERVICE_NAME} - Allowed consuming events from '${producerServiceContext.serviceName}' for '${ownServiceContext.serviceName}'`);
+        return new ConsumeEventsContext(ownServiceContext, producerServiceContext);
+    }
+
+    public async unDeploy(ownServiceContext: ServiceContext<SnsServiceConfig>): Promise<UnDeployContext> {
+        return deletePhases.unDeployService(ownServiceContext, SERVICE_NAME);
+    }
 }
-
-export async function deploy(ownServiceContext: ServiceContext<SnsServiceConfig>, ownPreDeployContext: PreDeployContext, dependenciesDeployContexts: DeployContext[]): Promise<DeployContext> {
-    const stackName = ownServiceContext.stackName();
-    winston.info(`${SERVICE_NAME} - Deploying topic '${stackName}'`);
-
-    const compiledSnsTemplate = await getCompiledSnsTemplate(stackName, ownServiceContext);
-    const stackTags = tagging.getTags(ownServiceContext);
-    const deployedStack = await deployPhase.deployCloudFormationStack(ownServiceContext, stackName, compiledSnsTemplate, [], true, 30, stackTags);
-    winston.info(`${SERVICE_NAME} - Finished deploying topic '${stackName}'`);
-    return getDeployContext(ownServiceContext, deployedStack);
-}
-
-export async function produceEvents(ownServiceContext: ServiceContext<SnsServiceConfig>, ownDeployContext: DeployContext, eventConsumerConfig: ServiceEventConsumer, consumerServiceContext: ServiceContext<ServiceConfig>, consumerDeployContext: DeployContext): Promise<ProduceEventsContext> {
-    winston.info(`${SERVICE_NAME} - Producing events from '${ownServiceContext.serviceName}' for consumer '${consumerServiceContext.serviceName}'`);
-    if(!ownDeployContext.eventOutputs || !consumerDeployContext.eventOutputs) {
-        throw new Error(`${SERVICE_NAME} - Both the consumer and producer must return event outputs from their deploy`);
-    }
-    // Add subscription to sns service
-    const topicArn = ownDeployContext.eventOutputs.resourceArn;
-    const endpoint = consumerDeployContext.eventOutputs.resourceArn;
-    if(!topicArn || !endpoint) {
-        throw new Error(`${SERVICE_NAME} - Expected topic ARN and endpoint from event outputs`);
-    }
-    const consumerServiceType = consumerDeployContext.eventOutputs.serviceEventType;
-    let protocol;
-    if (consumerServiceType === ServiceEventType.Lambda) {
-        protocol = 'lambda';
-    }
-    else if (consumerServiceType === ServiceEventType.SQS) {
-        protocol = 'sqs';
-    }
-    else {
-        throw new Error(`${SERVICE_NAME} - Unsupported event consumer type given: ${consumerServiceType}`);
-    }
-
-    const subscriptionArn = await snsCalls.subscribeToTopic(topicArn, protocol, endpoint);
-    winston.info(`${SERVICE_NAME} - Configured production of events from '${ownServiceContext.serviceName}' for consumer '${consumerServiceContext.serviceName}'`);
-    return new ProduceEventsContext(ownServiceContext, consumerServiceContext);
-}
-
-export async function consumeEvents(ownServiceContext: ServiceContext<SnsServiceConfig>, ownDeployContext: DeployContext, eventConsumerConfig: ServiceEventConsumer, producerServiceContext: ServiceContext<ServiceConfig>, producerDeployContext: DeployContext): Promise<ConsumeEventsContext> {
-    winston.info(`${SERVICE_NAME} - Consuming events from service '${producerServiceContext.serviceName}' for service '${ownServiceContext.serviceName}'`);
-    if(!ownDeployContext.eventOutputs || !producerDeployContext.eventOutputs) {
-        throw new Error(`${SERVICE_NAME} - Both the consumer and producer must return event outputs from their deploy`);
-    }
-
-    const topicArn = ownDeployContext.eventOutputs.resourceArn;
-    const producerArn = producerDeployContext.eventOutputs.resourceArn;
-    if(!topicArn || !producerArn) {
-        throw new Error(`${SERVICE_NAME} - Expected topic ARN and producer ARN from event outputs`);
-    }
-
-    const producerServiceType = producerDeployContext.eventOutputs.serviceEventType;
-    const principalService = producerDeployContext.eventOutputs.resourcePrincipal;
-    if(!consumedEventsSupportedServices.includes(producerServiceType)) {
-        throw new Error('${SERVICE_NAME} - Unsupported event producer type given: ${consumerEventType}');
-    }
-    const policyStatement = getPolicyStatementForEventConsumption(topicArn, principalService);
-
-    // Add SNS permission
-    const permissionStatement = await snsCalls.addSnsPermissionIfNotExists(topicArn, producerArn, policyStatement);
-    winston.info(`${SERVICE_NAME} - Allowed consuming events from '${producerServiceContext.serviceName}' for '${ownServiceContext.serviceName}'`);
-    return new ConsumeEventsContext(ownServiceContext, producerServiceContext);
-}
-
-export async function unDeploy(ownServiceContext: ServiceContext<SnsServiceConfig>): Promise<UnDeployContext> {
-    return deletePhases.unDeployService(ownServiceContext, SERVICE_NAME);
-}
-
-export const providedEventType = ServiceEventType.SNS;
-
-export const producedEventsSupportedTypes = [
-    ServiceEventType.Lambda,
-    ServiceEventType.SQS
-];
-
-export const consumedEventsSupportedServices = [
-    ServiceEventType.CloudWatchEvents,
-    ServiceEventType.S3
-];
-
-export const producedDeployOutputTypes = [
-    DeployOutputType.EnvironmentVariables,
-    DeployOutputType.Policies
-];
-
-export const consumedDeployOutputTypes = [];
-
-export const supportsTagging = true;

--- a/handel/src/services/stdlib.ts
+++ b/handel/src/services/stdlib.ts
@@ -33,7 +33,8 @@ export async function loadStandardLib(): Promise<LoadedExtension> {
 export class StandardLibExtension implements Extension {
     public async loadHandelExtension(context: ExtensionContext) {
         for (const service of await listDefaultServices()) {
-            context.service(service.name, await import(service.path));
+            const module = await import(service.path);
+            context.service(service.name, new module.Service());
         }
     }
 }

--- a/handel/test/services/aiservices/aiservices-test.ts
+++ b/handel/test/services/aiservices/aiservices-test.ts
@@ -15,11 +15,18 @@
  *
  */
 import { expect } from 'chai';
-import {  AccountConfig, DeployContext, PreDeployContext, ServiceContext, ServiceType } from 'handel-extension-api';
+import {
+    AccountConfig,
+    DeployContext,
+    PreDeployContext,
+    ServiceContext,
+    ServiceDeployer,
+    ServiceType
+} from 'handel-extension-api';
 import 'mocha';
 import * as sinon from 'sinon';
 import config from '../../../src/account-config/account-config';
-import * as aiservices from '../../../src/services/aiservices';
+import { Service } from '../../../src/services/aiservices';
 import { AIServicesConfig } from '../../../src/services/aiservices/config-types';
 import { STDLIB_PREFIX } from '../../../src/services/stdlib';
 
@@ -28,8 +35,10 @@ describe('aiservices deployer', () => {
     let serviceContext: ServiceContext<AIServicesConfig>;
     let serviceParams: AIServicesConfig;
     let accountConfig: AccountConfig;
+    let aiservices: ServiceDeployer;
 
     beforeEach(async () => {
+        aiservices = new Service();
         accountConfig = await config(`${__dirname}/../../test-account-config.yml`);
         sandbox = sinon.sandbox.create();
         serviceParams = {
@@ -48,7 +57,7 @@ describe('aiservices deployer', () => {
     describe('check', () => {
         it('should not allow invaid or unsupported ai services', () => {
             serviceParams.ai_services[0] = 'fake';
-            const errors = aiservices.check(serviceContext, []);
+            const errors = aiservices.check!(serviceContext, []);
             expect(errors.length).to.equal(1);
             expect(errors[0]).to.include(`The 'ai_services' field must be a list of strings, containing 'rekognition' or 'polly'`);
         });
@@ -57,7 +66,7 @@ describe('aiservices deployer', () => {
     describe('deploy', () => {
         it('should return a deploy context with the given policies', async () => {
             const preDeployContext = new PreDeployContext(serviceContext);
-            const deployContext = await aiservices.deploy(serviceContext, preDeployContext, []);
+            const deployContext = await aiservices.deploy!(serviceContext, preDeployContext, []);
             expect(deployContext).to.be.instanceof(DeployContext);
             expect(deployContext.policies.length).to.equal(2);
         });

--- a/handel/test/services/alexaskillkit/alexaskillkit-test.ts
+++ b/handel/test/services/alexaskillkit/alexaskillkit-test.ts
@@ -22,20 +22,23 @@ import {
     ProduceEventsContext,
     ServiceConfig,
     ServiceContext,
+    ServiceDeployer,
     ServiceType
 } from 'handel-extension-api';
 import 'mocha';
 import * as sinon from 'sinon';
 import config from '../../../src/account-config/account-config';
-import * as alexaSkillKit from '../../../src/services/alexaskillkit';
+import { Service } from '../../../src/services/alexaskillkit';
 import { STDLIB_PREFIX } from '../../../src/services/stdlib';
 
 describe('alexaskillkit deployer', () => {
     let sandbox: sinon.SinonSandbox;
     let serviceContext: ServiceContext<ServiceConfig>;
     let accountConfig: AccountConfig;
+    let alexaSkillKit: ServiceDeployer;
 
     beforeEach(async () => {
+        alexaSkillKit = new Service();
         accountConfig = await config(`${__dirname}/../../test-account-config.yml`);
         sandbox = sinon.sandbox.create();
         serviceContext = new ServiceContext('Fakepp', 'FakeEnv', 'FakeService', new ServiceType(STDLIB_PREFIX, 'alexaskillkit'), {type: 'alexaskillkit'}, accountConfig);
@@ -47,7 +50,7 @@ describe('alexaskillkit deployer', () => {
 
     describe('check', () => {
         it('should return no errors', () => {
-            const errors = alexaSkillKit.check(serviceContext, []);
+            const errors = alexaSkillKit.check!(serviceContext, []);
             expect(errors.length).to.equal(0);
         });
     });
@@ -55,7 +58,7 @@ describe('alexaskillkit deployer', () => {
     describe('deploy', () => {
         it('should return an empty deploy context', async () => {
             const ownPreDeployContext = new PreDeployContext(serviceContext);
-            const deployContext = await alexaSkillKit.deploy(serviceContext, ownPreDeployContext, []);
+            const deployContext = await alexaSkillKit.deploy!(serviceContext, ownPreDeployContext, []);
             expect(deployContext).to.be.instanceof(DeployContext);
         });
     });
@@ -68,7 +71,7 @@ describe('alexaskillkit deployer', () => {
             const eventConfigConsumer = {
                 service_name: 'FakeService2'
             };
-            const produceEventsContext = await alexaSkillKit.produceEvents(serviceContext, ownDeployContext, eventConfigConsumer, consumerServiceContext, consumerDeployContext);
+            const produceEventsContext = await alexaSkillKit.produceEvents!(serviceContext, ownDeployContext, eventConfigConsumer, consumerServiceContext, consumerDeployContext);
             expect(produceEventsContext).to.be.instanceof(ProduceEventsContext);
         });
     });

--- a/handel/test/services/apiaccess/apiaccess-test.ts
+++ b/handel/test/services/apiaccess/apiaccess-test.ts
@@ -15,11 +15,18 @@
  *
  */
 import { expect } from 'chai';
-import {  AccountConfig, DeployContext, PreDeployContext, ServiceContext, ServiceType } from 'handel-extension-api';
+import {
+    AccountConfig,
+    DeployContext,
+    PreDeployContext,
+    ServiceContext,
+    ServiceDeployer,
+    ServiceType
+} from 'handel-extension-api';
 import 'mocha';
 import * as sinon from 'sinon';
 import config from '../../../src/account-config/account-config';
-import * as apiaccess from '../../../src/services/apiaccess';
+import { Service } from '../../../src/services/apiaccess';
 import { APIAccessConfig } from '../../../src/services/apiaccess/config-types';
 import { STDLIB_PREFIX } from '../../../src/services/stdlib';
 
@@ -28,8 +35,10 @@ describe('apiaccess deployer', () => {
     let serviceContext: ServiceContext<APIAccessConfig>;
     let serviceParams: APIAccessConfig;
     let accountConfig: AccountConfig;
+    let apiaccess: ServiceDeployer;
 
     beforeEach(async () => {
+        apiaccess = new Service();
         accountConfig = await config(`${__dirname}/../../test-account-config.yml`);
         sandbox = sinon.sandbox.create();
         serviceParams = {
@@ -52,7 +61,7 @@ describe('apiaccess deployer', () => {
         it('should return a deploy context with the given policies', async () => {
             const preDeployContext = new PreDeployContext(serviceContext);
 
-            const deployContext = await apiaccess.deploy(serviceContext, preDeployContext, []);
+            const deployContext = await apiaccess.deploy!(serviceContext, preDeployContext, []);
             expect(deployContext).to.be.instanceof(DeployContext);
             expect(deployContext.policies.length).to.equal(2);
         });

--- a/handel/test/services/ses/ses-test.ts
+++ b/handel/test/services/ses/ses-test.ts
@@ -20,13 +20,14 @@ import {
     DeployContext,
     PreDeployContext,
     ServiceContext,
+    ServiceDeployer,
     ServiceType
 } from 'handel-extension-api';
 import 'mocha';
 import * as sinon from 'sinon';
 import config from '../../../src/account-config/account-config';
 import * as sesCalls from '../../../src/aws/ses-calls';
-import * as ses from '../../../src/services/ses';
+import { Service } from '../../../src/services/ses';
 import { SesServiceConfig } from '../../../src/services/ses/config-types';
 import { STDLIB_PREFIX } from '../../../src/services/stdlib';
 
@@ -38,8 +39,10 @@ describe('ses deployer', () => {
     const app = `FakeApp`;
     const env = `FakeEnv`;
     const service = 'FakeService';
+    let ses: ServiceDeployer;
 
     beforeEach(async () => {
+        ses = new Service();
         accountConfig = await config(`${__dirname}/../../test-account-config.yml`);
         serviceParams = {
             type: 'ses',
@@ -56,18 +59,18 @@ describe('ses deployer', () => {
     describe('check', () => {
         it(`should require an address`, () => {
             delete serviceContext.params.address;
-            const errors = ses.check(serviceContext, []);
+            const errors = ses.check!(serviceContext, []);
             expect(errors.length).to.equal(1);
             expect(errors[0]).to.include(`field is required`);
         });
         it(`should require a valid email address`, () => {
             serviceContext.params.address = 'example.com';
-            const errors = ses.check(serviceContext, []);
+            const errors = ses.check!(serviceContext, []);
             expect(errors.length).to.equal(1);
             expect(errors[0]).to.include(`valid email address`);
         });
         it(`should pass with a valid address`, () => {
-            const errors = ses.check(serviceContext, []);
+            const errors = ses.check!(serviceContext, []);
             expect(errors).to.deep.equal([]);
         });
     });
@@ -80,7 +83,7 @@ describe('ses deployer', () => {
 
             const verifyStub = sandbox.stub(sesCalls, 'verifyEmailAddress').returns(Promise.resolve());
 
-            const deployContext = await ses.deploy(serviceContext, ownPreDeployContext, []);
+            const deployContext = await ses.deploy!(serviceContext, ownPreDeployContext, []);
             expect(verifyStub.callCount).to.equal(1);
             expect(deployContext).to.be.instanceof(DeployContext);
 

--- a/handel/test/services/sns/sns-test.ts
+++ b/handel/test/services/sns/sns-test.ts
@@ -22,6 +22,7 @@ import {
     PreDeployContext,
     ProduceEventsContext,
     ServiceContext,
+    ServiceDeployer,
     ServiceEventConsumer,
     ServiceEventType,
     ServiceType,
@@ -32,7 +33,7 @@ import 'mocha';
 import * as sinon from 'sinon';
 import config from '../../../src/account-config/account-config';
 import * as snsCalls from '../../../src/aws/sns-calls';
-import * as sns from '../../../src/services/sns';
+import { Service } from '../../../src/services/sns';
 import { SnsServiceConfig } from '../../../src/services/sns/config-types';
 import { STDLIB_PREFIX } from '../../../src/services/stdlib';
 
@@ -45,8 +46,10 @@ describe('sns deployer', () => {
     const envName = 'FakeEnv';
     const serviceName = 'FakeService';
     const serviceType = 'sns';
+    let sns: ServiceDeployer;
 
     beforeEach(async () => {
+        sns = new Service();
         accountConfig = await config(`${__dirname}/../../test-account-config.yml`);
         serviceParams = {
             type: serviceType,
@@ -84,7 +87,7 @@ describe('sns deployer', () => {
                 ]
             }));
 
-            const deployContext = await sns.deploy(serviceContext, ownPreDeployContext, []);
+            const deployContext = await sns.deploy!(serviceContext, ownPreDeployContext, []);
             expect(deployStackStub.callCount).to.equal(1);
             expect(deployContext).to.be.instanceof(DeployContext);
 
@@ -123,7 +126,7 @@ describe('sns deployer', () => {
 
             const subscribeToTopicStub = sandbox.stub(snsCalls, 'subscribeToTopic').resolves({});
 
-            const produceEventsContext = await sns.produceEvents(serviceContext, ownDeployContext, eventConsumerConfig, consumerServiceContext, consumerDeployContext);
+            const produceEventsContext = await sns.produceEvents!(serviceContext, ownDeployContext, eventConsumerConfig, consumerServiceContext, consumerDeployContext);
             expect(produceEventsContext).to.be.instanceof(ProduceEventsContext);
             expect(subscribeToTopicStub.callCount).to.equal(1);
         });
@@ -147,7 +150,7 @@ describe('sns deployer', () => {
             const subscribeToTopicStub = sandbox.stub(snsCalls, 'subscribeToTopic').resolves({});
 
             try {
-                const produceEventsContext = await sns.produceEvents(serviceContext, ownDeployContext, eventConsumerConfig, consumerServiceContext, consumerDeployContext);
+                const produceEventsContext = await sns.produceEvents!(serviceContext, ownDeployContext, eventConsumerConfig, consumerServiceContext, consumerDeployContext);
                 expect(produceEventsContext).to.be.instanceof(ProduceEventsContext);
                 expect(true).to.equal(false);
             }
@@ -181,7 +184,7 @@ describe('sns deployer', () => {
             const addSnsPermissionStub = sandbox.stub(snsCalls, 'addSnsPermissionIfNotExists').resolves({});
 
             const eventConsumerConfig = { service_name: serviceName };
-            const consumeEventsContext = await sns.consumeEvents(serviceContext, deployContext, eventConsumerConfig, producerServiceContext, producerDeployContext);
+            const consumeEventsContext = await sns.consumeEvents!(serviceContext, deployContext, eventConsumerConfig, producerServiceContext, producerDeployContext);
             expect(addSnsPermissionStub.callCount).to.equal(1);
             expect(consumeEventsContext).to.be.instanceOf(ConsumeEventsContext);
         });
@@ -198,7 +201,7 @@ describe('sns deployer', () => {
             const addSnsPermissionStub = sandbox.stub(snsCalls, 'addSnsPermissionIfNotExists').resolves({});
 
             const eventConsumerConfig = { service_name: serviceName };
-            const consumeEventsContext = await sns.consumeEvents(serviceContext, deployContext, eventConsumerConfig, producerServiceContext, producerDeployContext);
+            const consumeEventsContext = await sns.consumeEvents!(serviceContext, deployContext, eventConsumerConfig, producerServiceContext, producerDeployContext);
             expect(addSnsPermissionStub.callCount).to.equal(1);
             expect(consumeEventsContext).to.be.instanceOf(ConsumeEventsContext);
         });
@@ -208,7 +211,7 @@ describe('sns deployer', () => {
         it('should undeploy the stack', async () => {
             const unDeployStackStub = sandbox.stub(deletePhases, 'unDeployService').resolves(new UnDeployContext(serviceContext));
 
-            const unDeployContext = await sns.unDeploy(serviceContext);
+            const unDeployContext = await sns.unDeploy!(serviceContext);
             expect(unDeployContext).to.be.instanceof(UnDeployContext);
             expect(unDeployStackStub.callCount).to.equal(1);
         });

--- a/handel/test/services/sqs/sqs-test.ts
+++ b/handel/test/services/sqs/sqs-test.ts
@@ -21,6 +21,7 @@ import {
     DeployContext,
     PreDeployContext,
     ServiceContext,
+    ServiceDeployer,
     ServiceEventType,
     ServiceType,
     UnDeployContext
@@ -30,7 +31,7 @@ import 'mocha';
 import * as sinon from 'sinon';
 import config from '../../../src/account-config/account-config';
 import * as sqsCalls from '../../../src/aws/sqs-calls';
-import * as sqs from '../../../src/services/sqs';
+import { Service } from '../../../src/services/sqs';
 import { SqsServiceConfig } from '../../../src/services/sqs/config-types';
 import { STDLIB_PREFIX } from '../../../src/services/stdlib';
 
@@ -43,8 +44,10 @@ describe('sqs deployer', () => {
     const envName = 'FakeEnv';
     const serviceName = 'FakeService'; // FIXME: deadLetter versions?
     const serviceType = 'sqs';
+    let sqs: ServiceDeployer;
 
     beforeEach(async () => {
+        sqs = new Service();
         accountConfig = await config(`${__dirname}/../../test-account-config.yml`);
         serviceParams = {
             type: 'sqs',
@@ -110,7 +113,7 @@ describe('sqs deployer', () => {
                 ]
             });
 
-            const deployContext = await sqs.deploy(serviceContext, ownPreDeployContext, []);
+            const deployContext = await sqs.deploy!(serviceContext, ownPreDeployContext, []);
             expect(deployStackStub.callCount).to.equal(1);
 
             expect(deployContext).to.be.instanceof(DeployContext);
@@ -158,7 +161,7 @@ describe('sqs deployer', () => {
             const addSqsPermissionStub = sandbox.stub(sqsCalls, 'addSqsPermissionIfNotExists').resolves({});
 
             const eventConsumerConfig = { service_name: serviceName };
-            const consumeEventsContext = await sqs.consumeEvents(serviceContext, deployContext, eventConsumerConfig, producerServiceContext, producerDeployContext);
+            const consumeEventsContext = await sqs.consumeEvents!(serviceContext, deployContext, eventConsumerConfig, producerServiceContext, producerDeployContext);
             expect(addSqsPermissionStub.callCount).to.equal(1);
             expect(consumeEventsContext).to.be.instanceOf(ConsumeEventsContext);
         });
@@ -175,7 +178,7 @@ describe('sqs deployer', () => {
             const addSqsPermissionStub = sandbox.stub(sqsCalls, 'addSqsPermissionIfNotExists').resolves({});
 
             const eventConsumerConfig = { service_name: serviceName };
-            const consumeEventsContext = await sqs.consumeEvents(serviceContext, deployContext, eventConsumerConfig, producerServiceContext, producerDeployContext);
+            const consumeEventsContext = await sqs.consumeEvents!(serviceContext, deployContext, eventConsumerConfig, producerServiceContext, producerDeployContext);
             expect(addSqsPermissionStub.callCount).to.equal(1);
             expect(consumeEventsContext).to.be.instanceOf(ConsumeEventsContext);
         });
@@ -185,7 +188,7 @@ describe('sqs deployer', () => {
         it('should undeploy the stack', async () => {
             const unDeployStackStub = sandbox.stub(deletePhases, 'unDeployService').resolves(new UnDeployContext(serviceContext));
 
-            const unDeployContext = await sqs.unDeploy(serviceContext);
+            const unDeployContext = await sqs.unDeploy!(serviceContext);
             expect(unDeployContext).to.be.instanceof(UnDeployContext);
             expect(unDeployStackStub.callCount).to.equal(1);
         });


### PR DESCRIPTION
This pull request changes the service deployers to use classes and implement the ServiceDeploy interface. This gives us type checks on the deployer objects to make sure we're implementing the contract correctly.