### PR TITLE
Add getPreDeployContext deployer method

### DIFF
--- a/docs/extensions/writing-extensions.rst
+++ b/docs/extensions/writing-extensions.rst
@@ -172,9 +172,18 @@ The following TypeScript interface defines the contract for a service deployer:
         *
         * Implement this phase if you'll be creating security groups for any of your resources
         *
-        * Example AWS services that woulod need to implement this phase include Beanstalk and RDS
+        * Example AWS services that would need to implement this phase include Beanstalk and RDS.
+        *
+        * NOTE: If you implement preDeploy, you must implement getPreDeployContext as well
         */
         preDeploy?(serviceContext: ServiceContext<ServiceConfig>): Promise<PreDeployContext>;
+
+        /**
+        * Get the PreDeploy context information without running preDeploy
+        *
+        * Return null if preDeploy has not been executed yet
+        */
+        getPreDeployContext?(serviceContext: ServiceContext<ServiceConfig>): Promise<IPreDeployContext | null>;
 
         /**
         * Bind two resources from the preDeploy phase together by performing some wiring action on them. An example

--- a/extension-api/extension-api.ts
+++ b/extension-api/extension-api.ts
@@ -92,17 +92,8 @@ export interface ServiceDeployer {
      * created for your service.
      *
      * All this service's dependencies are guaranteed to be deployed before this phase gets called
-     *
-     * NOTE: If you implement deploy, you must implement getDeployContext as well
      */
     deploy?(ownServiceContext: ServiceContext<ServiceConfig>, ownPreDeployContext: IPreDeployContext, dependenciesDeployContexts: IDeployContext[]): Promise<IDeployContext>;
-
-    /**
-     * Get the DeployContext information without running deploy
-     *
-     * Return null if deploy has not been executed yet
-     */
-    getDeployContext?(ownServiceContext: ServiceContext<ServiceConfig>, ownPreDeployContext: IPreDeployContext, dependenciesDeployContexts: IDeployContext[]): Promise<IDeployContext>;
 
     /**
      * In this phase, this service should make any changes necessary to allow it to consume events from the given source

--- a/extension-api/extension-api.ts
+++ b/extension-api/extension-api.ts
@@ -41,7 +41,7 @@ export interface ServiceDeployer {
     supportsTagging: boolean; // If true, indicates that a deployer supports tagging its resources. This is used to enforce tagging rules.
 
     // ------------------------------------------------
-    // Phase types that hte provisioner supports
+    // Phase types that the provisioner supports
     // ------------------------------------------------
     /**
      * Checks the given service configuration in the user's Handel file for required parameters and correctness.
@@ -58,8 +58,17 @@ export interface ServiceDeployer {
      * Implement this phase if you'll be creating security groups for any of your resources
      *
      * Example AWS services that woulod need to implement this phase include Beanstalk and RDS
+     *
+     * NOTE: If you implement preDeploy, you must implement getPreDeployContext as well
      */
     preDeploy?(serviceContext: ServiceContext<ServiceConfig>): Promise<PreDeployContext>;
+
+    /**
+     * Get the PreDeploy context information without running preDeploy
+     *
+     * Return null if preDeploy has not been executed yet
+     */
+    getPreDeployContext?(serviceContext: ServiceContext<ServiceConfig>): Promise<IPreDeployContext>;
 
     /**
      * Bind two resources from the preDeploy phase together by performing some wiring action on them. An example
@@ -83,8 +92,17 @@ export interface ServiceDeployer {
      * created for your service.
      *
      * All this service's dependencies are guaranteed to be deployed before this phase gets called
+     *
+     * NOTE: If you implement deploy, you must implement getDeployContext as well
      */
     deploy?(ownServiceContext: ServiceContext<ServiceConfig>, ownPreDeployContext: IPreDeployContext, dependenciesDeployContexts: IDeployContext[]): Promise<IDeployContext>;
+
+    /**
+     * Get the DeployContext information without running deploy
+     *
+     * Return null if deploy has not been executed yet
+     */
+    getDeployContext?(ownServiceContext: ServiceContext<ServiceConfig>, ownPreDeployContext: IPreDeployContext, dependenciesDeployContexts: IDeployContext[]): Promise<IDeployContext>;
 
     /**
      * In this phase, this service should make any changes necessary to allow it to consume events from the given source
@@ -114,7 +132,7 @@ export interface ServiceDeployer {
     /**
      * In this phase, the service should remove all bindings on preDeploy resources.
      */
