### PR TITLE
Pin Caporal to 1.1.0

### DIFF
--- a/handel/package-lock.json
+++ b/handel/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "handel",
-	"version": "0.34.6",
+	"version": "0.35.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -570,19 +570,17 @@
 			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
 		},
 		"archiver": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
-			"integrity": "sha1-TyGU1tj5nfP1MeaIHxTxXVX6ryI=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/archiver/-/archiver-3.0.0.tgz",
+			"integrity": "sha512-5QeR6Xc5hSA9X1rbQfcuQ6VZuUXOaEdB65Dhmk9duuRJHYif/ZyJfuyJqsQrj34PFjU5emv5/MmfgA8un06onw==",
 			"requires": {
-				"archiver-utils": "^1.3.0",
+				"archiver-utils": "^2.0.0",
 				"async": "^2.0.0",
 				"buffer-crc32": "^0.2.1",
 				"glob": "^7.0.0",
-				"lodash": "^4.8.0",
 				"readable-stream": "^2.0.0",
 				"tar-stream": "^1.5.0",
-				"walkdir": "^0.0.11",
-				"zip-stream": "^1.1.0"
+				"zip-stream": "^2.0.1"
 			},
 			"dependencies": {
 				"async": {
@@ -596,15 +594,21 @@
 			}
 		},
 		"archiver-utils": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
-			"integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.0.0.tgz",
+			"integrity": "sha512-JRBgcVvDX4Mwu2RBF8bBaHcQCSxab7afsxAPYDQ5W+19quIPP5CfKE7Ql+UHs9wYvwsaNR8oDuhtf5iqrKmzww==",
 			"requires": {
 				"glob": "^7.0.0",
 				"graceful-fs": "^4.1.0",
 				"lazystream": "^1.0.0",
-				"lodash": "^4.8.0",
-				"normalize-path": "^2.0.0",
+				"lodash.assign": "^4.2.0",
+				"lodash.defaults": "^4.2.0",
+				"lodash.difference": "^4.5.0",
+				"lodash.flatten": "^4.4.0",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.toarray": "^4.4.0",
+				"lodash.union": "^4.6.0",
+				"normalize-path": "^3.0.0",
 				"readable-stream": "^2.0.0"
 			}
 		},
@@ -1234,6 +1238,16 @@
 				"crc32-stream": "^2.0.0",
 				"normalize-path": "^2.0.0",
 				"readable-stream": "^2.0.0"
+			},
+			"dependencies": {
+				"normalize-path": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+					"requires": {
+						"remove-trailing-separator": "^1.0.1"
+					}
+				}
 			}
 		},
 		"concat-map": {
@@ -2172,29 +2186,29 @@
 			"dev": true
 		},
 		"handel-extension-api": {
-			"version": "0.34.6",
-			"resolved": "https://registry.npmjs.org/handel-extension-api/-/handel-extension-api-0.34.6.tgz",
-			"integrity": "sha512-8MusKWp55i7Tqon16gGHJkzseXx/6b4AZF9g2OO8YDCgT5SbmpoTVd30Wnk6z5SCONYMwX9lj0q0WW/Bxa0pfQ=="
+			"version": "0.35.1",
+			"resolved": "https://registry.npmjs.org/handel-extension-api/-/handel-extension-api-0.35.1.tgz",
+			"integrity": "sha512-zAKqdqs/64c7Sjn6fIR+oxvcSMSy2J6rIdEcqsBlJr3UMJQaU+GDmAb4rme3oK1fscNOdZ1VWlLOyxEWBEMxxQ=="
 		},
 		"handel-extension-support": {
-			"version": "0.34.6",
-			"resolved": "https://registry.npmjs.org/handel-extension-support/-/handel-extension-support-0.34.6.tgz",
-			"integrity": "sha512-PfJ4uwg2N4t8SD6BwONBWHA4+9Cn8gqf1/+2rCfuxZ2SoyCd//6PN4KvDWLlN25AaOnf9Qf7ETzi03tjP4TyuQ==",
+			"version": "0.35.1",
+			"resolved": "https://registry.npmjs.org/handel-extension-support/-/handel-extension-support-0.35.1.tgz",
+			"integrity": "sha512-DvJgkBciLgJYgoMN5XjJCFNUQYLHwgSIRW8BElPUsoumlaGoKcTDFW/ng0SMTympRotP8WJ1eBc4Xinyr65kRw==",
 			"requires": {
 				"ajv": "^5.2.3",
-				"ajv-errors": "^1.0.0",
-				"archiver": "^1.3.0",
-				"handel-extension-api": "^0.34.6",
-				"handlebars": "^4.0.6",
+				"ajv-errors": "^1.0.1",
+				"archiver": "^3.0.0",
+				"handel-extension-api": "^0.35.1",
+				"handlebars": "^4.1.1",
 				"pascal-case": "^2.0.1",
 				"uuid": "^3.0.1",
 				"winston": "2.3.1"
 			}
 		},
 		"handlebars": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.1.tgz",
