### PR TITLE
Add proper cloudwatch permissions for exporting logs

### DIFF
--- a/handel/src/services/beanstalk/beanstalk-instance-role-statements.json
+++ b/handel/src/services/beanstalk/beanstalk-instance-role-statements.json
@@ -23,12 +23,14 @@
     },
     {
         "Action": [
+            "logs:CreateLogGroup",
+            "logs:CreateLogStream",
             "logs:PutLogEvents",
-            "logs:CreateLogStream"
+            "logs:DescribeLogStreams"
         ],
         "Effect": "Allow",
         "Resource": [
-            "arn:aws:logs:*:*:log-group:/aws/elasticbeanstalk*"
+            "arn:aws:logs:*:*:*"
         ]
     },
     {


### PR DESCRIPTION
There important permissions missing from the EC2 instance role for beanstalk. Also, CloudWatch doesn't let you apply fine-grained permissions - * for everyone!