### PR TITLE
Add support for Dynamod on-demand capacity

### DIFF
--- a/docs/supported-services/dynamodb.rst
+++ b/docs/supported-services/dynamodb.rst
@@ -42,6 +42,11 @@ Parameters
      - No
      - None
      - The SortKey element details how you want your sort key specified. Unlike partition_key, sort_key is not required.
+   * - capacity_mode
+     - :ref:`dynamodb-capacity-mode`
+     - No
+     - 'provisioned'
+     - The capacity provisioning mode. Either 'provisioned' or 'on-demand'. See `The Dynamo docs <https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html>`_ for more.
    * - provisioned_throughput
      - :ref:`dynamodb-provisioned-throughput`
      - No
@@ -96,6 +101,21 @@ The SortKey element tells how to configure your sort key in DynamoDB. It has the
     sort_key:
       name: <key_name> 
       type: <String|Number>
+
+
+.. _dynamodb-capacity-mode:
+
+CapacityMode
+~~~~~~~~~~~~
+The value of `capacity_mode` must be either `provisioned` or `on-demand`. If set to `provisioned`, Read/Write capacity
+is provisioned using `provisioned_throughput`. If set to `on-demand`, you are charged a flat fee per request, and AWS
+automatically scales the underlying datastore to meet demand.
+
+For non-production, new, or unpredictable workloads, `on-demand` is a good choice. For workloads with predictable usage,
+`provisioned` is usually the best choice. For more information, read
+`the Dynamo docs <https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html>`_.
+
+If `capacity_mode` is set to `on-demand`, the `provisioned_throughput` element must not be set.
 
 .. _dynamodb-provisioned-throughput:
 
@@ -170,6 +190,8 @@ The GlobalIndexes element allows you to configure global secondary indexes on yo
 
 The provisioned throughput configuration for Global Secondary Indexes matches that for the table. If the provisioned
 throughput is not configured for the index, the table's configuration will be used, including any autoscaling configuration.
+
+If the table's `capacity_mode` is set to `on-demand`, the `provisioned_throughput` element must not be set.
 
 .. WARNING::
 

--- a/handel/src/services/dynamodb/autoscaling.ts
+++ b/handel/src/services/dynamodb/autoscaling.ts
@@ -17,6 +17,7 @@
 import { Tags } from 'handel-extension-api';
 import { awsCalls, deployPhase, handlebars, util } from 'handel-extension-support';
 import * as types from './config-types';
+import { CapacityMode, DEFAULT_CAPACITY_MODE } from './config-types';
 
 /* tslint:disable:max-classes-per-file */
 
@@ -75,8 +76,10 @@ export async function undeployAutoscaling(ownServiceContext: types.DynamoDBConte
     }
 }
 
-export function getThroughputConfig(throughputConfig: types.ProvisionedThroughput | undefined,
-    defaultConfig: ThroughputConfig | null): ThroughputConfig {
+export function getThroughputConfig(
+    throughputConfig: types.ProvisionedThroughput | undefined,
+    defaultConfig: ThroughputConfig | null
+): ThroughputConfig {
     const throughput = throughputConfig || {};
     const defaults = defaultConfig || {} as ThroughputConfig;
     const defaultRead = defaults.read || {};
@@ -103,6 +106,9 @@ function isValidTargetUtilization(target: number): boolean {
 
 function tableOrIndexesHaveAutoscaling(ownServiceContext: types.DynamoDBContext): boolean {
     const params = ownServiceContext.params;
+    if ((params.capacity_mode || DEFAULT_CAPACITY_MODE) === CapacityMode.ON_DEMAND) {
+        return false;
+    }
     if (params.provisioned_throughput) {
         if (provisionedThroughputHasAutoscaling(params.provisioned_throughput)) {
             return true;

--- a/handel/src/services/dynamodb/config-types.ts
+++ b/handel/src/services/dynamodb/config-types.ts
@@ -26,6 +26,7 @@ export interface DynamoDBConfig extends ServiceConfig {
     table_name?: string;
     partition_key: KeyDefinition;
     sort_key?: KeyDefinition;
+    capacity_mode?: CapacityMode;
     provisioned_throughput?: ProvisionedThroughput;
     ttl_attribute?: string;
     stream_view_type?: StreamViewType;
@@ -41,6 +42,13 @@ export enum StreamViewType {
     OLD_IMAGE = 'OLD_IMAGE',
     NEW_AND_OLD_IMAGES = 'NEW_AND_OLD_IMAGES'
 }
+
+export enum CapacityMode {
+    PROVISIONED = 'provisioned',
+    ON_DEMAND = 'on-demand'
+}
+
+export const DEFAULT_CAPACITY_MODE = CapacityMode.PROVISIONED;
 
 export interface ProvisionedThroughput {
     read_capacity_units?: string | number;

--- a/handel/src/services/dynamodb/dynamodb-template.yml
+++ b/handel/src/services/dynamodb/dynamodb-template.yml
@@ -18,9 +18,12 @@ Resources:
       - AttributeName: {{tableSortKeyName}}
         KeyType: RANGE
       {{/if}}
+      BillingMode: {{billingMode}}
+      {{#if throughput}}
       ProvisionedThroughput:
-        ReadCapacityUnits: {{tableReadCapacityUnits}}
-        WriteCapacityUnits: {{tableWriteCapacityUnits}}
+        ReadCapacityUnits: {{throughput.readUnits}}
+        WriteCapacityUnits: {{throughput.writeUnits}}
+      {{/if}}
       {{#if globalIndexes}}
       GlobalSecondaryIndexes:
       {{#each globalIndexes}}
@@ -42,9 +45,11 @@ Resources:
           {{else}}
           ProjectionType: ALL
           {{/if}}
+        {{#if throughput}}
         ProvisionedThroughput:
-          ReadCapacityUnits: {{indexReadCapacityUnits}}
-          WriteCapacityUnits: {{indexWriteCapacityUnits}}
+          ReadCapacityUnits: {{throughput.readUnits}}
+          WriteCapacityUnits: {{throughput.writeUnits}}
+        {{/if}}
       {{/each}}
       {{/if}}
       {{#if localIndexes}}

--- a/handel/src/services/dynamodb/params-schema.json
+++ b/handel/src/services/dynamodb/params-schema.json
@@ -69,6 +69,12 @@
                 "additionalProperties": "Invalid/Unknown property specified"
             }
         },
+        "capacity_mode": {
+            "type": "string",
+            "description": "The capacity provisioning mode",
+            "enum": ["provisioned", "on-demand"],
+            "errorMessage": "Must be 'provisioned' or 'on-demand'"
+        },
         "provisioned_throughput": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
https://aws.amazon.com/blogs/aws/amazon-dynamodb-on-demand-no-capacity-planning-and-pay-per-request-pricing/