-    unBind?(ownServiceContext: ServiceContext<ServiceConfig>): Promise<IUnBindContext>;
+    unBind?(ownServiceContext: ServiceContext<ServiceConfig>, ownPreDeployContext: IPreDeployContext, dependentOfServiceContext: ServiceContext<ServiceConfig>, dependentOfPreDeployContext: IPreDeployContext): Promise<IUnBindContext>;
 
     /**
      * In this phase, the service should delete resources created during the deploy phase.

--- a/extension-support/test/common/pre-deploy-phase-test.ts
+++ b/extension-support/test/common/pre-deploy-phase-test.ts
@@ -84,4 +84,32 @@ describe('PreDeploy Phase Common module', () => {
             expect(getSecurityGroupByIdStub.callCount).to.equal(1);
         });
     });
+
+    describe('getSecurityGroup', () => {
+        it('should return the security group in the PreDeployContext when it exists', async () => {
+            const getStackStub = sandbox.stub(cloudformationCalls, 'getStack').resolves({
+                Outputs: [{
+                    OutputKey: 'GroupId',
+                    OutputValue: 'SomeId'
+                }]
+            });
+            const getSecurityGroupByIdStub = sandbox.stub(ec2Calls, 'getSecurityGroupById').resolves({});
+
+            const preDeployContext = await preDeployPhase.getSecurityGroup(serviceContext);
+            expect(preDeployContext).to.be.instanceOf(PreDeployContext);
+            expect(preDeployContext.securityGroups.length).to.equal(1);
+            expect(preDeployContext.securityGroups[0]).to.deep.equal({});
+            expect(getStackStub.callCount).to.equal(1);
+            expect(getSecurityGroupByIdStub.callCount).to.equal(1);
+        });
+
+        it('should return an emtpy PreDeployContext when the security group doesnt exist', async () => {
+            const getStackStub = sandbox.stub(cloudformationCalls, 'getStack').resolves(null);
+
+            const preDeployContext = await preDeployPhase.getSecurityGroup(serviceContext);
+            expect(preDeployContext).to.be.instanceOf(PreDeployContext);
+            expect(preDeployContext.securityGroups.length).to.equal(0);
+            expect(getStackStub.callCount).to.equal(1);
+        });
+    });
 });

--- a/handel/src/phases/pre-deploy.ts
+++ b/handel/src/phases/pre-deploy.ts
@@ -52,3 +52,40 @@ export async function preDeployServices(serviceRegistry: ServiceRegistry, enviro
     await Promise.all(preDeployPromises);
     return preDeployContexts; // This was built up dynamically above
 }
+
+export async function getPreDeployContexts(serviceRegistry: ServiceRegistry, environmentContext: EnvironmentContext): Promise<PreDeployContexts> {
+    const preDeployPromises: Array<Promise<void>> = [];
+    const preDeployContexts: PreDeployContexts = {};
+
+    for (const serviceName in environmentContext.serviceContexts) {
+        if (environmentContext.serviceContexts.hasOwnProperty(serviceName)) {
+            const serviceContext = environmentContext.serviceContexts[serviceName];
+            winston.info(`Executing getPreDeployContexts on service ${serviceContext.serviceName}`);
+            const serviceDeployer = serviceRegistry.getService(serviceContext.serviceType);
+            if (serviceDeployer.preDeploy) {
+                if(!serviceDeployer.getPreDeployContext) {
+                    throw new DontBlameHandelError(`Expected getPreDeployContext to be implemented by service deployer`, serviceContext.serviceType);
+                }
+
+                const preDeployPromise = serviceDeployer.getPreDeployContext(serviceContext)
+                    .then(preDeployContext => {
+                        if (!isPreDeployContext(preDeployContext)) {
+                            throw new DontBlameHandelError('Expected PreDeployContext as result from \'preDeploy\' phase', serviceContext.serviceType);
+                        }
+                        preDeployContexts[serviceContext.serviceName] = preDeployContext;
+                    });
+                preDeployPromises.push(preDeployPromise);
+            }
+            else { // If deployer doesn't implement preDeploy, then just return an empty PreDeployContext
+                const preDeployPromise = lifecyclesCommon.preDeployNotRequired(serviceContext)
+                    .then(preDeployContext => {
+                        preDeployContexts[serviceContext.serviceName] = preDeployContext;
+                    });
+                preDeployPromises.push(preDeployPromise);
+            }
+        }
+    }
+
+    await Promise.all(preDeployPromises);
+    return preDeployContexts; // This was built up dynamically above
+}

--- a/handel/src/phases/un-bind.ts
+++ b/handel/src/phases/un-bind.ts
@@ -17,35 +17,62 @@
 import { isUnBindContext, ServiceRegistry } from 'handel-extension-api';
 import * as winston from 'winston';
 import * as lifecyclesCommon from '../common/lifecycles-common';
-import { DeployOrder, DontBlameHandelError, EnvironmentContext, UnBindContexts } from '../datatypes';
+import { DeployOrder, DontBlameHandelError, EnvironmentContext, PreDeployContexts, UnBindContexts } from '../datatypes';
 
-export async function unBindServicesInLevel(serviceRegistry: ServiceRegistry, environmentContext: EnvironmentContext, deployOrder: DeployOrder, level: number): Promise<UnBindContexts> {
+function getDependentServicesForCurrentUnBindService(environmentContext: EnvironmentContext, toBindServiceName: string): string[] {
+    const dependentServices = [];
+    for (const currentServiceName in environmentContext.serviceContexts) {
+        if (environmentContext.serviceContexts.hasOwnProperty(currentServiceName)) {
+            const currentService = environmentContext.serviceContexts[currentServiceName];
+            const currentServiceDeps = currentService.params.dependencies;
+            if (currentServiceDeps && currentServiceDeps.includes(toBindServiceName)) {
+                dependentServices.push(currentServiceName);
+            }
+        }
+    }
+    return dependentServices;
+}
+
+function getUnBindContextName(unBindServiceName: string, dependentServiceName: string): string {
+    return `${dependentServiceName}->${unBindServiceName}`;
+}
+
+export async function unBindServicesInLevel(serviceRegistry: ServiceRegistry, environmentContext: EnvironmentContext, preDeployContexts: PreDeployContexts, deployOrder: DeployOrder, level: number): Promise<UnBindContexts> {
     const unBindPromises: Array<Promise<void>> = [];
     const unBindContexts: UnBindContexts = {};
 
     const currentLevelServicesToUnBind = deployOrder[level];
     winston.info(`Executing UnBind phase in level ${level} in environment '${environmentContext.environmentName}' for services ${currentLevelServicesToUnBind.join(', ')}`);
-    for(const toUnBindServiceName of currentLevelServicesToUnBind) {
+    for (const toUnBindServiceName of currentLevelServicesToUnBind) {
         const toUnBindServiceContext = environmentContext.serviceContexts[toUnBindServiceName];
+        const toUnBindPreDeployContext = preDeployContexts[toUnBindServiceName];
         const serviceDeployer = serviceRegistry.getService(toUnBindServiceContext.serviceType);
 
-        if (serviceDeployer.unBind) {
-            winston.info(`UnBinding service ${toUnBindServiceName}`);
-            const unBindPromise = serviceDeployer.unBind(toUnBindServiceContext)
-                .then(unBindContext => {
-                    if (!isUnBindContext(unBindContext)) {
-                        throw new DontBlameHandelError(`Expected UnBindContext back from 'unBind' phase of service deployer`, toUnBindServiceContext.serviceType);
-                    }
-                    unBindContexts[toUnBindServiceName] = unBindContext;
-                });
-            unBindPromises.push(unBindPromise);
-        }
-        else { // If unbind not implemented by deployer, return an empty unbind context
-            const unBindPromise = lifecyclesCommon.unBindNotRequired(toUnBindServiceContext)
-                .then(unBindContext => {
-                    unBindContexts[toUnBindServiceName] = unBindContext;
-                });
-            unBindPromises.push(unBindPromise);
+        for (const dependentOfServiceName of getDependentServicesForCurrentUnBindService(environmentContext, toUnBindServiceName)) {
+            // Get ServiceContext for the dependent service
+            const dependentOfServiceContext = environmentContext.serviceContexts[dependentOfServiceName];
+            const dependentOfPreDeployContext = preDeployContexts[dependentOfServiceName];
+
+            // Run unBind on the service combination (if implemented by the dependency service)
+            const unBindContextName = getUnBindContextName(toUnBindServiceName, dependentOfServiceName);
+            if (serviceDeployer.unBind) {
+                winston.info(`UnBinding service ${toUnBindServiceName}`);
+                const unBindPromise = serviceDeployer.unBind(toUnBindServiceContext, toUnBindPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext)
+                    .then(unBindContext => {
+                        if (!isUnBindContext(unBindContext)) {
+                            throw new DontBlameHandelError(`Expected UnBindContext back from 'unBind' phase of service deployer`, toUnBindServiceContext.serviceType);
+                        }
+                        unBindContexts[unBindContextName] = unBindContext;
+                    });
+                unBindPromises.push(unBindPromise);
+            }
+            else { // If unbind not implemented by deployer, return an empty unbind context
+                const unBindPromise = lifecyclesCommon.unBindNotRequired(toUnBindServiceContext)
+                    .then(unBindContext => {
+                        unBindContexts[unBindContextName] = unBindContext;
+                    });
+                unBindPromises.push(unBindPromise);
+            }
         }
     }
 

--- a/handel/src/services/apigateway/index.ts
+++ b/handel/src/services/apigateway/index.ts
@@ -117,6 +117,14 @@ export class Service implements ServiceDeployer {
         }
     }
 
+    public async getPreDeployContext(serviceContext: ServiceContext<APIGatewayConfig>): Promise<PreDeployContext> {
+        if(serviceContext.params.vpc) {
+            return preDeployPhase.getSecurityGroup(serviceContext);
+        } else {
+            return lifecyclesCommon.preDeployNotRequired(serviceContext);
+        }
+    }
+
     public async deploy(ownServiceContext: ServiceContext<APIGatewayConfig>, ownPreDeployContext: PreDeployContext, dependenciesDeployContexts: DeployContext[]): Promise<DeployContext> {
         const stackName = ownServiceContext.stackName();
         winston.info(`${SERVICE_NAME} - Deploying API Gateway service '${stackName}'`);

--- a/handel/src/services/aurora/index.ts
+++ b/handel/src/services/aurora/index.ts
@@ -180,6 +180,10 @@ export class Service implements ServiceDeployer {
         return preDeployPhase.preDeployCreateSecurityGroup(serviceContext, dbPort, SERVICE_NAME);
     }
 
+    public async getPreDeployContext(serviceContext: ServiceContext<AuroraConfig>): Promise<PreDeployContext> {
+        return preDeployPhase.getSecurityGroup(serviceContext);
+    }
+
     public async bind(ownServiceContext: ServiceContext<AuroraConfig>, ownPreDeployContext: PreDeployContext, dependentOfServiceContext: ServiceContext<ServiceConfig>, dependentOfPreDeployContext: PreDeployContext): Promise<BindContext> {
         const dbPort = getPort(ownServiceContext.params);
         return bindPhase.bindDependentSecurityGroup(ownServiceContext,
@@ -234,7 +238,7 @@ export class Service implements ServiceDeployer {
         return deletePhases.unPreDeploySecurityGroup(ownServiceContext, SERVICE_NAME);
     }
 
-    public async unBind(ownServiceContext: ServiceContext<AuroraConfig>): Promise<UnBindContext> {
+    public async unBind(ownServiceContext: ServiceContext<AuroraConfig>, ownPreDeployContext: PreDeployContext, dependentOfServiceContext: ServiceContext<ServiceConfig>, dependentOfPreDeployContext: PreDeployContext): Promise<UnBindContext> {
         return deletePhases.unBindSecurityGroups(ownServiceContext, SERVICE_NAME);
     }
 

--- a/handel/src/services/beanstalk/index.ts
+++ b/handel/src/services/beanstalk/index.ts
@@ -281,6 +281,10 @@ export class Service implements ServiceDeployer {
         return preDeployPhase.preDeployCreateSecurityGroup(serviceContext, 22, SERVICE_NAME);
     }
 
+    public async getPreDeployContext(serviceContext: ServiceContext<BeanstalkServiceConfig>): Promise<PreDeployContext> {
+        return preDeployPhase.getSecurityGroup(serviceContext);
+    }
+
     public async deploy(ownServiceContext: ServiceContext<BeanstalkServiceConfig>, ownPreDeployContext: PreDeployContext, dependenciesDeployContexts: DeployContext[]): Promise<DeployContext> {
         const stackName = ownServiceContext.stackName();
         winston.info(`${SERVICE_NAME} - Deploying Beanstalk application '${stackName}'`);

--- a/handel/src/services/codedeploy/index.ts
+++ b/handel/src/services/codedeploy/index.ts
@@ -91,6 +91,10 @@ export class Service implements ServiceDeployer {
         return preDeployPhase.preDeployCreateSecurityGroup(serviceContext, 22, SERVICE_NAME);
     }
 
+    public async getPreDeployContext(serviceContext: ServiceContext<CodeDeployServiceConfig>): Promise<PreDeployContext> {
+        return preDeployPhase.getSecurityGroup(serviceContext);
+    }
+
     public async deploy(ownServiceContext: ServiceContext<CodeDeployServiceConfig>, ownPreDeployContext: PreDeployContext, dependenciesDeployContexts: DeployContext[]): Promise<DeployContext> {
         const stackName = ownServiceContext.stackName();
         winston.info(`${SERVICE_NAME} - Deploying application '${stackName}'`);

--- a/handel/src/services/ecs-fargate/index.ts
+++ b/handel/src/services/ecs-fargate/index.ts
@@ -145,6 +145,10 @@ export class Service implements ServiceDeployer {
         return preDeployPhase.preDeployCreateSecurityGroup(serviceContext, null, SERVICE_NAME);
     }
 
+    public async getPreDeployContext(serviceContext: ServiceContext<FargateServiceConfig>): Promise<PreDeployContext> {
+        return preDeployPhase.getSecurityGroup(serviceContext);
+    }
+
     public async deploy(ownServiceContext: ServiceContext<FargateServiceConfig>, ownPreDeployContext: PreDeployContext, dependenciesDeployContexts: DeployContext[]): Promise<DeployContext> {
         const stackName = ownServiceContext.stackName();
         winston.info(`${SERVICE_NAME} - Deploying ECS Fargate Service '${stackName}'`);

--- a/handel/src/services/ecs/index.ts
+++ b/handel/src/services/ecs/index.ts
@@ -154,6 +154,10 @@ export class Service implements ServiceDeployer {
         return preDeployPhase.preDeployCreateSecurityGroup(serviceContext, 22, SERVICE_NAME);
     }
 
+    public async getPreDeployContext(serviceContext: ServiceContext<EcsServiceConfig>): Promise<PreDeployContext> {
+        return preDeployPhase.getSecurityGroup(serviceContext);
+    }
+
     public async deploy(ownServiceContext: ServiceContext<EcsServiceConfig>, ownPreDeployContext: PreDeployContext, dependenciesDeployContexts: DeployContext[]): Promise<DeployContext> {
         const stackName = ownServiceContext.stackName();
         winston.info(`${SERVICE_NAME} - Deploying service '${stackName}'`);

--- a/handel/src/services/efs/index.ts
+++ b/handel/src/services/efs/index.ts
@@ -137,6 +137,10 @@ export class Service implements ServiceDeployer {
         return preDeployPhase.preDeployCreateSecurityGroup(serviceContext, null, SERVICE_NAME);
     }
 
+    public async getPreDeployContext(serviceContext: ServiceContext<EfsServiceConfig>): Promise<PreDeployContext> {
+        return preDeployPhase.getSecurityGroup(serviceContext);
+    }
+
     public async bind(ownServiceContext: ServiceContext<EfsServiceConfig>, ownPreDeployContext: PreDeployContext, dependentOfServiceContext: ServiceContext<ServiceConfig>, dependentOfPreDeployContext: PreDeployContext): Promise<BindContext> {
         return bindPhase.bindDependentSecurityGroup(ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext, EFS_SG_PROTOCOL, EFS_PORT, SERVICE_NAME);
     }
@@ -158,7 +162,7 @@ export class Service implements ServiceDeployer {
         return deletePhases.unPreDeploySecurityGroup(ownServiceContext, SERVICE_NAME);
     }
 
-    public async unBind(ownServiceContext: ServiceContext<EfsServiceConfig>): Promise<UnBindContext> {
+    public async unBind(ownServiceContext: ServiceContext<EfsServiceConfig>, ownPreDeployContext: PreDeployContext, dependentOfServiceContext: ServiceContext<ServiceConfig>, dependentOfPreDeployContext: PreDeployContext): Promise<UnBindContext> {
         return deletePhases.unBindSecurityGroups(ownServiceContext, SERVICE_NAME);
     }
 

--- a/handel/src/services/elasticsearch/index.ts
+++ b/handel/src/services/elasticsearch/index.ts
@@ -27,7 +27,16 @@ import {
     UnDeployContext,
     UnPreDeployContext
 } from 'handel-extension-api';
-import { awsCalls, bindPhase, checkPhase, deletePhases, deployPhase, handlebars, preDeployPhase, tagging } from 'handel-extension-support';
+import {
+    awsCalls,
+    bindPhase,
+    checkPhase,
+    deletePhases,
+    deployPhase,
+    handlebars,
+    preDeployPhase,
+    tagging
+} from 'handel-extension-support';
 import * as winston from 'winston';
 import * as iamCalls from '../../aws/iam-calls';
 import { ElasticsearchConfig, HandlebarsDedicatedMasterNode, HandlebarsEbs, HandlebarsElasticsearchTemplate } from './config-types';
@@ -131,6 +140,10 @@ export class Service implements ServiceDeployer {
         return preDeployPhase.preDeployCreateSecurityGroup(serviceContext, ES_PORT, SERVICE_NAME);
     }
 
+    public async getPreDeployContext(serviceContext: ServiceContext<ElasticsearchConfig>): Promise<PreDeployContext> {
+        return preDeployPhase.getSecurityGroup(serviceContext);
+    }
+
     public async bind(ownServiceContext: ServiceContext<ElasticsearchConfig>,
         ownPreDeployContext: PreDeployContext,
         dependentOfServiceContext: ServiceContext<ServiceConfig>,
@@ -161,7 +174,7 @@ export class Service implements ServiceDeployer {
         return deletePhases.unPreDeploySecurityGroup(ownServiceContext, SERVICE_NAME);
     }
 
-    public async unBind(ownServiceContext: ServiceContext<ElasticsearchConfig>): Promise<UnBindContext> {
+    public async unBind(ownServiceContext: ServiceContext<ElasticsearchConfig>, ownPreDeployContext: PreDeployContext, dependentOfServiceContext: ServiceContext<ServiceConfig>, dependentOfPreDeployContext: PreDeployContext): Promise<UnBindContext> {
         return deletePhases.unBindSecurityGroups(ownServiceContext, SERVICE_NAME);
     }
 

--- a/handel/src/services/lambda/index.ts
+++ b/handel/src/services/lambda/index.ts
@@ -185,6 +185,14 @@ export class Service implements ServiceDeployer {
         }
     }
 
+    public async getPreDeployContext(serviceContext: ServiceContext<LambdaServiceConfig>): Promise<PreDeployContext> {
+        if (serviceContext.params.vpc) {
+            return preDeployPhase.getSecurityGroup(serviceContext);
+        } else {
+            return lifecyclesCommon.preDeployNotRequired(serviceContext);
+        }
+    }
+
     public async deploy(ownServiceContext: ServiceContext<LambdaServiceConfig>, ownPreDeployContext: PreDeployContext, dependenciesDeployContexts: DeployContext[]): Promise<DeployContext> {
         const stackName = ownServiceContext.stackName();
         winston.info(`${SERVICE_NAME} - Executing Deploy on '${stackName}'`);

--- a/handel/src/services/memcached/index.ts
+++ b/handel/src/services/memcached/index.ts
@@ -112,6 +112,10 @@ export class Service implements ServiceDeployer {
         return preDeployPhase.preDeployCreateSecurityGroup(serviceContext, null, SERVICE_NAME);
     }
 
+    public async getPreDeployContext(serviceContext: ServiceContext<MemcachedServiceConfig>): Promise<PreDeployContext> {
+        return preDeployPhase.getSecurityGroup(serviceContext);
+    }
+
     public async bind(ownServiceContext: ServiceContext<MemcachedServiceConfig>, ownPreDeployContext: PreDeployContext, dependentOfServiceContext: ServiceContext<ServiceConfig>, dependentOfPreDeployContext: PreDeployContext): Promise<BindContext> {
         return bindPhase.bindDependentSecurityGroup(ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext, MEMCACHED_SG_PROTOCOL, MEMCACHED_PORT, SERVICE_NAME);
     }
@@ -130,7 +134,7 @@ export class Service implements ServiceDeployer {
         return deletePhases.unPreDeploySecurityGroup(ownServiceContext, SERVICE_NAME);
     }
 
-    public async unBind(ownServiceContext: ServiceContext<MemcachedServiceConfig>): Promise<UnBindContext> {
+    public async unBind(ownServiceContext: ServiceContext<MemcachedServiceConfig>, ownPreDeployContext: PreDeployContext, dependentOfServiceContext: ServiceContext<ServiceConfig>, dependentOfPreDeployContext: PreDeployContext): Promise<UnBindContext> {
         return deletePhases.unBindSecurityGroups(ownServiceContext, SERVICE_NAME);
     }
 

--- a/handel/src/services/mysql/index.ts
+++ b/handel/src/services/mysql/index.ts
@@ -26,7 +26,16 @@ import {
     UnDeployContext,
     UnPreDeployContext
 } from 'handel-extension-api';
-import { awsCalls, bindPhase, checkPhase, deletePhases, deployPhase, handlebars, preDeployPhase, tagging } from 'handel-extension-support';
+import {
+    awsCalls,
+    bindPhase,
+    checkPhase,
+    deletePhases,
+    deployPhase,
+    handlebars,
+    preDeployPhase,
+    tagging
+} from 'handel-extension-support';
 import * as winston from 'winston';
 import * as rdsDeployersCommon from '../../common/rds-deployers-common';
 import { HandlebarsMySqlTemplate, MySQLConfig, MySQLStorageType } from './config-types';
@@ -103,6 +112,10 @@ export class Service implements ServiceDeployer {
         return preDeployPhase.preDeployCreateSecurityGroup(serviceContext, MYSQL_PORT, SERVICE_NAME);
     }
 
+    public async getPreDeployContext(serviceContext: ServiceContext<MySQLConfig>): Promise<PreDeployContext> {
+        return preDeployPhase.getSecurityGroup(serviceContext);
+    }
+
     public async bind(ownServiceContext: ServiceContext<MySQLConfig>,
         ownPreDeployContext: PreDeployContext,
         dependentOfServiceContext: ServiceContext<ServiceConfig>,
@@ -159,7 +172,7 @@ export class Service implements ServiceDeployer {
         return deletePhases.unPreDeploySecurityGroup(ownServiceContext, SERVICE_NAME);
     }
 
-    public async unBind(ownServiceContext: ServiceContext<MySQLConfig>): Promise<UnBindContext> {
+    public async unBind(ownServiceContext: ServiceContext<MySQLConfig>, ownPreDeployContext: PreDeployContext, dependentOfServiceContext: ServiceContext<ServiceConfig>, dependentOfPreDeployContext: PreDeployContext): Promise<UnBindContext> {
         return deletePhases.unBindSecurityGroups(ownServiceContext, SERVICE_NAME);
     }
 

--- a/handel/src/services/neptune/index.ts
+++ b/handel/src/services/neptune/index.ts
@@ -27,7 +27,15 @@ import {
     UnDeployContext,
     UnPreDeployContext
 } from 'handel-extension-api';
-import { awsCalls, bindPhase, checkPhase, deletePhases, handlebars, preDeployPhase, tagging } from 'handel-extension-support';
+import {
+    awsCalls,
+    bindPhase,
+    checkPhase,
+    deletePhases,
+    handlebars,
+    preDeployPhase,
+    tagging
+} from 'handel-extension-support';
 import * as winston from 'winston';
 import { HandlebarsInstanceConfig, HandlebarsNeptuneTemplate, NeptuneConfig } from './config-types';
 
@@ -133,6 +141,10 @@ export class Service implements ServiceDeployer {
         return preDeployPhase.preDeployCreateSecurityGroup(serviceContext, NEPTUNE_PORT, SERVICE_NAME);
     }
 
+    public async getPreDeployContext(serviceContext: ServiceContext<NeptuneConfig>): Promise<PreDeployContext> {
+        return preDeployPhase.getSecurityGroup(serviceContext);
+    }
+
     public async bind(ownServiceContext: ServiceContext<NeptuneConfig>,
         ownPreDeployContext: PreDeployContext,
         dependentOfServiceContext: ServiceContext<ServiceConfig>,
@@ -176,7 +188,7 @@ export class Service implements ServiceDeployer {
         return deletePhases.unPreDeploySecurityGroup(ownServiceContext, SERVICE_NAME);
     }
 
-    public async unBind(ownServiceContext: ServiceContext<NeptuneConfig>): Promise<UnBindContext> {
+    public async unBind(ownServiceContext: ServiceContext<NeptuneConfig>, ownPreDeployContext: PreDeployContext, dependentOfServiceContext: ServiceContext<ServiceConfig>, dependentOfPreDeployContext: PreDeployContext): Promise<UnBindContext> {
         return deletePhases.unBindSecurityGroups(ownServiceContext, SERVICE_NAME);
     }
 

--- a/handel/src/services/postgresql/index.ts
+++ b/handel/src/services/postgresql/index.ts
@@ -26,7 +26,16 @@ import {
     UnDeployContext,
     UnPreDeployContext
 } from 'handel-extension-api';
-import { awsCalls, bindPhase, checkPhase, deletePhases, deployPhase, handlebars, preDeployPhase, tagging } from 'handel-extension-support';
+import {
+    awsCalls,
+    bindPhase,
+    checkPhase,
+    deletePhases,
+    deployPhase,
+    handlebars,
+    preDeployPhase,
+    tagging
+} from 'handel-extension-support';
 import * as winston from 'winston';
 import * as rdsDeployersCommon from '../../common/rds-deployers-common';
 import { HandlebarsPostgreSQLTemplate, PostgreSQLConfig, PostgreSQLStorageType } from './config-types';
@@ -127,6 +136,10 @@ export class Service implements ServiceDeployer {
         return preDeployPhase.preDeployCreateSecurityGroup(serviceContext, POSTGRES_PORT, SERVICE_NAME);
     }
 
+    public async getPreDeployContext(serviceContext: ServiceContext<PostgreSQLConfig>): Promise<PreDeployContext> {
+        return preDeployPhase.getSecurityGroup(serviceContext);
+    }
+
     public async bind(ownServiceContext: ServiceContext<PostgreSQLConfig>,
         ownPreDeployContext: PreDeployContext,
         dependentOfServiceContext: ServiceContext<ServiceConfig>,
@@ -185,7 +198,7 @@ export class Service implements ServiceDeployer {
         return deletePhases.unPreDeploySecurityGroup(ownServiceContext, SERVICE_NAME);
     }
 
-    public async unBind(ownServiceContext: ServiceContext<PostgreSQLConfig>): Promise<UnBindContext> {
+    public async unBind(ownServiceContext: ServiceContext<PostgreSQLConfig>, ownPreDeployContext: PreDeployContext, dependentOfServiceContext: ServiceContext<ServiceConfig>, dependentOfPreDeployContext: PreDeployContext): Promise<UnBindContext> {
         return deletePhases.unBindSecurityGroups(ownServiceContext, SERVICE_NAME);
     }
 

--- a/handel/src/services/redis/index.ts
+++ b/handel/src/services/redis/index.ts
@@ -26,7 +26,16 @@ import {
     UnDeployContext,
     UnPreDeployContext
 } from 'handel-extension-api';
-import { awsCalls, bindPhase, checkPhase, deletePhases, deployPhase, handlebars, preDeployPhase, tagging } from 'handel-extension-support';
+import {
+    awsCalls,
+    bindPhase,
+    checkPhase,
+    deletePhases,
+    deployPhase,
+    handlebars,
+    preDeployPhase,
+    tagging
+} from 'handel-extension-support';
 import * as winston from 'winston';
 import * as elasticacheDeployersCommon from '../../common/elasticache-deployers-common';
 import { HandlebarsRedisTemplate, RedisServiceConfig } from './config-types';
@@ -173,6 +182,10 @@ export class Service implements ServiceDeployer {
         return preDeployPhase.preDeployCreateSecurityGroup(serviceContext, null, SERVICE_NAME);
     }
 
+    public async getPreDeployContext(serviceContext: ServiceContext<RedisServiceConfig>): Promise<PreDeployContext> {
+        return preDeployPhase.getSecurityGroup(serviceContext);
+    }
+
     public async bind(ownServiceContext: ServiceContext<RedisServiceConfig>, ownPreDeployContext: PreDeployContext, dependentOfServiceContext: ServiceContext<ServiceConfig>, dependentOfPreDeployContext: PreDeployContext): Promise<BindContext> {
         return bindPhase.bindDependentSecurityGroup(ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext, REDIS_SG_PROTOCOL, REDIS_PORT, SERVICE_NAME);
     }
@@ -191,7 +204,7 @@ export class Service implements ServiceDeployer {
         return deletePhases.unPreDeploySecurityGroup(ownServiceContext, SERVICE_NAME);
     }
 
-    public async unBind(ownServiceContext: ServiceContext<RedisServiceConfig>): Promise<UnBindContext> {
+    public async unBind(ownServiceContext: ServiceContext<RedisServiceConfig>, ownPreDeployContext: PreDeployContext, dependentOfServiceContext: ServiceContext<ServiceConfig>, dependentOfPreDeployContext: PreDeployContext): Promise<UnBindContext> {
         return deletePhases.unBindSecurityGroups(ownServiceContext, SERVICE_NAME);
     }
 

--- a/handel/test/lifecycles/delete-test.ts
+++ b/handel/test/lifecycles/delete-test.ts
@@ -23,6 +23,7 @@ import * as util from '../../src/common/util';
 import { DeleteOptions, HandelFile } from '../../src/datatypes';
 import * as handelFileParser from '../../src/handelfile/parser-v1';
 import * as deleteLifecycle from '../../src/lifecycles/delete';
+import * as preDeployPhase from '../../src/phases/pre-deploy';
 import * as unBindPhase from '../../src/phases/un-bind';
 import * as unDeployPhase from '../../src/phases/un-deploy';
 import * as unPreDeployPhase from '../../src/phases/un-pre-deploy';
@@ -45,6 +46,7 @@ describe('delete lifecycle module', () => {
     describe('delete', () => {
         it('should delete the application environment', async () => {
             const serviceContext = new ServiceContext('FakeApp', 'FakeEnv', 'FakeService', new ServiceType(STDLIB_PREFIX, 'FakeType'), {type: 'FakeType'}, accountConfig);
+            const getPreDeployContextsStub = sandbox.stub(preDeployPhase, 'getPreDeployContexts').returns({});
             const unDeployServicesStub = sandbox.stub(unDeployPhase, 'unDeployServicesInLevel').returns({});
             const unBindServicesStub = sandbox.stub(unBindPhase, 'unBindServicesInLevel').returns({});
             const unPreDeployStub = sandbox.stub(unPreDeployPhase, 'unPreDeployServices').resolves({
@@ -54,6 +56,7 @@ describe('delete lifecycle module', () => {
             const opts: DeleteOptions = { linkExtensions: false, yes: false, environment: 'dev', accountConfig: '' };
             const handelFile: HandelFile = util.readYamlFileSync(`${__dirname}/../test-handel.yml`);
             const results = await deleteLifecycle.deleteEnv(accountConfig, handelFile, 'dev', handelFileParser, serviceRegistry, opts);
+            expect(getPreDeployContextsStub.callCount).to.equal(1);
             expect(unPreDeployStub.callCount).to.equal(1);
             expect(unBindServicesStub.callCount).to.equal(2);
             expect(unDeployServicesStub.callCount).to.equal(2);

--- a/handel/test/phases/pre-deploy-test.ts
+++ b/handel/test/phases/pre-deploy-test.ts
@@ -25,44 +25,41 @@ import FakeServiceRegistry from '../service-registry/fake-service-registry';
 
 describe('preDeploy', () => {
     let accountConfig: AccountConfig;
+    let environmentContext: EnvironmentContext;
+    let serviceNameA: string;
+    let serviceNameB: string;
 
     beforeEach(async () => {
         accountConfig = await config(`${__dirname}/../test-account-config.yml`);
+
+        // Create EnvironmentContext
+        const appName = 'test';
+        const environmentName = 'dev';
+        environmentContext = new EnvironmentContext(appName, environmentName, accountConfig);
+
+        // Construct ServiceContext B
+        serviceNameB = 'B';
+        const serviceTypeB = 'efs';
+        const paramsB = {
+            type: serviceTypeB,
+            other: 'param'
+        };
+        const serviceContextB = new ServiceContext(appName, environmentName, serviceNameB, new ServiceType(STDLIB_PREFIX, serviceTypeB), paramsB, accountConfig);
+        environmentContext.serviceContexts[serviceNameB] = serviceContextB;
+
+        // Construct ServiceContext A
+        serviceNameA = 'A';
+        const serviceTypeA = 'ecs';
+        const paramsA = {
+            type: serviceTypeA,
+            some: 'param',
+            dependencies: [serviceNameB]
+        };
+        const serviceContextA = new ServiceContext(appName, environmentName, serviceNameA, new ServiceType(STDLIB_PREFIX, serviceTypeA), paramsA, accountConfig);
+        environmentContext.serviceContexts[serviceNameA] = serviceContextA;
     });
 
     describe('preDeployServices', () => {
-        let environmentContext: EnvironmentContext;
-        let serviceNameA: string;
-        let serviceNameB: string;
-
-        beforeEach(() => {
-            // Create EnvironmentContext
-            const appName = 'test';
-            const environmentName = 'dev';
-            environmentContext = new EnvironmentContext(appName, environmentName, accountConfig);
-
-            // Construct ServiceContext B
-            serviceNameB = 'B';
-            const serviceTypeB = 'efs';
-            const paramsB = {
-                type: serviceTypeB,
-                other: 'param'
-            };
-            const serviceContextB = new ServiceContext(appName, environmentName, serviceNameB, new ServiceType(STDLIB_PREFIX, serviceTypeB), paramsB, accountConfig);
-            environmentContext.serviceContexts[serviceNameB] = serviceContextB;
-
-            // Construct ServiceContext A
-            serviceNameA = 'A';
-            const serviceTypeA = 'ecs';
-            const paramsA = {
-                type: serviceTypeA,
-                some: 'param',
-                dependencies: [serviceNameB]
-            };
-            const serviceContextA = new ServiceContext(appName, environmentName, serviceNameA, new ServiceType(STDLIB_PREFIX, serviceTypeA), paramsA, accountConfig);
-            environmentContext.serviceContexts[serviceNameA] = serviceContextA;
-        });
-
         it('should execute predeploy on all services, even across levels', async () => {
             const serviceRegistry = new FakeServiceRegistry({
                 efs: {
@@ -131,6 +128,112 @@ describe('preDeploy', () => {
             const retPreDeployContexts = await preDeployPhase.preDeployServices(serviceRegistry, environmentContext);
             expect(retPreDeployContexts[serviceNameA]).to.be.instanceof(PreDeployContext);
             expect(retPreDeployContexts[serviceNameB]).to.be.instanceof(PreDeployContext);
+        });
+    });
+
+    describe('getPreDeployContexts', () => {
+        it('should execute getPreDeployContext on all services, even across levels', async () => {
+            const serviceRegistry = new FakeServiceRegistry({
+                efs: {
+                    producedEventsSupportedTypes: [],
+                    producedDeployOutputTypes: [
+                        DeployOutputType.Scripts,
+                        DeployOutputType.EnvironmentVariables,
+                        DeployOutputType.SecurityGroups
+                    ],
+                    consumedDeployOutputTypes: [],
+                    preDeploy: async (serviceContext: ServiceContext<ServiceConfig>) => {
+                        return new PreDeployContext(serviceContext);
+                    },
+                    getPreDeployContext: async (serviceContext: ServiceContext<ServiceConfig>) => {
+                        return new PreDeployContext(serviceContext);
+                    },
+                    supportsTagging: true,
+                },
+                ecs: {
+                    producedEventsSupportedTypes: [],
+                    producedDeployOutputTypes: [],
+                    consumedDeployOutputTypes: [
+                        DeployOutputType.Scripts,
+                        DeployOutputType.EnvironmentVariables,
+                        DeployOutputType.SecurityGroups,
+                        DeployOutputType.Policies
+                    ],
+                    preDeploy: async (serviceContext: ServiceContext<ServiceConfig>) => {
+                        return new PreDeployContext(serviceContext);
+                    },
+                    getPreDeployContext: async (serviceContext: ServiceContext<ServiceConfig>) => {
+                        return new PreDeployContext(serviceContext);
+                    },
+                    supportsTagging: true,
+                }
+            });
+
+            const retPreDeployContexts = await preDeployPhase.getPreDeployContexts(serviceRegistry, environmentContext);
+            expect(retPreDeployContexts[serviceNameA]).to.be.instanceof(PreDeployContext);
+            expect(retPreDeployContexts[serviceNameB]).to.be.instanceof(PreDeployContext);
+        });
+
+        it('should return empty preDeployContexts for services that dont implement preDeploy', async () => {
+            const serviceRegistry = new FakeServiceRegistry({
+                efs: {
+                    producedEventsSupportedTypes: [],
+                    producedDeployOutputTypes: [
+                        DeployOutputType.Scripts,
+                        DeployOutputType.EnvironmentVariables,
+                        DeployOutputType.SecurityGroups
+                    ],
+                    consumedDeployOutputTypes: [],
+                    preDeploy: async (serviceContext: ServiceContext<ServiceConfig>) => {
+                        return new PreDeployContext(serviceContext);
+                    },
+                    getPreDeployContext: async (serviceContext: ServiceContext<ServiceConfig>) => {
+                        return new PreDeployContext(serviceContext);
+                    },
+                    supportsTagging: true,
+                },
+                ecs: {
+                    producedEventsSupportedTypes: [],
+                    producedDeployOutputTypes: [],
+                    consumedDeployOutputTypes: [
+                        DeployOutputType.Scripts,
+                        DeployOutputType.EnvironmentVariables,
+                        DeployOutputType.SecurityGroups,
+                        DeployOutputType.Policies
+                    ],
+                    supportsTagging: true,
+                    // We're pretending here that ECS doesn't implement predeploy for the purposes of this test, even though it really does
+                }
+            });
+
+            const retPreDeployContexts = await preDeployPhase.getPreDeployContexts(serviceRegistry, environmentContext);
+            expect(retPreDeployContexts[serviceNameA]).to.be.instanceof(PreDeployContext);
+            expect(retPreDeployContexts[serviceNameB]).to.be.instanceof(PreDeployContext);
+        });
+
+        it('should throw an error when a service that implements preDeploy doesnt implement getPreDeployContext', async () => {
+            const serviceRegistry = new FakeServiceRegistry({
+                efs: {
+                    producedEventsSupportedTypes: [],
+                    producedDeployOutputTypes: [
+                        DeployOutputType.Scripts,
+                        DeployOutputType.EnvironmentVariables,
+                        DeployOutputType.SecurityGroups
+                    ],
+                    consumedDeployOutputTypes: [],
+                    preDeploy: async (serviceContext: ServiceContext<ServiceConfig>) => {
+                        return new PreDeployContext(serviceContext);
+                    },
+                    supportsTagging: true,
+                }
+            });
+
+            try {
+                const retPreDeployContexts = await preDeployPhase.getPreDeployContexts(serviceRegistry, environmentContext);
+            }
+            catch(err) {
+                expect(err.message).to.include('Expected getPreDeployContext');
+            }
         });
     });
 });

--- a/handel/test/phases/un-bind-test.ts
+++ b/handel/test/phases/un-bind-test.ts
@@ -15,17 +15,29 @@
  *
  */
 import { expect } from 'chai';
