### PR TITLE
Fix putMetrics policy document

### DIFF
--- a/extension-support/src/common/deploy-phase.ts
+++ b/extension-support/src/common/deploy-phase.ts
@@ -179,7 +179,9 @@ export function getAllPolicyStatementsForServiceRole(serviceContext: ServiceCont
                 Action: [
                     'cloudwatch:PutMetricData'
                 ],
-                Resource: '*' // CloudWatch only allows '*' for metric permissions 🤷
+                Resource: [
+                    '*' // CloudWatch only allows '*' for metric permissions 🤷
+                ]
             }
         ];
         policyStatementsToConsume.push(...putMetricStatements);

--- a/extension-support/test/common/deploy-phase-test.ts
+++ b/extension-support/test/common/deploy-phase-test.ts
@@ -225,7 +225,9 @@ describe('Deploy phase common module', () => {
             expect(policyStatements).to.deep.include({
                 Effect: 'Allow',
                 Action: ['cloudwatch:PutMetricData'],
-                Resource: '*'
+                Resource: [
+                    '*'
+                ]
             });
         });
     });


### PR DESCRIPTION
This pull fixes an issue where the resource definition in the policy document wasn't an array which caused cloudformation to fail. 