-			"integrity": "sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+			"integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
 			"requires": {
 				"neo-async": "^2.6.0",
 				"optimist": "^0.6.1",
@@ -2850,15 +2864,35 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
 			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
 		},
+		"lodash.assign": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+		},
 		"lodash.camelcase": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
 			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
 		},
+		"lodash.defaults": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+			"integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+		},
 		"lodash.difference": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
 			"integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
+		},
+		"lodash.flatten": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+		},
+		"lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
 		},
 		"lodash.kebabcase": {
 			"version": "4.1.1",
@@ -2884,6 +2918,16 @@
 			"version": "4.6.1",
 			"resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
 			"integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs="
+		},
+		"lodash.toarray": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
+			"integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE="
+		},
+		"lodash.union": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+			"integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
 		},
 		"lodash.uniq": {
 			"version": "4.5.0",
@@ -3327,9 +3371,9 @@
 			"integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M="
 		},
 		"neo-async": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
-			"integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA=="
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
 		},
 		"nested-error-stacks": {
 			"version": "2.0.1",
@@ -3379,12 +3423,9 @@
 			}
 		},
 		"normalize-path": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-			"requires": {
-				"remove-trailing-separator": "^1.0.1"
-			}
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
 		},
 		"npm-run-path": {
 			"version": "2.0.2",
@@ -5666,19 +5707,19 @@
 			"dev": true
 		},
 		"uglify-js": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.3.tgz",
-			"integrity": "sha512-rIQPT2UMDnk4jRX+w4WO84/pebU2jiLsjgIyrCktYgSvx28enOE3iYQMr+BD1rHiitWnDmpu0cY/LfIEpKcjcw==",
+			"version": "3.5.12",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.12.tgz",
+			"integrity": "sha512-KeQesOpPiZNgVwJj8Ge3P4JYbQHUdZzpx6Fahy6eKAYRSV4zhVmLXoC+JtOeYxcHCHTve8RG1ZGdTvpeOUM26Q==",
 			"optional": true,
 			"requires": {
-				"commander": "~2.19.0",
+				"commander": "~2.20.0",
 				"source-map": "~0.6.1"
 			},
 			"dependencies": {
 				"commander": {
-					"version": "2.19.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-					"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+					"version": "2.20.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+					"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
 					"optional": true
 				},
 				"source-map": {
@@ -5905,11 +5946,6 @@
 				"spdx-expression-parse": "^3.0.0"
 			}
 		},
-		"walkdir": {
-			"version": "0.0.11",
-			"resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
-			"integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI="
-		},
 		"which": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -6049,13 +6085,12 @@
 			"dev": true
 		},
 		"zip-stream": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
-			"integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-2.0.1.tgz",
+			"integrity": "sha512-c+eUhhkDpaK87G/py74wvWLtz2kzMPNCCkUApkun50ssE0oQliIQzWpTnwjB+MTKVIf2tGzIgHyqW/Y+W77ecQ==",
 			"requires": {
-				"archiver-utils": "^1.3.0",
+				"archiver-utils": "^2.0.0",
 				"compress-commons": "^1.2.0",
-				"lodash": "^4.8.0",
 				"readable-stream": "^2.0.0"
 			}
 		}

--- a/handel/package.json
+++ b/handel/package.json
@@ -21,7 +21,7 @@
     "ajv": "^5.2.3",
     "ajv-errors": "^1.0.1",
     "aws-sdk": "^2.433.0",
-    "caporal": "^1.1.0",
+    "caporal": "1.1.0",
     "child-process-es6-promise": "^1.2.1",
     "common-tags": "^1.7.2",
     "crypto-random-string": "^1.0.0",


### PR DESCRIPTION
Caporal version 1.2.0 is not working correctly at the moment. More work needs
to be done to figure out why. But in the meantime this pull will fix running
pipelines.