### PR TITLE
Add automatic redirects to HTTPS in ecs and fargate

### DIFF
--- a/handel/src/services/ecs-fargate/ecs-fargate-template.yml
+++ b/handel/src/services/ecs-fargate/ecs-fargate-template.yml
@@ -293,14 +293,15 @@ Resources:
       GroupDescription: Security group for ALB
       VpcId: {{vpcId}}
       SecurityGroupIngress:
+      {{#if loadBalancer.httpsCertificate}}
       - IpProtocol: tcp
-        {{#if loadBalancer.httpsCertificate}}
         FromPort: '443'
         ToPort: '443'
-        {{else}}
+        CidrIp: 0.0.0.0/0
+      {{/if}}
+      - IpProtocol: tcp
         FromPort: '80'
         ToPort: '80'
-        {{/if}}
         CidrIp: 0.0.0.0/0
       Tags:
       {{#if tags}}
@@ -346,6 +347,23 @@ Resources:
       Port: '80'
       Protocol: HTTP
       {{/if}}
+  {{#if loadBalancer.httpsCertificate}}
+  RedirectToHttpsListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    DependsOn:
+      - Alb
+    Properties:
+      DefaultActions:
+        - Type: redirect
+          RedirectConfig:
+            Protocol: HTTPS
+            StatusCode: HTTP_301
+            Port: 443
+      Port: '80'
+      Protocol: HTTP
+      LoadBalancerArn:
+        Ref: Alb
+  {{/if}}
   {{#each containerConfigs}}
   {{#if routingInfo}}
   AlbListenerRule{{logicalId name}}:

--- a/handel/src/services/ecs/ecs-service-template.yml
+++ b/handel/src/services/ecs/ecs-service-template.yml
@@ -440,14 +440,15 @@ Resources:
       GroupDescription: Security group for ALB
       VpcId: {{vpcId}}
       SecurityGroupIngress:
+      {{#if loadBalancer.httpsCertificate}}
       - IpProtocol: tcp
-        {{#if loadBalancer.httpsCertificate}}
         FromPort: '443'
         ToPort: '443'
-        {{else}}
+        CidrIp: 0.0.0.0/0
+      {{/if}}
+      - IpProtocol: tcp
         FromPort: '80'
         ToPort: '80'
-        {{/if}}
         CidrIp: 0.0.0.0/0
       Tags:
       {{#if tags}}
@@ -493,6 +494,23 @@ Resources:
       Port: '80'
       Protocol: HTTP
       {{/if}}
+  {{#if loadBalancer.httpsCertificate}}
+  RedirectToHttpsListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    DependsOn:
+      - Alb
+    Properties:
+      DefaultActions:
+        - Type: redirect
+          RedirectConfig:
+            Protocol: HTTPS
+            StatusCode: HTTP_301
+            Port: 443
+      Port: '80'
+      Protocol: HTTP
+      LoadBalancerArn:
+        Ref: Alb
+  {{/if}}
   {{#each containerConfigs}}
   {{#if routingInfo}}
   AlbListenerRule{{name}}:


### PR DESCRIPTION
Partial fix to #496 . Only works in ECS and ECS Fargate for now, but it should be pretty easy to extend it to every other service that uses ALB.