### PR TITLE
Add minimum HTTPS protocol to s3 static site deployer

### DIFF
--- a/docs/supported-services/s3staticsite.rst
+++ b/docs/supported-services/s3staticsite.rst
@@ -98,6 +98,11 @@ The `cloudfront` section is defined by the following schema:
      - No
      -
      - The ID of an Amazon Certificate Manager certificate to use for this site
+   * - minimum_https_protocol
+     - string
+     - No
+     - 'TLSv1.2_2018'
+     - The minimum allowed HTTPS protocol version. Valid values are listed in the `Cloudfront API Docs <https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ViewerCertificate.html>`_.
    * - dns_names
      - List<string>
      - No

--- a/handel/src/services/s3staticsite/config-types.ts
+++ b/handel/src/services/s3staticsite/config-types.ts
@@ -33,6 +33,7 @@ export interface CloudFrontConfig {
     min_ttl?: string;
     max_ttl?: string;
     default_ttl?: string;
+    minimum_https_protocol?: string;
 }
 
 export interface HandlebarsS3StaticSiteTemplate {
@@ -54,6 +55,7 @@ export interface HandlebarsCloudFrontParams {
     priceClass: string;
     httpsCertificateId?: string;
     dnsNames?: HandlebarsCloudFrontDnsName[];
+    minimumHttpsProtocol: string;
 }
 
 export interface HandlebarsCloudFrontDnsName {

--- a/handel/src/services/s3staticsite/index.ts
+++ b/handel/src/services/s3staticsite/index.ts
@@ -51,6 +51,8 @@ const TTL_UNITS: TtlUnits = {
 };
 const TTL_REGEX = new RegExp(`^(\\d+)(?:(?: )*(${Object.keys(TTL_UNITS).join('|')})(?:s)?)?$`);
 
+const DEFAULT_HTTPS_MINIMUM_PROTOCOL = 'TLSv1.2_2018';
+
 async function getCompiledS3Template(ownServiceContext: ServiceContext<S3StaticSiteServiceConfig>, stackName: string, loggingBucketName: string): Promise<string> {
     const serviceParams = ownServiceContext.params;
 
@@ -89,6 +91,7 @@ async function getCloudfrontTemplateParameters(ownServiceContext: ServiceContext
         defaultTTL: computeTTL(cf.default_ttl, TTL_UNITS.day),
         priceClass: computePriceClass(cf.price_class, 'all'),
         httpsCertificateId: cf.https_certificate,
+        minimumHttpsProtocol: cf.minimum_https_protocol || DEFAULT_HTTPS_MINIMUM_PROTOCOL
     };
 
     const dnsNames = cf.dns_names;

--- a/handel/src/services/s3staticsite/params-schema.json
+++ b/handel/src/services/s3staticsite/params-schema.json
@@ -86,6 +86,10 @@
                         {"type": "string"}
                     ],
                     "errorMessage": "Must be a number, or a number written in 'second(s)/minute(s)/hour(s)/day(s)/year'"
+                },
+                "minimum_https_protocol": {
+                    "type": "string",
+                    "errorMessage": "Must be a string"
                 }
             },
             "additionalProperties": false,

--- a/handel/src/services/s3staticsite/s3-static-site-template.yml
+++ b/handel/src/services/s3staticsite/s3-static-site-template.yml
@@ -60,6 +60,7 @@ Resources:
         ViewerCertificate:
           AcmCertificateArn: !Sub "arn:aws:acm:us-east-1:${AWS::AccountId}:certificate/{{cloudfront.httpsCertificateId}}"
           SslSupportMethod: sni-only
+          MinimumProtocolVersion: {{cloudfront.minimumHttpsProtocol}}
         {{/if}}
         DefaultCacheBehavior:
           AllowedMethods: [GET, HEAD, OPTIONS]

