### PR TITLE
use rolling deploys for beanstalk, instead of the 'all at once' default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/node:6.13-stretch
+      - image: circleci/node:10
     steps:
       - checkout
       - run: npm install

--- a/handel/src/services/beanstalk/index.ts
+++ b/handel/src/services/beanstalk/index.ts
@@ -120,7 +120,7 @@ async function getCompiledBeanstalkTemplate(stackName: string, preDeployContext:
     handlebarsParams.optionSettings.push(getEbConfigurationOption('aws:autoscaling:updatepolicy:rollingupdate', 'RollingUpdateEnabled', true));
 
     // Configure rolling deploys
-    handlebarsParams.optionSettings.push(getEbConfigurationOption('aws:elasticbeanstalk:command', 'DeploymentPolicy', 'RollingWithAdditionalBatch'));
+    handlebarsParams.optionSettings.push(getEbConfigurationOption('aws:elasticbeanstalk:command', 'DeploymentPolicy', 'Rolling'));
     handlebarsParams.optionSettings.push(getEbConfigurationOption('aws:elasticbeanstalk:command', 'BatchSizeType', 'Percentage'));
     handlebarsParams.optionSettings.push(getEbConfigurationOption('aws:elasticbeanstalk:command', 'BatchSize', '25'));
 

--- a/handel/src/services/beanstalk/index.ts
+++ b/handel/src/services/beanstalk/index.ts
@@ -119,6 +119,11 @@ async function getCompiledBeanstalkTemplate(stackName: string, preDeployContext:
     // Configure rolling updates
     handlebarsParams.optionSettings.push(getEbConfigurationOption('aws:autoscaling:updatepolicy:rollingupdate', 'RollingUpdateEnabled', true));
 
+    // Configure rolling deploys
+    handlebarsParams.optionSettings.push(getEbConfigurationOption('aws:elasticbeanstalk:command', 'DeploymentPolicy', 'RollingWithAdditionalBatch'));
+    handlebarsParams.optionSettings.push(getEbConfigurationOption('aws:elasticbeanstalk:command', 'BatchSizeType', 'Percentage'));
+    handlebarsParams.optionSettings.push(getEbConfigurationOption('aws:elasticbeanstalk:command', 'BatchSize', '25'));
+
     // Configure VPC
     handlebarsParams.optionSettings.push(getEbConfigurationOption('aws:ec2:vpc', 'VPCId', accountConfig.vpc));
     handlebarsParams.optionSettings.push(getEbConfigurationOption('aws:ec2:vpc', 'Subnets', accountConfig.private_subnets.join(',')));


### PR DESCRIPTION
The all at once default takes your app offline as documented here: 
https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.rolling-version-deploy.html?shortFooter=true'

Followed the policy syntax here: 
https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html?shortFooter=true#command-options-general-elasticbeanstalkcommand