-import { AccountConfig, DeployOutputType, ServiceContext, ServiceType, UnBindContext } from 'handel-extension-api';
+import {
+    AccountConfig,
+    DeployOutputType,
+    PreDeployContext,
+    ServiceContext,
+    ServiceType,
+    UnBindContext
+} from 'handel-extension-api';
 import 'mocha';
 import * as sinon from 'sinon';
 import config from '../../src/account-config/account-config';
-import { DeployOrder, EnvironmentContext, } from '../../src/datatypes';
+import {
+    DeployOrder,
+    EnvironmentContext,
+    PreDeployContexts
+} from '../../src/datatypes';
 import * as unBindPhase from '../../src/phases/un-bind';
 import { STDLIB_PREFIX } from '../../src/services/stdlib';
 import FakeServiceRegistry from '../service-registry/fake-service-registry';
 
 describe('unBind', () => {
     let sandbox: sinon.SinonSandbox;
+    let preDeployContexts: PreDeployContexts;
     let accountConfig: AccountConfig;
 
     beforeEach(async () => {
@@ -69,6 +81,11 @@ describe('unBind', () => {
             const serviceContextA = new ServiceContext(appName, environmentName, serviceNameA, new ServiceType(STDLIB_PREFIX, serviceTypeA), paramsA, accountConfig);
             environmentContext.serviceContexts[serviceNameA] = serviceContextA;
 
+            // Construct PreDeployContexts
+            preDeployContexts = {};
+            preDeployContexts[serviceNameA] = new PreDeployContext(serviceContextA);
+            preDeployContexts[serviceNameB] = new PreDeployContext(serviceContextB);
+
             // Set deploy order
             deployOrder = [
                 [serviceNameB],
@@ -108,8 +125,8 @@ describe('unBind', () => {
                 }
             });
 
-            const unBindContexts = await unBindPhase.unBindServicesInLevel(serviceRegistry, environmentContext, deployOrder, levelToUnBind);
-            expect(unBindContexts.B).to.be.instanceof(UnBindContext);
+            const unBindContexts = await unBindPhase.unBindServicesInLevel(serviceRegistry, environmentContext, preDeployContexts, deployOrder, levelToUnBind);
+            expect(unBindContexts['A->B']).to.be.instanceof(UnBindContext);
         });
 
         it('should return emtpy unbind contexts for services that dont implement unbind', async () => {
@@ -141,8 +158,8 @@ describe('unBind', () => {
                 }
             });
 
-            const unBindContexts = await unBindPhase.unBindServicesInLevel(serviceRegistry, environmentContext, deployOrder, levelToUnBind);
-            expect(unBindContexts.B).to.be.instanceof(UnBindContext);
+            const unBindContexts = await unBindPhase.unBindServicesInLevel(serviceRegistry, environmentContext, preDeployContexts, deployOrder, levelToUnBind);
+            expect(unBindContexts['A->B']).to.be.instanceof(UnBindContext);
         });
     });
 });

