### PR TITLE
Add ability to put metrics to all compute-ish services

### DIFF
--- a/extension-support/src/common/deploy-phase.ts
+++ b/extension-support/src/common/deploy-phase.ts
@@ -117,7 +117,7 @@ export async function uploadDeployableArtifactToHandelBucket(serviceContext: Ser
     }
 }
 
-export function getAllPolicyStatementsForServiceRole(serviceContext: ServiceContext<ServiceConfig>, ownServicePolicyStatements: any[], dependenciesDeployContexts: any[], includeAppSecretsStatements: boolean): any[] {
+export function getAllPolicyStatementsForServiceRole(serviceContext: ServiceContext<ServiceConfig>, ownServicePolicyStatements: any[], dependenciesDeployContexts: any[], includeAppSecretsStatements: boolean, includePutMetricStatements: boolean = false): any[] {
     const policyStatementsToConsume = [];
 
     // Add policies from dependencies that have them
@@ -171,6 +171,20 @@ export function getAllPolicyStatementsForServiceRole(serviceContext: ServiceCont
             }
         ];
         policyStatementsToConsume.push(...appSecretsAcessStatements);
+    }
+    if (includePutMetricStatements) {
+        const putMetricStatements = [
+            {
+                Effect: 'Allow',
+                Action: [
+                    'cloudwatch:GetMetricData',
+                    'cloudwatch:GetMetricStatistics',
+                    'cloudwatch:PutMetricData'
+                ],
+                Resource: '*' // CloudWatch only allows '*' for metric permissions 🤷
+            }
+        ];
+        policyStatementsToConsume.push(...putMetricStatements);
     }
 
     return policyStatementsToConsume;