--- a/handel/test/services/s3staticsite/s3staticsite-test.ts
+++ b/handel/test/services/s3staticsite/s3staticsite-test.ts
@@ -91,14 +91,14 @@ describe('s3staticsite deployer', () => {
             const valid = ['enabled', 'disabled'];
             for (const validValue of valid) {
                 it(`should allow '${validValue}'`, () => {
-                    ownServiceContext.params.cloudfront = { logging: validValue };
+                    ownServiceContext.params.cloudfront = {logging: validValue};
 
                     const errors = s3StaticSite.check!(ownServiceContext, []);
                     expect(errors.length).to.equal(0);
                 });
             }
             it('should reject invalid values', () => {
-                ownServiceContext.params.cloudfront = { logging: 'off' };
+                ownServiceContext.params.cloudfront = {logging: 'off'};
                 const errors = s3StaticSite.check!(ownServiceContext, []);
                 expect(errors).to.have.lengthOf(1);
                 expect(errors[0]).to.include('Must be either \'enabled\' or \'disabled\'');
@@ -108,14 +108,14 @@ describe('s3staticsite deployer', () => {
             const valid = [100, 200, 'all'];
             for (const validValue of valid) {
                 it(`should allow '${validValue}'`, () => {
-                    ownServiceContext.params.cloudfront = { price_class: validValue };
+                    ownServiceContext.params.cloudfront = {price_class: validValue};
 
                     const errors = s3StaticSite.check!(ownServiceContext, []);
                     expect(errors.length).to.equal(0);
                 });
             }
             it('should reject invalid values', () => {
-                ownServiceContext.params.cloudfront = { price_class: 'off' };
+                ownServiceContext.params.cloudfront = {price_class: 'off'};
                 const errors = s3StaticSite.check!(ownServiceContext, []);
                 expect(errors).to.have.lengthOf(1);
                 expect(errors[0]).to.include('Must be one of 100, 200, or \'all\'');
@@ -126,24 +126,24 @@ describe('s3staticsite deployer', () => {
             const aliases = ['second', 'minute', 'hour', 'day', 'year'];
             for (const field of ttlFields.map(it => `${it}_ttl`)) {
                 it(`should allow numbers in '${field}`, () => {
-                    ownServiceContext.params.cloudfront = { [field]: 100 };
+                    ownServiceContext.params.cloudfront = {[field]: 100};
                     const errors = s3StaticSite.check!(ownServiceContext, []);
                     expect(errors.length).to.equal(0);
                 });
                 for (const alias of aliases) {
                     it(`should allow ${alias} aliases in '${field}`, () => {
-                        ownServiceContext.params.cloudfront = { [field]: `2 ${alias}` };
+                        ownServiceContext.params.cloudfront = {[field]: `2 ${alias}`};
                         let errors = s3StaticSite.check!(ownServiceContext, []);
                         expect(errors.length).to.equal(0);
 
                         // plural
-                        ownServiceContext.params.cloudfront = { [field]: `2 ${alias}s` };
+                        ownServiceContext.params.cloudfront = {[field]: `2 ${alias}s`};
                         errors = s3StaticSite.check!(ownServiceContext, []);
                         expect(errors.length).to.equal(0);
                     });
                 }
                 it(`should reject invalid values in '${field}`, () => {
-                    ownServiceContext.params.cloudfront = { [field]: 'foobar' };
+                    ownServiceContext.params.cloudfront = {[field]: 'foobar'};
 
                     const errors = s3StaticSite.check!(ownServiceContext, []);
                     expect(errors).to.have.lengthOf(1);
@@ -153,13 +153,13 @@ describe('s3staticsite deployer', () => {
         });
         describe('cloudfront.dns_name', () => {
             it('should allow valid hostnames', () => {
-                ownServiceContext.params.cloudfront = { dns_names: ['valid.dns.name.com'] };
+                ownServiceContext.params.cloudfront = {dns_names: ['valid.dns.name.com']};
 
                 const errors = s3StaticSite.check!(ownServiceContext, []);
                 expect(errors.length).to.equal(0);
             });
             it('should reject invalid values', () => {
-                ownServiceContext.params.cloudfront = { dns_names: ['invalid hostname', 'valid.dns.name.com'] };
+                ownServiceContext.params.cloudfront = {dns_names: ['invalid hostname', 'valid.dns.name.com']};
 
                 const errors = s3StaticSite.check!(ownServiceContext, []);
                 expect(errors).to.have.lengthOf(1);
@@ -245,12 +245,12 @@ describe('s3staticsite deployer', () => {
 
                 expect(params).to.have.property('cloudfront')
                     .that.includes({
-                        logging: true,
-                        minTTL: 0,
-                        maxTTL: 31536000,
-                        defaultTTL: 86400,
-                        priceClass: 'PriceClass_All'
-                    });
+                    logging: true,
+                    minTTL: 0,
+                    maxTTL: 31536000,
+                    defaultTTL: 86400,
+                    priceClass: 'PriceClass_All'
+                });
             });
 
             it('should allow DNS names to be set', async () => {
@@ -281,7 +281,18 @@ describe('s3staticsite deployer', () => {
                 expect(params).to.have.property('cloudfront')
                     .which.has.property('httpsCertificateId', 'abc123');
             });
+            it('Should set a default minimum HTTP protocol', async () => {
+                ownServiceContext.params.cloudfront!.https_certificate = 'abc123';
 
+                await s3StaticSite.deploy!(ownServiceContext, ownPreDeployContext, []);
+
+                const params = handlebarsSpy.lastCall.args[1];
+
+                expect(params).to.have.property('cloudfront')
+                    .which.includes({
+                    'minimumHttpsProtocol': 'TLSv1.2_2018'
+                });
+            });
             it('should allow cloudfront logging to be disabled', async () => {
                 ownServiceContext.params.cloudfront!.logging = 'disabled';
 
@@ -311,10 +322,10 @@ describe('s3staticsite deployer', () => {
 
                 expect(params).to.have.property('cloudfront')
                     .which.includes({
-                        minTTL: 60,
-                        defaultTTL: 3600 * 2,
-                        maxTTL: 3600 * 24 * 30,
-                    });
+                    minTTL: 60,
+                    defaultTTL: 3600 * 2,
+                    maxTTL: 3600 * 24 * 30,
+                });
             });
         });
     });


### PR DESCRIPTION
This is a Good Thing, since the defaults for Cloudfront are atrocious from a security perspective.

Defaults to `TLSv1.2_2018`, which supports any recent browsers and disallows known-insecure protocols and ciphers. Also allows the user to specify a version if they don't want that one. I really hope they don't override it unless it's to set a newer value that we haven't added support for yet 🙏 .