--- a/handel/test/services/aurora/aurora-test.ts
+++ b/handel/test/services/aurora/aurora-test.ts
@@ -220,8 +220,11 @@ describe('aurora deployer', () => {
         it('should unbind the security group', async () => {
             const unBindStub = sandbox.stub(deletePhases, 'unBindSecurityGroups')
                 .resolves(new UnBindContext(serviceContext));
+            const dependencyPreDeployContext = new PreDeployContext(serviceContext);
+            const dependentOfServiceContext = new ServiceContext(appName, envName, 'FakeService', new ServiceType(STDLIB_PREFIX, 'beanstalk'), {type: 'beanstalk'}, accountConfig);
+            const dependentOfPreDeployContext = new PreDeployContext(dependentOfServiceContext);
 
-            const unBindContext = await aurora.unBind!(serviceContext);
+            const unBindContext = await aurora.unBind!(serviceContext, dependencyPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext);
             expect(unBindContext).to.be.instanceof(UnBindContext);
             expect(unBindStub.callCount).to.equal(1);
         });

--- a/handel/test/services/efs/efs-test.ts
+++ b/handel/test/services/efs/efs-test.ts
@@ -142,8 +142,12 @@ describe('efs deployer', () => {
     describe('unBind', () => {
         it('should unbind the security group', async () => {
             const unBindStub = sandbox.stub(deletePhases, 'unBindSecurityGroups').resolves(new UnBindContext(serviceContext));
+            const dependencyPreDeployContext = new PreDeployContext(serviceContext);
+            const dependentOfServiceContext = new ServiceContext(appName, envName, 'FakeService', new ServiceType(STDLIB_PREFIX, 'beanstalk'), {type: 'beanstalk'}, accountConfig);
+            const dependentOfPreDeployContext = new PreDeployContext(dependentOfServiceContext);
 
-            const unBindContext = await efs.unBind!(serviceContext);
+
+            const unBindContext = await efs.unBind!(serviceContext, dependencyPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext);
             expect(unBindContext).to.be.instanceof(UnBindContext);
             expect(unBindStub.callCount).to.equal(1);
         });

--- a/handel/test/services/elasticsearch/elasticsearch-test.ts
+++ b/handel/test/services/elasticsearch/elasticsearch-test.ts
@@ -152,8 +152,11 @@ describe('elasticsearch deployer', () => {
         it('should unbind the security group', async () => {
             const unBindStub = sandbox.stub(deletePhases, 'unBindSecurityGroups')
                 .resolves(new UnBindContext(serviceContext));
+                const dependencyPreDeployContext = new PreDeployContext(serviceContext);
+                const dependentOfServiceContext = new ServiceContext(appName, envName, 'FakeService', new ServiceType(STDLIB_PREFIX, 'beanstalk'), {type: 'beanstalk'}, accountConfig);
+                const dependentOfPreDeployContext = new PreDeployContext(dependentOfServiceContext);
 
-            const unBindContext = await elasticsearch.unBind!(serviceContext);
+            const unBindContext = await elasticsearch.unBind!(serviceContext, dependencyPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext);
             expect(unBindContext).to.be.instanceof(UnBindContext);
             expect(unBindStub.callCount).to.equal(1);
         });

--- a/handel/test/services/memcached/memcached-test.ts
+++ b/handel/test/services/memcached/memcached-test.ts
@@ -161,8 +161,11 @@ describe('memcached deployer', () => {
     describe('unBind', () => {
         it('should unbind the security group', async () => {
             const unBindStub = sandbox.stub(deletePhases, 'unBindSecurityGroups').resolves(new UnBindContext(serviceContext));
+            const dependencyPreDeployContext = new PreDeployContext(serviceContext);
+            const dependentOfServiceContext = new ServiceContext(appName, envName, 'FakeService', new ServiceType(STDLIB_PREFIX, 'beanstalk'), {type: 'beanstalk'}, accountConfig);
+            const dependentOfPreDeployContext = new PreDeployContext(dependentOfServiceContext);
 
-            const unBindContext = await memcached.unBind!(serviceContext);
+            const unBindContext = await memcached.unBind!(serviceContext, dependencyPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext);
             expect(unBindContext).to.be.instanceof(UnBindContext);
             expect(unBindStub.callCount).to.equal(1);
         });

--- a/handel/test/services/mysql/mysql-test.ts
+++ b/handel/test/services/mysql/mysql-test.ts
@@ -194,8 +194,11 @@ describe('mysql deployer', () => {
         it('should unbind the security group', async () => {
             const unBindStub = sandbox.stub(deletePhases, 'unBindSecurityGroups')
                 .resolves(new UnBindContext(serviceContext));
+            const dependencyPreDeployContext = new PreDeployContext(serviceContext);
+            const dependentOfServiceContext = new ServiceContext(appName, envName, 'FakeService', new ServiceType(STDLIB_PREFIX, 'beanstalk'), {type: 'beanstalk'}, accountConfig);
+            const dependentOfPreDeployContext = new PreDeployContext(dependentOfServiceContext);
 
-            const unBindContext = await mysql.unBind!(serviceContext);
+            const unBindContext = await mysql.unBind!(serviceContext, dependencyPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext);
             expect(unBindContext).to.be.instanceof(UnBindContext);
             expect(unBindStub.callCount).to.equal(1);
         });

--- a/handel/test/services/neptune/neptune-test.ts
+++ b/handel/test/services/neptune/neptune-test.ts
@@ -174,8 +174,11 @@ describe('neptune deployer', () => {
         it('should unbind the security group', async () => {
             const unBindStub = sandbox.stub(deletePhases, 'unBindSecurityGroups')
                 .resolves(new UnBindContext(serviceContext));
+            const dependencyPreDeployContext = new PreDeployContext(serviceContext);
+            const dependentOfServiceContext = new ServiceContext(appName, envName, 'FakeService', new ServiceType(STDLIB_PREFIX, 'beanstalk'), {type: 'beanstalk'}, accountConfig);
+            const dependentOfPreDeployContext = new PreDeployContext(dependentOfServiceContext);
 
-            const unBindContext = await neptune.unBind!(serviceContext);
+            const unBindContext = await neptune.unBind!(serviceContext, dependencyPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext);
             expect(unBindContext).to.be.instanceof(UnBindContext);
             expect(unBindStub.callCount).to.equal(1);
         });

--- a/handel/test/services/postgresql/postgresql-test.ts
+++ b/handel/test/services/postgresql/postgresql-test.ts
@@ -208,8 +208,11 @@ describe('postgresql deployer', () => {
         it('should unbind the security group', async () => {
             const unBindStub = sandbox.stub(deletePhases, 'unBindSecurityGroups')
                 .resolves(new UnBindContext(serviceContext));
+            const dependencyPreDeployContext = new PreDeployContext(serviceContext);
+            const dependentOfServiceContext = new ServiceContext(appName, envName, 'FakeService', new ServiceType(STDLIB_PREFIX, 'beanstalk'), {type: 'beanstalk'}, accountConfig);
+            const dependentOfPreDeployContext = new PreDeployContext(dependentOfServiceContext);
 
-            const unBindContext = await postgresql.unBind!(serviceContext);
+            const unBindContext = await postgresql.unBind!(serviceContext, dependencyPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext);
             expect(unBindContext).to.be.instanceof(UnBindContext);
             expect(unBindStub.callCount).to.equal(1);
         });

--- a/handel/test/services/redis/redis-test.ts
+++ b/handel/test/services/redis/redis-test.ts
@@ -171,8 +171,11 @@ describe('redis deployer', () => {
     describe('unBind', () => {
         it('should unbind the security group', async () => {
             const unBindStub = sandbox.stub(deletePhases, 'unBindSecurityGroups').resolves(new UnBindContext(serviceContext));
+            const dependencyPreDeployContext = new PreDeployContext(serviceContext);
+            const dependentOfServiceContext = new ServiceContext(appName, envName, 'FakeService', new ServiceType(STDLIB_PREFIX, 'beanstalk'), {type: 'beanstalk'}, accountConfig);
+            const dependentOfPreDeployContext = new PreDeployContext(dependentOfServiceContext);
 
-            const unBindContext = await redis.unBind!(serviceContext);
+            const unBindContext = await redis.unBind!(serviceContext, dependencyPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext);
             expect(unBindContext).to.be.instanceof(UnBindContext);
             expect(unBindStub.callCount).to.equal(1);
         });


### PR DESCRIPTION
This is my second attempt at coming up with a way to provide PreDeploy information to the UnBind phase. This time, we add a method to the API contract, `getPreDeployContext`, that is for returning PreDeploy information without calling PreDeploy.

There can be future changes such as adding an equivalent `getDeployContext`, but that will change more than I'd like to fit into this PR. We have also talked about aggregating the service output information, but I don't want to tackle this yet.