--- a/extension-support/src/common/deploy-phase.ts
+++ b/extension-support/src/common/deploy-phase.ts
@@ -177,8 +177,6 @@ export function getAllPolicyStatementsForServiceRole(serviceContext: ServiceCont
             {
                 Effect: 'Allow',
                 Action: [
-                    'cloudwatch:GetMetricData',
-                    'cloudwatch:GetMetricStatistics',
                     'cloudwatch:PutMetricData'
                 ],
                 Resource: '*' // CloudWatch only allows '*' for metric permissions 🤷

--- a/extension-support/test/common/deploy-phase-test.ts
+++ b/extension-support/test/common/deploy-phase-test.ts
@@ -224,7 +224,7 @@ describe('Deploy phase common module', () => {
             expect(policyStatements.length).to.equal(2); // 1 for logs, 1 for metrics
             expect(policyStatements).to.deep.include({
                 Effect: 'Allow',
-                Action: ['cloudwatch:GetMetricData', 'cloudwatch:GetMetricStatistics', 'cloudwatch:PutMetricData'],
+                Action: ['cloudwatch:PutMetricData'],
                 Resource: '*'
             });
         });

--- a/handel/src/services/apigateway/common.ts
+++ b/handel/src/services/apigateway/common.ts
@@ -49,7 +49,7 @@ export function getPolicyStatementsForLambdaRole(serviceContext: ServiceContext<
         ownPolicyStatements = JSON.parse(util.readFileSync(`${__dirname}/lambda-role-statements.json`));
     }
 
-    return deployPhase.getAllPolicyStatementsForServiceRole(serviceContext, ownPolicyStatements, dependenciesDeployContexts, true);
+    return deployPhase.getAllPolicyStatementsForServiceRole(serviceContext, ownPolicyStatements, dependenciesDeployContexts, true, true);
 }
 
 export async function getCustomDomainHandlebarsParams(serviceContext: ServiceContext<any>, customDomains?: CustomDomain[]): Promise<any[]> {

--- a/handel/src/services/beanstalk/index.ts
+++ b/handel/src/services/beanstalk/index.ts
@@ -183,7 +183,7 @@ async function getPolicyStatementsForInstanceRole(serviceContext: ServiceContext
     };
     const compiledPolicyStatements = await handlebars.compileTemplate(ownPolicyStatementsTemplate, handlebarsParams);
     const ownPolicyStatements = JSON.parse(compiledPolicyStatements);
-    return deployPhase.getAllPolicyStatementsForServiceRole(serviceContext, ownPolicyStatements, dependenciesDeployContexts, true);
+    return deployPhase.getAllPolicyStatementsForServiceRole(serviceContext, ownPolicyStatements, dependenciesDeployContexts, true, true);
 }
 
 function getAutoScalingEbExtension(stackName: string, ownServiceContext: ServiceContext<BeanstalkServiceConfig>): Promise<string> {

--- a/handel/src/services/codedeploy/iam-roles.ts
+++ b/handel/src/services/codedeploy/iam-roles.ts
@@ -27,5 +27,5 @@ export async function getStatementsForInstanceRole(ownServiceContext: ServiceCon
     };
     const compiledPolicyStatements = await handlebars.compileTemplate(ownPolicyStatementsTemplate, handlebarsParams);
     const ownPolicyStatements = JSON.parse(compiledPolicyStatements);
-    return deployPhase.getAllPolicyStatementsForServiceRole(ownServiceContext, ownPolicyStatements, dependenciesDeployContexts, true);
+    return deployPhase.getAllPolicyStatementsForServiceRole(ownServiceContext, ownPolicyStatements, dependenciesDeployContexts, true, true);
 }

--- a/handel/src/services/ecs-fargate/index.ts
+++ b/handel/src/services/ecs-fargate/index.ts
@@ -59,7 +59,7 @@ const ALLOWED_FARGATE_MEMORY_FOR_CPU: AllowedFargateMemoryForCpu = {
 };
 
 function getTaskRoleStatements(serviceContext: ServiceContext<FargateServiceConfig>, dependenciesDeployContexts: DeployContext[]) {
-    return deployPhase.getAllPolicyStatementsForServiceRole(serviceContext, [], dependenciesDeployContexts, true);
+    return deployPhase.getAllPolicyStatementsForServiceRole(serviceContext, [], dependenciesDeployContexts, true, true);
 }
 
 async function getCompiledEcsFargateTemplate(serviceName: string, ownServiceContext: ServiceContext<FargateServiceConfig>, ownPreDeployContext: PreDeployContext, dependenciesDeployContexts: DeployContext[]): Promise<string> {

--- a/handel/src/services/ecs/index.ts
+++ b/handel/src/services/ecs/index.ts
@@ -49,7 +49,7 @@ const SERVICE_NAME = 'ECS';
 const DEFAULT_INSTANCE_TYPE = 't2.micro';
 
 function getTaskRoleStatements(serviceContext: ServiceContext<EcsServiceConfig>, dependenciesDeployContexts: DeployContext[]) {
-    return deployPhase.getAllPolicyStatementsForServiceRole(serviceContext, [], dependenciesDeployContexts, true);
+    return deployPhase.getAllPolicyStatementsForServiceRole(serviceContext, [], dependenciesDeployContexts, true, true);
 }
 
 function getLatestEcsAmiId() {

--- a/handel/src/services/lambda/index.ts
+++ b/handel/src/services/lambda/index.ts
@@ -148,7 +148,7 @@ async function getPolicyStatementsForLambdaRole(serviceContext: ServiceContext<L
     }
     const ownPolicyStatements = JSON.parse(compiledTemplate);
 
-    return deployPhase.getAllPolicyStatementsForServiceRole(serviceContext, ownPolicyStatements, dependenciesDeployContexts, true);
+    return deployPhase.getAllPolicyStatementsForServiceRole(serviceContext, ownPolicyStatements, dependenciesDeployContexts, true, true);
 }
 
 export class Service implements ServiceDeployer {

--- a/handel/src/services/stepfunctions/index.ts
+++ b/handel/src/services/stepfunctions/index.ts
@@ -56,7 +56,7 @@ function generateDefinitionString(filename: string, dependenciesDeployContexts: 
 
 function getCompiledStepFunctionsTemplate(stackName: string, ownServiceContext: ServiceContext<StepFunctionsConfig>, dependenciesDeployContexts: DeployContext[]): Promise<string> {
     const definitionString = generateDefinitionString(ownServiceContext.params.definition, dependenciesDeployContexts);
-    const policyStatements = deployPhase.getAllPolicyStatementsForServiceRole(ownServiceContext, [], dependenciesDeployContexts, false);
+    const policyStatements = deployPhase.getAllPolicyStatementsForServiceRole(ownServiceContext, [], dependenciesDeployContexts, false, false);
     const handlebarsParams: HandlebarsStepFunctionsTemplate = {
         stateMachineName: stackName,
         definitionString,

--- a/handel/test/services/apigateway/common-test.ts
+++ b/handel/test/services/apigateway/common-test.ts
@@ -65,7 +65,7 @@ describe('apigateway common module', () => {
     describe('getPolicyStatementsForLambdaRole', () => {
         it('should return the list of policy statements for the service role', async () => {
             const statements = await common.getPolicyStatementsForLambdaRole(serviceContext, []);
-            expect(statements.length).to.equal(4);
+            expect(statements.length).to.equal(5);
         });
     });
 

--- a/handel/test/services/codedeploy/iam-roles-test.ts
+++ b/handel/test/services/codedeploy/iam-roles-test.ts
@@ -50,7 +50,7 @@ describe('codedeploy asg-launchconfig config module', () => {
             const compileTemplateStub = sandbox.stub(handlebars, 'compileTemplate').resolves('[]');
 
             const statements = await iamRoles.getStatementsForInstanceRole(serviceContext, []);
-            expect(statements.length).to.equal(3);
+            expect(statements.length).to.equal(4);
             expect(compileTemplateStub.callCount).to.equal(1);
         });
     });


### PR DESCRIPTION
This allows applications to put custom metrics (like, for example, JVM memory stats) to CloudWatch.