### PR TITLE
Add ECS Secret injection support

### DIFF
--- a/docs/handel-basics/accessing-secrets.rst
+++ b/docs/handel-basics/accessing-secrets.rst
@@ -10,6 +10,8 @@ Many applications have a need to securely store and access *secrets*. These secr
     
     Handel provides a different mechanism for passing secrets to your application, as explained in this document.
 
+.. _accessing-secrets-application:
+
 Application Secrets in Handel
 -----------------------------
 Handel uses the `EC2 Systems Manager Parameter Store <https://aws.amazon.com/ec2/systems-manager/parameter-store/>`_ for secrets storage. This service provides a key/value store where you can securely store secrets in a named parameter. You can then call the AWS API from your application to obtain these secrets.
@@ -44,7 +46,11 @@ This Lambda, when deployed, will be able to access any EC2 Parameter Store param
 
 .. WARNING::
 
-    Previously Handel wired permmissions based on a prefix like: ``<appName>.<environmentName>`` This functionality is being deprecated in favor of paths. As a convenience, Handel still wires the permissions and injects an environment variable called ``HANDEL_PARAMETER_STORE_PREFIX`` into your application. This variable contains the pre-built ``<appName>.<environmentName>`` prefix so that you don't have to build it yourself. Please only use prefix if required. Otherwise Path is preferred. More info can be found `Here <https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-su-organize.html>`_
+    Previously Handel wired permissions based on a prefix like: ``<appName>.<environmentName>`` This functionality is being deprecated in favor of paths. As a convenience, Handel still wires the permissions and injects an environment variable called ``HANDEL_PARAMETER_STORE_PREFIX`` into your application. This variable contains the pre-built ``<appName>.<environmentName>`` prefix so that you don't have to build it yourself. Please only use prefix if required. Otherwise Path is preferred. More info can be found `Here <https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-su-organize.html>`_
+
+    Any Handel services which add secrets to Parameter Store will, by default, create both path- and dot-style parameters.
+
+.. _accessing-secrets-global:
 
 Global Parameters
 ~~~~~~~~~~~~~~~~~

--- a/docs/handel-basics/consuming-service-dependencies.rst
+++ b/docs/handel-basics/consuming-service-dependencies.rst
@@ -62,9 +62,16 @@ Each parameter Handel puts in the parameter store has a common prefix, which is 
 
 .. code-block:: none
 
-    <app_name>.<environment_name>
+    /<app_name>/<environment_name>/
 
 You can use the :ref:`consuming-service-dependencies-common-vars` to obtain the value of this prefix.
+
+.. WARNING::
+
+    Previously Handel wired permissions based on a prefix like: ``<appName>.<environmentName>`` This functionality is being deprecated in favor of paths. As a convenience, Handel still wires the permissions and injects an environment variable called ``HANDEL_PARAMETER_STORE_PREFIX`` into your application. This variable contains the pre-built ``<appName>.<environmentName>`` prefix so that you don't have to build it yourself. Please only use prefix if required. Otherwise Path is preferred. More info can be found `Here <https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-su-organize.html>`_
+
+    Any Handel services which add secrets to Parameter Store will, by default, create both path- and dot-style parameters.
+
 
 .. _consuming-service-dependencies-common-vars:
 
@@ -83,7 +90,9 @@ In addition to environment variables injected by services your applications cons
      - This is the value of the *\<environment\>* field from your Handel file. It is the name of the environment the current service is a part of.
    * - HANDEL_SERVICE_NAME
      - This is the value of the *\<service_name>* field from your Handel file. It is the name of the currently deployed service.
-   * - HANDEL_PARAMETER_STORE_PREFIX
+   * - HANDEL_PARAMETER_STORE_PATH
      - This is the :ref:`prefix <parameter-store-prefix>` used for secrets stored in Parameter Store.
+   * - HANDEL_PARAMETER_STORE_PREFIX
+     - Deprecated. This is an old form of the :ref:`prefix <parameter-store-prefix>` used for secrets stored in Parameter Store.
    * - HANDEL_REGION_NAME
      - This is the value of the *<region_name>* field from your Handel file, or the current region if the region id not specified.

--- a/docs/supported-services/aurora-serverless.rst
+++ b/docs/supported-services/aurora-serverless.rst
@@ -165,9 +165,9 @@ In addition, the Aurora service puts the following credentials into the EC2 para
 
    * - Parameter Name 
      - Description
-   * - <parameter_prefix>.<service_name>.db_username
+   * - /<parameter_prefix>/<service_name>/db_username
      - The username for your database user.
-   * - <parameter_prefix>.<service_name>.db_password
+   * - /<parameter_prefix>/<service_name>/db_password
      - The password for your database user.
 
 .. NOTE::

--- a/docs/supported-services/aurora.rst
+++ b/docs/supported-services/aurora.rst
@@ -139,9 +139,9 @@ In addition, the Aurora service puts the following credentials into the EC2 para
 
    * - Parameter Name 
      - Description
-   * - <parameter_prefix>.<service_name>.db_username
+   * - /<parameter_prefix>/<service_name>/db_username
      - The username for your database user.
-   * - <parameter_prefix>.<service_name>.db_password
+   * - /<parameter_prefix>/<service_name>/db_password
      - The password for your database user.
 
 .. NOTE::

--- a/docs/supported-services/ecs.rst
+++ b/docs/supported-services/ecs.rst
@@ -95,6 +95,10 @@ The `containers` section is defined by the following schema:
         health_check_path: <string> # Optional. Default: /
       environment_variables: # Optional
         <string>: <string>
+      secrets:
+        <string>:
+          # either 'app:' or 'global:' - see "Secret Injection" below
+          app: my-ssm-parameter-name
 
 .. NOTE::
 
@@ -204,6 +208,60 @@ Logging
 If logging is enabled, a CloudWatch log group will be created, with a name like ecs/<appName>-<environmentName>-<serviceName>.
 Each container in the container configuration will have a log prefix matching its name. The retention time for the log
 group is set with `log_retention_in_days`, and defaults to keeping the logs indefinitely.
+
+.. _ecs-secrets:
+
+Secret Injection
+~~~~~~~~~~~~~~~~
+By default, the ECS service will inject any parameter store parameters created by your declared dependencies using
+the ECS support for `injecting values from SSM <https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html>`_.
+
+This support causes environment variables to be set on your tasks which will contain the decrypted values from SSM Parameter
+Store.
+
+For example, if your ECS service depends on an Aurora Serverless database, like in the following Handel file (abridged
+for clarity):
+
+.. code-block:: yaml
+
+    environments:
+      dev:
+        my-db:
+          type: aurora-serverless
+          # other aurora serverless settings
+        my-app:
+          type: ecs
+          dependencies:
+            - database
+          # Other ecs settings, including container configs
+
+The Aurora Serverless service will create two parameters in Parameter Store: `/<app name>/<env name>/my-db/db_username` and `/<app name>/<env name>/my-db/db_password`.
+The ECS deployer will look for any parameters with the prefix `/<app name>/<env name>/my-db/` and will cause the values to be
+injected into environment variables named `MY_DB_DB_USERNAME` and `MY_DB_DB_PASSWORD` (following the pattern `<dependency name>_<SSM parameter name>`.
+
+You can also add custom secrets to containers in your task. In each container configuration, you can add a `secrets` key:
+
+.. code-block:: yaml
+
+    environments:
+      dev:
+        my-app:
+          type: ecs
+          containers:
+            - name: mywebapp
+              secrets:
+                MY_APP_SECRET: # Name of the environment variable in which to inject the value
+                  app: my-secret # Will load the secret from /<app name>/<env name/my-secret
+                MY_GLOBAL_SECRET: # Name of the environment variable in which to inject the value
+                  global: my-secret # Will load the secret from /handel/global/my-secret
+              # Other container settings
+
+If the secret value uses the `app:` key, the secret will be resolved relative to the app-specific prefix, as described
+in :ref:`accessing-secrets-application`. If it uses the `global:` key, the secret will be resolved relative to the
+`/handel/global/` prefix, as described in :ref:`accessing-secrets-global`.
+
+If you specify a custom secret with the same environment variable name as one from a dependency, the custom secret will
+replace the auto-injected dependency secret.
 
 .. _ecs-example-handel-files:
 

--- a/docs/supported-services/mysql.rst
+++ b/docs/supported-services/mysql.rst
@@ -135,9 +135,9 @@ In addition, the MySQL service puts the following credentials into the EC2 param
 
    * - Parameter Name 
      - Description
-   * - <parameter_prefix>.<service_name>.db_username
+   * - /<parameter_prefix>/<service_name>/db_username
      - The username for your database user.
-   * - <parameter_prefix>.<service_name>.db_password
+   * - /<parameter_prefix>/<service_name>/db_password
      - The password for your database user.
 
 .. NOTE::

--- a/docs/supported-services/postgresql.rst
+++ b/docs/supported-services/postgresql.rst
@@ -134,9 +134,9 @@ In addition, the PostgreSQL service puts the following credentials into the EC2 
 
    * - Parameter Name 
      - Description
-   * - <parameter_prefix>.<service_name>.db_username
+   * - /<parameter_prefix>/<service_name>/db_username
      - The username for your database user.
-   * - <parameter_prefix>.<service_name>.db_password
+   * - /<parameter_prefix>/<service_name>/db_password
      - The password for your database user.
 
 .. NOTE::

--- a/examples/ecs-fargate/handel.yml
+++ b/examples/ecs-fargate/handel.yml
@@ -2,10 +2,30 @@ version: 1
 
 name: ecs-fargate-test
 
+tags:
+  team: test
+  data-sensitivity: public
+
 environments:
   dev:
+    database:
+      type: aurora-serverless
+      engine: mysql
+      version: 5.6.10a
+      database_name: HandelFargateTest
+      scaling:
+        min_capacity: 2
+        max_capacity: 16
+        auto_pause: true
+        seconds_until_auto_pause: 600 # 10 minutes
+      cluster_parameters: # This is where you can set parameters that configure the cluster as a whole
+        character_set_database: utf8mb4
+      tags:
+        some: tag
     webapp:
       type: ecs-fargate
+      dependencies:
+        - database
       max_mb: 1024
       cpu_units: 512
       containers:
@@ -17,6 +37,9 @@ environments:
           base_path: /
         environment_variables:
           MY_VAR: myValue
+        secrets:
+          MY_SECRET:
+            global: /test
       auto_scaling:
         min_tasks: 1
         max_tasks: 3
@@ -41,4 +64,4 @@ environments:
         timeout: 90
       log_retention_in_days: 1
       tags:
-        mytag: myvalue 
+        mytag: myvalue

--- a/examples/ecs/handel.yml
+++ b/examples/ecs/handel.yml
@@ -2,10 +2,30 @@ version: 1
 
 name: ecs-test
 
+tags:
+  team: test
+  data-sensitivity: public
+
 environments:
   dev:
+    database:
+      type: aurora-serverless
+      engine: mysql
+      version: 5.6.10a
+      database_name: HandelEcsTest
+      scaling:
+        min_capacity: 2
+        max_capacity: 16
+        auto_pause: true
+        seconds_until_auto_pause: 600 # 10 minutes
+      cluster_parameters: # This is where you can set parameters that configure the cluster as a whole
+        character_set_database: utf8mb4
+      tags:
+        some: tag
     webapp:
       type: ecs
+      dependencies:
+        - database
       containers:
       - name: ecstest
         image_name: nginx:latest
@@ -14,6 +34,9 @@ environments:
         routing:
           base_path: /
           health_check_path: /
+        secrets:
+          MY_SECRET:
+            global: test
       auto_scaling:
         min_tasks: 1
         max_tasks: 4

--- a/extension-api/extension-api.ts
+++ b/extension-api/extension-api.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
-import { EC2 } from 'aws-sdk';
+import {EC2} from 'aws-sdk';
 
 /***********************************
  * Types for the Extension contract
@@ -226,13 +226,21 @@ export interface IServiceContext<Config extends ServiceConfig> extends HasAppSer
     tags: Tags;
 
     resourceName(): string;
+
     stackName(): string;
+
     injectedEnvVars(outputs: any): any;
+
     ssmApplicationPrefix(): string;
+
     ssmParamName(suffix: string): string;
+
     ssmParamPath(suffix: string): string;
+
     allSsmParamNames(suffix: string): string[];
+
     ssmServicePath(): string;
+
     ssmServicePrefix(): string;
 }
 
@@ -265,6 +273,8 @@ export interface ServiceConfig {
     event_consumers?: ServiceEventConsumer[];
     dependencies?: string[];
 }
+
+export type InjectableSecretsServiceConfig = ServiceConfig & HasInjectableSecrets;
 
 export function isServiceConfig(obj: any): obj is ServiceConfig {
     return !!obj
@@ -315,10 +325,10 @@ export interface IDeployContext extends HasAppServiceInfo {
     // Scripts intended to be run on startup by the consuming resource.
     scripts: string[];
 
-    addEnvironmentVariables(envVars: EnvironmentVariables): void;
-
     ssmServicePath: string;
     ssmServicePrefix: string;
+
+    addEnvironmentVariables(envVars: EnvironmentVariables): void;
 }
 
 export function isDeployContext(obj: any | IDeployContext): obj is IDeployContext {
@@ -567,7 +577,7 @@ export class DeployContext implements IDeployContext {
     }
 
     public getInjectedEnvVarName(suffix: string) {
-        return `${this.serviceName}_${suffix}`.toUpperCase().replace(/-/g, '_');
+        return `${this.serviceName}_${suffix}`.toUpperCase().replace(/[-/.]/g, '_');
     }
 }
 
@@ -642,6 +652,41 @@ export class UnPreDeployContext implements IUnPreDeployContext {
 /***********************************
  * Other Types
  ***********************************/
+
+export interface HasInjectableSecrets {
+    injectSecrets: ExtraSecrets;
+}
+
+export interface ExtraSecrets {
+    [EnvName: string]: SecretSource;
+}
+
+export function isExtraSecrets(obj: any): obj is ExtraSecrets {
+    return !!obj && Object.values(obj).every(isSecretSource);
+}
+
+export type SecretSource = AppSecret | GlobalSecret;
+
+export function isSecretSource(obj: any): obj is SecretSource {
+    return isAppSecret(obj) || isGlobalSecret(obj);
+}
+
+export interface AppSecret {
+    app: string;
+}
+
+export interface GlobalSecret {
+    global: string;
+}
+
+export function isAppSecret(obj: any): obj is AppSecret {
+    return 'app' in obj;
+}
+
+export function isGlobalSecret(obj: any): obj is GlobalSecret {
+    return 'global' in obj;
+}
+
 export interface Tags {
     [key: string]: string;
 }

--- a/extension-api/package-lock.json
+++ b/extension-api/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "handel-extension-api",
-	"version": "0.36.0",
+	"version": "0.36.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/extension-api/package-lock.json
+++ b/extension-api/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "handel-extension-api",
-	"version": "0.35.6",
+	"version": "0.36.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/extension-support/package-lock.json
+++ b/extension-support/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "handel-extension-support",
-	"version": "0.36.0",
+	"version": "0.36.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1596,11 +1596,6 @@
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
-		},
-		"handel-extension-api": {
-			"version": "0.36.0",
-			"resolved": "https://registry.npmjs.org/handel-extension-api/-/handel-extension-api-0.36.0.tgz",
-			"integrity": "sha512-uWS6qUD0dqb6x50Dr9iwlDFfrovY5weG2CidG8aghhTht54OeT9Kz0kZSri9ipO8bTeGOYZhDe4XZGoejQ4Epw=="
 		},
 		"handlebars": {
 			"version": "4.1.2",

--- a/extension-support/package-lock.json
+++ b/extension-support/package-lock.json
@@ -1597,6 +1597,11 @@
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
 		},
+		"handel-extension-api": {
+			"version": "0.36.0",
+			"resolved": "https://registry.npmjs.org/handel-extension-api/-/handel-extension-api-0.36.0.tgz",
+			"integrity": "sha512-uWS6qUD0dqb6x50Dr9iwlDFfrovY5weG2CidG8aghhTht54OeT9Kz0kZSri9ipO8bTeGOYZhDe4XZGoejQ4Epw=="
+		},
 		"handlebars": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",

--- a/extension-support/package-lock.json
+++ b/extension-support/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "handel-extension-support",
-	"version": "0.35.6",
+	"version": "0.36.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1596,11 +1596,6 @@
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
-		},
-		"handel-extension-api": {
-			"version": "0.35.6",
-			"resolved": "https://registry.npmjs.org/handel-extension-api/-/handel-extension-api-0.35.6.tgz",
-			"integrity": "sha512-a6/U5uWulpobPCQ1twNrprgIU2+7jOLGQkiyZdhQu82cMDJaGexsyD6nx7DBYd2ih6UByO4V+Klna2BrmFHLlg=="
 		},
 		"handlebars": {
 			"version": "4.1.2",

--- a/extension-support/src/aws/aws-wrapper.ts
+++ b/extension-support/src/aws/aws-wrapper.ts
@@ -113,11 +113,45 @@ const awsWrapper = {
             const ssm = new AWS.SSM({ apiVersion: '2014-11-06' });
             return ssm.deleteParameters(params).promise();
         },
-        describeParameters: (params: AWS.SSM.DescribeParametersRequest): Promise<AWS.SSM.DescribeParametersResult> => {
+        describeParameters: (params: AWS.SSM.DescribeParametersRequest): Promise<AWS.SSM.ParameterMetadata[]> => {
             const ssm = new AWS.SSM({ apiVersion: '2014-11-06' });
-            return ssm.describeParameters(params).promise();
+            return nextTokenStyleList(p => ssm.describeParameters(p), params, r => r.Parameters);
+        },
+        getParametersByPath: (params: AWS.SSM.GetParametersByPathRequest): Promise<AWS.SSM.Parameter[]> => {
+            const ssm = new AWS.SSM({apiVersion: '2014-11-06'});
+            return nextTokenStyleList(p => ssm.getParametersByPath(p), params, r => r.Parameters);
+        },
+        getParameters: (params: AWS.SSM.GetParametersRequest): Promise<AWS.SSM.GetParametersResult> => {
+            const ssm = new AWS.SSM({apiVersion: '2014-11-06'});
+            return ssm.getParameters(params).promise();
         }
     }
 };
+
+async function nextTokenStyleList<P extends {NextToken?: string}, R extends {NextToken?: string}, V>(
+    fn: (params: P) => AWS.Request<R, AWS.AWSError>,
+    params: P,
+    extract: (result: R) => V[] | undefined
+): Promise<V[]> {
+    return makeCall(undefined);
+
+    async function makeCall(
+        token: string | undefined
+    ): Promise<V[]> {
+        const results = [];
+        params.NextToken = token;
+
+        const result = await fn(params).promise();
+        const extracted = extract(result);
+        if (extracted) {
+            results.push(...extracted);
+        }
+        if (result.NextToken) {
+            const next = await makeCall(result.NextToken);
+            results.push(...next);
+        }
+        return results;
+    }
+}
 
 export default awsWrapper;

--- a/extension-support/src/aws/aws-wrapper.ts
+++ b/extension-support/src/aws/aws-wrapper.ts
@@ -112,6 +112,10 @@ const awsWrapper = {
         deleteParameters: (params: AWS.SSM.DeleteParametersRequest): Promise<AWS.SSM.DeleteParametersResult> => {
             const ssm = new AWS.SSM({ apiVersion: '2014-11-06' });
             return ssm.deleteParameters(params).promise();
+        },
+        describeParameters: (params: AWS.SSM.DescribeParametersRequest): Promise<AWS.SSM.DescribeParametersResult> => {
+            const ssm = new AWS.SSM({ apiVersion: '2014-11-06' });
+            return ssm.describeParameters(params).promise();
         }
     }
 };

--- a/extension-support/src/aws/ssm-calls.ts
+++ b/extension-support/src/aws/ssm-calls.ts
@@ -38,7 +38,8 @@ export async function listParameterNamesStartingWith(...prefixes: string[]): Pro
             }
         ]
     };
-    return (await awsWrapper.ssm.describeParameters(params)).map(p => p.Name!);
+    const results = await awsWrapper.ssm.describeParameters(params);
+    return results.map(p => p.Name!);
 }
 
 export interface NameAndArn {

--- a/extension-support/src/common/check-phase.ts
+++ b/extension-support/src/common/check-phase.ts
@@ -1,6 +1,6 @@
 import * as Ajv from 'ajv';
 import * as fs from 'fs';
-import { ServiceConfig, ServiceContext } from 'handel-extension-api';
+import {ServiceConfig, ServiceContext} from 'handel-extension-api';
 
 export function checkJsonSchema(schemaPath: string, serviceContext: ServiceContext<ServiceConfig>): string[] {
     const ajv = new Ajv({allErrors: true, jsonPointers: true});
@@ -8,26 +8,24 @@ export function checkJsonSchema(schemaPath: string, serviceContext: ServiceConte
     let schema;
     try {
         schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
-    }
-    catch (e) {
+    } catch (e) {
         return [`Couldn't read schema file to check the service schema`];
     }
     const valid = ajv.validate(schema, serviceContext.params);
     if (!valid) {
         return ajv.errors!.map(error => {
             const errorParams = error.params as any; // The types don't seem to be right on AJV when using AJV-errors, so we cast it to any here
-            const additionalPropsErrors = errorParams.errors.filter((errorParam: any) => errorParam.keyword === 'additionalProperties');
-            if(additionalPropsErrors.length > 0) { // Special error message for the 'additionalProps' error to make it more understandable
-                const additionalPropsError = additionalPropsErrors[0];
-                return `Invalid property '${error.dataPath}/${additionalPropsError.params.additionalProperty}' specified. Make sure to check your spelling!`;
+            if (!!errorParams.errors) {
+                const additionalPropsErrors = errorParams.errors.filter((errorParam: any) => errorParam.keyword === 'additionalProperties');
+                if (additionalPropsErrors.length > 0) { // Special error message for the 'additionalProps' error to make it more understandable
+                    const additionalPropsError = additionalPropsErrors[0];
+                    return `Invalid property '${error.dataPath}/${additionalPropsError.params.additionalProperty}' specified. Make sure to check your spelling!`;
+                }
             }
-            else {
-                const dataPath = error.dataPath || '/';
-                return `Error at path '${dataPath}': ${error.message}`;
-            }
+            const dataPath = error.dataPath || '/';
+            return `Error at path '${dataPath}': ${error.message}`;
         });
-    }
-    else {
+    } else {
         return [];
     }
 }

--- a/extension-support/src/common/deploy-phase.ts
+++ b/extension-support/src/common/deploy-phase.ts
@@ -131,7 +131,8 @@ export function getAllPolicyStatementsForServiceRole(serviceContext: ServiceCont
 
     if (includeAppSecretsStatements) {
         const applicationParameters = `arn:aws:ssm:${serviceContext.accountConfig.region}:${serviceContext.accountConfig.account_id}:parameter/${serviceContext.ssmApplicationPrefix()}.*`;
-        const applicationParametersPath = `arn:aws:ssm:${serviceContext.accountConfig.region}:${serviceContext.accountConfig.account_id}:parameter/${serviceContext.ssmApplicationPath()}*`;
+        const applicationParametersPath = `arn:aws:ssm:${serviceContext.accountConfig.region}:${serviceContext.accountConfig.account_id}:parameter/${serviceContext.ssmApplicationPath()}*`
+            .replace(/\/+/g, '/');
         const appSecretsAcessStatements = [
             {
                 Effect: 'Allow',
@@ -153,7 +154,7 @@ export function getAllPolicyStatementsForServiceRole(serviceContext: ServiceCont
                     applicationParameters,
                     applicationParametersPath,
                     `arn:aws:ssm:${serviceContext.accountConfig.region}:${serviceContext.accountConfig.account_id}:parameter/handel/global/*`,
-                    `arn:aws:ssm:${serviceContext.accountConfig.region}:${serviceContext.accountConfig.account_id}:parameter/handel.global*`
+                    `arn:aws:ssm:${serviceContext.accountConfig.region}:${serviceContext.accountConfig.account_id}:parameter/handel.global.*`
                 ]
             },
             {

--- a/extension-support/src/common/deploy-phase.ts
+++ b/extension-support/src/common/deploy-phase.ts
@@ -39,13 +39,11 @@ export async function deployCloudFormationStack(serviceContext: ServiceContext<S
     if (!stack) {
         const s3ObjectData = await uploadCFTemplateToHandelBucket(serviceContext, cfTemplate);
         return cloudFormationCalls.createStack(stackName, s3ObjectData.Location, cfParameters, timeoutInMinutes, stackTags);
-    }
-    else {
+    } else {
         if (updatesSupported) {
             const s3ObjectData = await uploadCFTemplateToHandelBucket(serviceContext, cfTemplate);
             return cloudFormationCalls.updateStack(stackName, s3ObjectData.Location, cfParameters, stackTags);
-        }
-        else { // Updates not supported, so just return stack
+        } else { // Updates not supported, so just return stack
             return stack;
         }
     }
@@ -111,8 +109,7 @@ export async function uploadDeployableArtifactToHandelBucket(serviceContext: Ser
     const artifactPrefix = getServiceUploadLocation(serviceContext);
     if (fileStats.isDirectory()) { // Zip up artifact and upload it
         return uploadDirectoryToHandelBucket(pathToArtifact, artifactPrefix, s3FileName, accountConfig);
-    }
-    else { // Is file (i.e. WAR file or some other already-compiled archive), just upload directly
+    } else { // Is file (i.e. WAR file or some other already-compiled archive), just upload directly
         return uploadFileToHandelBucket(pathToArtifact, artifactPrefix, s3FileName, accountConfig);
     }
 }
@@ -133,8 +130,8 @@ export function getAllPolicyStatementsForServiceRole(serviceContext: ServiceCont
     }
 
     if (includeAppSecretsStatements) {
-        const applicationParameters = `arn:aws:ssm:${serviceContext.accountConfig.region}:${serviceContext.accountConfig.account_id}:parameter/${serviceContext.appName}.${serviceContext.environmentName}*`;
-        const applicationParametersPath = `arn:aws:ssm:${serviceContext.accountConfig.region}:${serviceContext.accountConfig.account_id}:parameter/${serviceContext.appName}/${serviceContext.environmentName}/*`;
+        const applicationParameters = `arn:aws:ssm:${serviceContext.accountConfig.region}:${serviceContext.accountConfig.account_id}:parameter/${serviceContext.ssmApplicationPrefix()}.*`;
+        const applicationParametersPath = `arn:aws:ssm:${serviceContext.accountConfig.region}:${serviceContext.accountConfig.account_id}:parameter/${serviceContext.ssmApplicationPath()}*`;
         const appSecretsAcessStatements = [
             {
                 Effect: 'Allow',
@@ -155,6 +152,7 @@ export function getAllPolicyStatementsForServiceRole(serviceContext: ServiceCont
                 Resource: [
                     applicationParameters,
                     applicationParametersPath,
+                    `arn:aws:ssm:${serviceContext.accountConfig.region}:${serviceContext.accountConfig.account_id}:parameter/handel/global/*`,
                     `arn:aws:ssm:${serviceContext.accountConfig.region}:${serviceContext.accountConfig.account_id}:parameter/handel.global*`
                 ]
             },
@@ -202,23 +200,13 @@ export async function addItemToSSMParameterStore(ownServiceContext: ServiceConte
     return true;
 }
 
-export async function getSSMParameterNamesFor(deployContext: DeployContext): Promise<string[]> {
-    return ssmCalls.listParameterNamesStartingWith(
-        deployContext.ssmServicePath, deployContext.ssmServicePrefix + '.'
-    );
-}
-
 // ------------------------------------------------------------------------------
 // Private functions
 // ------------------------------------------------------------------------------
 function getEnvVarsFromDependencyDeployContexts(deployContexts: DeployContext[]): EnvironmentVariables {
     const envVars: EnvironmentVariables = {};
     for (const deployContext of deployContexts) {
-        for (const envVarKey in deployContext.environmentVariables) {
-            if (deployContext.environmentVariables.hasOwnProperty(envVarKey)) {
-                envVars[envVarKey] = deployContext.environmentVariables[envVarKey];
-            }
-        }
+        Object.assign(envVars, deployContext.environmentVariables);
     }
     return envVars;
 }

--- a/extension-support/src/common/deploy-phase.ts
+++ b/extension-support/src/common/deploy-phase.ts
@@ -192,9 +192,20 @@ export function getAllPolicyStatementsForServiceRole(serviceContext: ServiceCont
 }
 
 export async function addItemToSSMParameterStore(ownServiceContext: ServiceContext<ServiceConfig>, paramName: string, paramValue: string): Promise<boolean> {
-    const fullParamName = ownServiceContext.ssmParamName(paramName);
-    await ssmCalls.storeParameter(fullParamName, 'SecureString', paramValue);
+    const promises = ownServiceContext.allSsmParamNames(paramName)
+        .map(it => {
+            ssmCalls.storeParameter(it, 'SecureString', paramValue);
+        });
+
+    await Promise.all(promises);
+
     return true;
+}
+
+export async function getSSMParameterNamesFor(deployContext: DeployContext): Promise<string[]> {
+    return ssmCalls.listParameterNamesStartingWith(
+        deployContext.ssmServicePath, deployContext.ssmServicePrefix + '.'
+    );
 }
 
 // ------------------------------------------------------------------------------

--- a/extension-support/src/extension-support.ts
+++ b/extension-support/src/extension-support.ts
@@ -2,6 +2,7 @@ import * as awsTags from './aws/aws-tags';
 import * as cloudFormationCalls from './aws/cloudformation-calls';
 import * as ec2Calls from './aws/ec2-calls';
 import * as s3Calls from './aws/s3-calls';
+import * as ssmCalls from './aws/ssm-calls';
 import * as bindPhaseModule from './common/bind-phase';
 import * as checkPhaseModule from './common/check-phase';
 import * as deletePhasesModule from './common/delete-phases';
@@ -22,7 +23,8 @@ export const awsCalls = {
     cloudFormation: cloudFormationCalls,
     ec2: ec2Calls,
     s3: s3Calls,
-    tags: awsTags
+    tags: awsTags,
+    ssm: ssmCalls
 };
 
 export const handlebars = handlebarsUtils;

--- a/extension-support/test/aws/ssm-calls-test.ts
+++ b/extension-support/test/aws/ssm-calls-test.ts
@@ -53,7 +53,7 @@ describe('ssmCalls module', () => {
 
     describe('listParameterNamesStartingWith', () => {
         it('makes a request to SSM with the correct filters', async () => {
-            const stub = sandbox.stub(awsWrapper.ssm, 'describeParameters').resolves({});
+            const stub = sandbox.stub(awsWrapper.ssm, 'describeParameters').resolves([]);
 
             await ssmCalls.listParameterNamesStartingWith('/foobar/', 'foo.bar.');
 
@@ -67,36 +67,14 @@ describe('ssmCalls module', () => {
             }]);
         });
         it('extracts the names from the results', async () => {
-            const stub = sandbox.stub(awsWrapper.ssm, 'describeParameters').resolves({
-                Parameters: [
-                    {Name: '/foo/bar/baz'},
-                    {Name: 'foo.bar.baz'}
-                ]
-            });
+            const stub = sandbox.stub(awsWrapper.ssm, 'describeParameters').resolves([
+                {Name: '/foo/bar/baz'},
+                {Name: 'foo.bar.baz'}
+            ]);
 
             const result = await ssmCalls.listParameterNamesStartingWith('/foo/bar/', 'foo.bar.');
 
             expect(result).to.have.members(['/foo/bar/baz', 'foo.bar.baz']);
-        });
-        it('handles paged results properly', async () => {
-            const stub = sandbox.stub(awsWrapper.ssm, 'describeParameters')
-                .onFirstCall().resolves({
-                    Parameters: [
-                        {Name: '/foo/bar/baz'},
-                        {Name: 'foo.bar.baz'}
-                    ],
-                    NextToken: 'aabbcc'
-                })
-                .onSecondCall().resolves({
-                    Parameters: [
-                        {Name: '/foo/bar/baz2'},
-                        {Name: 'foo.bar.baz2'}
-                    ]
-                });
-
-            const result = await ssmCalls.listParameterNamesStartingWith('/foo/bar/', 'foo.bar.');
-
-            expect(result).to.have.members(['/foo/bar/baz', 'foo.bar.baz', '/foo/bar/baz2', 'foo.bar.baz2']);
         });
     });
 });

--- a/extension-support/test/aws/ssm-calls-test.ts
+++ b/extension-support/test/aws/ssm-calls-test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
-import { expect } from 'chai';
+import {expect} from 'chai';
 import 'mocha';
 import * as sinon from 'sinon';
 import awsWrapper from '../../src/aws/aws-wrapper';
@@ -48,6 +48,55 @@ describe('ssmCalls module', () => {
             const success = await ssmCalls.deleteParameters(['Param1', 'Param1']);
             expect(success).to.equal(true);
             expect(deleteParameterStub.callCount).to.equal(2);
+        });
+    });
+
+    describe('listParameterNamesStartingWith', () => {
+        it('makes a request to SSM with the correct filters', async () => {
+            const stub = sandbox.stub(awsWrapper.ssm, 'describeParameters').resolves({});
+
+            await ssmCalls.listParameterNamesStartingWith('/foobar/', 'foo.bar.');
+
+            const actualReq: AWS.SSM.DescribeParametersRequest = stub.firstCall.args[0];
+
+            expect(actualReq.ParameterFilters).to.exist
+                .and.to.eql([{
+                Key: 'Name',
+                Option: 'BeginsWith',
+                Values: ['/foobar/', 'foo.bar.']
+            }]);
+        });
+        it('extracts the names from the results', async () => {
+            const stub = sandbox.stub(awsWrapper.ssm, 'describeParameters').resolves({
+                Parameters: [
+                    {Name: '/foo/bar/baz'},
+                    {Name: 'foo.bar.baz'}
+                ]
+            });
+
+            const result = await ssmCalls.listParameterNamesStartingWith('/foo/bar/', 'foo.bar.');
+
+            expect(result).to.have.members(['/foo/bar/baz', 'foo.bar.baz']);
+        });
+        it('handles paged results properly', async () => {
+            const stub = sandbox.stub(awsWrapper.ssm, 'describeParameters')
+                .onFirstCall().resolves({
+                    Parameters: [
+                        {Name: '/foo/bar/baz'},
+                        {Name: 'foo.bar.baz'}
+                    ],
+                    NextToken: 'aabbcc'
+                })
+                .onSecondCall().resolves({
+                    Parameters: [
+                        {Name: '/foo/bar/baz2'},
+                        {Name: 'foo.bar.baz2'}
+                    ]
+                });
+
+            const result = await ssmCalls.listParameterNamesStartingWith('/foo/bar/', 'foo.bar.');
+
+            expect(result).to.have.members(['/foo/bar/baz', 'foo.bar.baz', '/foo/bar/baz2', 'foo.bar.baz2']);
         });
     });
 });

--- a/extension-support/test/common/deploy-phase-test.ts
+++ b/extension-support/test/common/deploy-phase-test.ts
@@ -192,9 +192,10 @@ describe('Deploy phase common module', () => {
 
             const policyStatements = deployPhase.getAllPolicyStatementsForServiceRole(serviceContext, ownServicePolicyStatements, dependenciesDeployContexts, true);
             expect(policyStatements.length).to.equal(5); // 2 of our own, plus 3 for the app secrets
-            expect(policyStatements[3].Resource[0]).to.contain(`parameter/${appName}.${envName}*`);
+            expect(policyStatements[3].Resource[0]).to.contain(`parameter/${appName}.${envName}.*`);
             expect(policyStatements[3].Resource[1]).to.contain(`parameter/${appName}/${envName}/*`);
-            expect(policyStatements[3].Resource[2]).to.contain(`parameter/handel.global*`);
+            expect(policyStatements[3].Resource[2]).to.contain(`parameter/handel/global/*`);
+            expect(policyStatements[3].Resource[3]).to.contain(`parameter/handel.global.*`);
         });
         it('should optionally include permissions to put and get cloudwatch metrics', async () => {
             const ownServicePolicyStatements = [{
@@ -246,30 +247,6 @@ describe('Deploy phase common module', () => {
             );
             expect(actualTypes).to.eql(['SecureString', 'SecureString']);
             expect(actualValues).to.eql(['FakeUsername', 'FakeUsername']);
-        });
-    });
-
-    describe('getSSMParameterNamesFor', () => {
-        const dependencyServiceContext = new ServiceContext<ServiceConfig>('fakeApp', 'fakeEnv', 'fakeService', new ServiceType('someExtension', 'db'), {type: 'db'}, accountConfig);
-        const dependencyDeployContext = new DeployContext(dependencyServiceContext);
-        it('Tries to get both path and \'.\' - style params', async () => {
-            const listStub = sandbox.stub(ssmCalls, 'listParameterNamesStartingWith')
-                .resolves([]);
-
-            await deployPhase.getSSMParameterNamesFor(dependencyDeployContext);
-
-            expect(listStub.firstCall.args).has.members([
-                'fakeApp.fakeEnv.fakeService.',
-                '/fakeApp/fakeEnv/fakeService/'
-            ]);
-        });
-        it('Returns the results of the SSM lookup', async () => {
-            sandbox.stub(ssmCalls, 'listParameterNamesStartingWith')
-                .resolves(['/fakeApp/fakeEnv/fakeService/foo', 'fakeApp.fakeEnv.fakeService.foo']);
-
-            const result = await deployPhase.getSSMParameterNamesFor(dependencyDeployContext);
-
-            expect(result).has.members(['/fakeApp/fakeEnv/fakeService/foo', 'fakeApp.fakeEnv.fakeService.foo']);
         });
     });
 

--- a/handel/package-lock.json
+++ b/handel/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "handel",
-	"version": "0.35.6",
+	"version": "0.36.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -570,95 +570,6 @@
 				"default-require-extensions": "^2.0.0"
 			}
 		},
-		"archiver": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/archiver/-/archiver-3.1.0.tgz",
-			"integrity": "sha512-FXYAX8Eso99q0c/Kaby/P4HxGdzwLzTxjTq7WL7dKk3FQkqAdZROmji67Xdn9C2SAXJBH5kqFQeL3UEXVDvWqw==",
-			"requires": {
-				"archiver-utils": "^2.1.0",
-				"async": "^2.6.3",
-				"buffer-crc32": "^0.2.1",
-				"glob": "^7.1.4",
-				"readable-stream": "^3.4.0",
-				"tar-stream": "^2.1.0",
-				"zip-stream": "^2.1.1"
-			},
-			"dependencies": {
-				"async": {
-					"version": "2.6.3",
-					"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-					"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-					"requires": {
-						"lodash": "^4.17.14"
-					}
-				},
-				"glob": {
-					"version": "7.1.4",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-				},
-				"readable-stream": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				}
-			}
-		},
-		"archiver-utils": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
-			"integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
-			"requires": {
-				"glob": "^7.1.4",
-				"graceful-fs": "^4.2.0",
-				"lazystream": "^1.0.0",
-				"lodash.defaults": "^4.2.0",
-				"lodash.difference": "^4.5.0",
-				"lodash.flatten": "^4.4.0",
-				"lodash.isplainobject": "^4.0.6",
-				"lodash.union": "^4.6.0",
-				"normalize-path": "^3.0.0",
-				"readable-stream": "^2.0.0"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "7.1.4",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-					"integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
-				}
-			}
-		},
 		"archy": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
@@ -781,7 +692,8 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
 		},
 		"base": {
 			"version": "0.11.2",
@@ -842,26 +754,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
 			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
-		},
-		"bl": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
-			"integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
-			"requires": {
-				"readable-stream": "^3.0.1"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				}
-			}
 		},
 		"bluebird": {
 			"version": "3.5.3",
@@ -949,6 +841,7 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -998,11 +891,6 @@
 				"ieee754": "^1.1.4",
 				"isarray": "^1.0.0"
 			}
-		},
-		"buffer-crc32": {
-			"version": "0.2.13",
-			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
 		},
 		"buffer-from": {
 			"version": "1.1.1",
@@ -1084,15 +972,6 @@
 			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
 			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
 			"dev": true
-		},
-		"camel-case": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
-			"integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
-			"requires": {
-				"no-case": "^2.2.0",
-				"upper-case": "^1.1.1"
-			}
 		},
 		"camelcase": {
 			"version": "4.1.0",
@@ -1355,21 +1234,11 @@
 			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
 			"dev": true
 		},
-		"compress-commons": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-2.1.0.tgz",
-			"integrity": "sha512-H6DhMQxI7NpvOGAjjop90bIOsGIZ8O1ewdKuS6ZTlnFA4YMpIhyajc+8fyEz4Em0c3iLjkOVfPJ+wtvy3RksQA==",
-			"requires": {
-				"buffer-crc32": "^0.2.13",
-				"crc32-stream": "^3.0.0",
-				"normalize-path": "^3.0.0",
-				"readable-stream": "^2.3.6"
-			}
-		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"concat-stream": {
 			"version": "1.6.2",
@@ -1449,46 +1318,6 @@
 			"requires": {
 				"cpy": "^7.0.0",
 				"meow": "^5.0.0"
-			}
-		},
-		"crc": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
-			"integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
-			"requires": {
-				"buffer": "^5.1.0"
-			},
-			"dependencies": {
-				"buffer": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
-					"integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4"
-					}
-				}
-			}
-		},
-		"crc32-stream": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-3.0.1.tgz",
-			"integrity": "sha512-mctvpXlbzsvK+6z8kJwSJ5crm7yBwrQMTybJzMw1O4lLGJqjlDCXY2Zw7KheiA6XBEcBmfLx1D88mjRGVJtY9w==",
-			"requires": {
-				"crc": "^3.4.4",
-				"readable-stream": "^3.4.0"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				}
 			}
 		},
 		"create-error-class": {
@@ -1891,6 +1720,7 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
 			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
 			}
@@ -2244,11 +2074,6 @@
 				"map-cache": "^0.2.2"
 			}
 		},
-		"fs-constants": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
-		},
 		"fs-extra": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
@@ -2262,7 +2087,8 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
 		},
 		"gauge": {
 			"version": "1.2.7",
@@ -2407,30 +2233,11 @@
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
 		},
-		"handel-extension-api": {
-			"version": "0.35.6",
-			"resolved": "https://registry.npmjs.org/handel-extension-api/-/handel-extension-api-0.35.6.tgz",
-			"integrity": "sha512-a6/U5uWulpobPCQ1twNrprgIU2+7jOLGQkiyZdhQu82cMDJaGexsyD6nx7DBYd2ih6UByO4V+Klna2BrmFHLlg=="
-		},
-		"handel-extension-support": {
-			"version": "0.35.6",
-			"resolved": "https://registry.npmjs.org/handel-extension-support/-/handel-extension-support-0.35.6.tgz",
-			"integrity": "sha512-NbY0QWtRCG4J8fLTNtSugfXYUMivn2O5Px2AWd5/jwS0uo+Gp1nX4l4sCiEbp+9BlbwRDD3t7iCxKetwcpQuCw==",
-			"requires": {
-				"ajv": "^5.2.3",
-				"ajv-errors": "^1.0.1",
-				"archiver": "^3.0.0",
-				"handel-extension-api": "^0.35.6",
-				"handlebars": "^4.1.2",
-				"pascal-case": "^2.0.1",
-				"uuid": "^3.0.1",
-				"winston": "2.3.1"
-			}
-		},
 		"handlebars": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
 			"integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+			"dev": true,
 			"requires": {
 				"neo-async": "^2.6.0",
 				"optimist": "^0.6.1",
@@ -2441,7 +2248,8 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
 				}
 			}
 		},
@@ -2566,6 +2374,7 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -3211,14 +3020,6 @@
 				"package-json": "^4.0.0"
 			}
 		},
-		"lazystream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
-			"integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
-			"requires": {
-				"readable-stream": "^2.0.5"
-			}
-		},
 		"lcid": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
@@ -3260,31 +3061,16 @@
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
 			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
 		},
-		"lodash.defaults": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-			"integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
-		},
 		"lodash.difference": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
 			"integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
-		},
-		"lodash.flatten": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
 		},
 		"lodash.flattendeep": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
 			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
 			"dev": true
-		},
-		"lodash.isplainobject": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
 		},
 		"lodash.kebabcase": {
 			"version": "4.1.1",
@@ -3311,11 +3097,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
 			"integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs="
 		},
-		"lodash.union": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
-			"integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
-		},
 		"lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -3336,11 +3117,6 @@
 				"currently-unhandled": "^0.4.1",
 				"signal-exit": "^3.0.0"
 			}
-		},
-		"lower-case": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
 		},
 		"lowercase-keys": {
 			"version": "1.0.1",
@@ -3674,6 +3450,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -3805,7 +3582,8 @@
 		"neo-async": {
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
+			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+			"dev": true
 		},
 		"nested-error-stacks": {
 			"version": "2.0.1",
@@ -3832,14 +3610,6 @@
 				"path-to-regexp": "^1.7.0"
 			}
 		},
-		"no-case": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
-			"integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
-			"requires": {
-				"lower-case": "^1.1.1"
-			}
-		},
 		"normalize-package-data": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -3851,11 +3621,6 @@
 				"semver": "2 || 3 || 4 || 5",
 				"validate-npm-package-license": "^3.0.1"
 			}
-		},
-		"normalize-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
 		},
 		"npm-run-path": {
 			"version": "2.0.2",
@@ -4091,6 +3856,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -4104,6 +3870,7 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+			"dev": true,
 			"requires": {
 				"minimist": "~0.0.1",
 				"wordwrap": "~0.0.2"
@@ -4112,7 +3879,8 @@
 				"minimist": {
 					"version": "0.0.10",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+					"dev": true
 				}
 			}
 		},
@@ -4278,15 +4046,6 @@
 			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
 			"dev": true
 		},
-		"pascal-case": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.1.tgz",
-			"integrity": "sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=",
-			"requires": {
-				"camel-case": "^3.0.0",
-				"upper-case-first": "^1.1.0"
-			}
-		},
 		"pascalcase": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -4308,7 +4067,8 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
@@ -5182,30 +4942,6 @@
 				}
 			}
 		},
-		"tar-stream": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.0.tgz",
-			"integrity": "sha512-+DAn4Nb4+gz6WZigRzKEZl1QuJVOLtAwwF+WUxy1fJ6X63CaGaUAxJRD2KEn1OMfcbCjySTYpNC6WmfQoIEOdw==",
-			"requires": {
-				"bl": "^3.0.0",
-				"end-of-stream": "^1.4.1",
-				"fs-constants": "^1.0.0",
-				"inherits": "^2.0.3",
-				"readable-stream": "^3.1.1"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				}
-			}
-		},
 		"term-size": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
@@ -5522,6 +5258,7 @@
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
 			"integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"commander": "~2.20.0",
@@ -5532,12 +5269,14 @@
 					"version": "2.20.0",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
 					"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+					"dev": true,
 					"optional": true
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true,
 					"optional": true
 				}
 			}
@@ -5661,19 +5400,6 @@
 						"has-flag": "^3.0.0"
 					}
 				}
-			}
-		},
-		"upper-case": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
-			"integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
-		},
-		"upper-case-first": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
-			"integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
-			"requires": {
-				"upper-case": "^1.1.1"
 			}
 		},
 		"urix": {
@@ -5815,7 +5541,8 @@
 		"wordwrap": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+			"dev": true
 		},
 		"wrap-ansi": {
 			"version": "5.1.0",
@@ -5868,7 +5595,8 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		},
 		"write-file-atomic": {
 			"version": "2.3.0",
@@ -6033,28 +5761,6 @@
 			"resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
 			"integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
 			"dev": true
-		},
-		"zip-stream": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-2.1.1.tgz",
-			"integrity": "sha512-v54puzKSjCN5COeMZizwIfGh9vJ6V1GR8BiRgr5Y9zZ9VngzRt8EmZHsbzCb5ktZT1JqHlt9xuN2HRv634SRPw==",
-			"requires": {
-				"archiver-utils": "^2.1.0",
-				"compress-commons": "^2.1.0",
-				"readable-stream": "^3.4.0"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				}
-			}
 		}
 	}
 }

--- a/handel/package-lock.json
+++ b/handel/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "handel",
-	"version": "0.36.0",
+	"version": "0.36.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -570,90 +570,6 @@
 				"default-require-extensions": "^2.0.0"
 			}
 		},
-		"archiver": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/archiver/-/archiver-3.1.1.tgz",
-			"integrity": "sha512-5Hxxcig7gw5Jod/8Gq0OneVgLYET+oNHcxgWItq4TbhOzRLKNAFUb9edAftiMKXvXfCB0vbGrJdZDNq0dWMsxg==",
-			"requires": {
-				"archiver-utils": "^2.1.0",
-				"async": "^2.6.3",
-				"buffer-crc32": "^0.2.1",
-				"glob": "^7.1.4",
-				"readable-stream": "^3.4.0",
-				"tar-stream": "^2.1.0",
-				"zip-stream": "^2.1.2"
-			},
-			"dependencies": {
-				"async": {
-					"version": "2.6.3",
-					"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-					"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-					"requires": {
-						"lodash": "^4.17.14"
-					}
-				},
-				"glob": {
-					"version": "7.1.4",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"readable-stream": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				}
-			}
-		},
-		"archiver-utils": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
-			"integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
-			"requires": {
-				"glob": "^7.1.4",
-				"graceful-fs": "^4.2.0",
-				"lazystream": "^1.0.0",
-				"lodash.defaults": "^4.2.0",
-				"lodash.difference": "^4.5.0",
-				"lodash.flatten": "^4.4.0",
-				"lodash.isplainobject": "^4.0.6",
-				"lodash.union": "^4.6.0",
-				"normalize-path": "^3.0.0",
-				"readable-stream": "^2.0.0"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "7.1.4",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.2.2",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
-					"integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q=="
-				}
-			}
-		},
 		"archy": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
@@ -776,7 +692,8 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
 		},
 		"base": {
 			"version": "0.11.2",
@@ -837,26 +754,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
 			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
-		},
-		"bl": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
-			"integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
-			"requires": {
-				"readable-stream": "^3.0.1"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				}
-			}
 		},
 		"bluebird": {
 			"version": "3.5.3",
@@ -944,6 +841,7 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -993,11 +891,6 @@
 				"ieee754": "^1.1.4",
 				"isarray": "^1.0.0"
 			}
-		},
-		"buffer-crc32": {
-			"version": "0.2.13",
-			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
 		},
 		"buffer-from": {
 			"version": "1.1.1",
@@ -1079,15 +972,6 @@
 			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
 			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
 			"dev": true
-		},
-		"camel-case": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
-			"integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
-			"requires": {
-				"no-case": "^2.2.0",
-				"upper-case": "^1.1.1"
-			}
 		},
 		"camelcase": {
 			"version": "4.1.0",
@@ -1350,21 +1234,11 @@
 			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
 			"dev": true
 		},
-		"compress-commons": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-2.1.1.tgz",
-			"integrity": "sha512-eVw6n7CnEMFzc3duyFVrQEuY1BlHR3rYsSztyG32ibGMW722i3C6IizEGMFmfMU+A+fALvBIwxN3czffTcdA+Q==",
-			"requires": {
-				"buffer-crc32": "^0.2.13",
-				"crc32-stream": "^3.0.1",
-				"normalize-path": "^3.0.0",
-				"readable-stream": "^2.3.6"
-			}
-		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"concat-stream": {
 			"version": "1.6.2",
@@ -1444,46 +1318,6 @@
 			"requires": {
 				"cpy": "^7.0.0",
 				"meow": "^5.0.0"
-			}
-		},
-		"crc": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
-			"integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
-			"requires": {
-				"buffer": "^5.1.0"
-			},
-			"dependencies": {
-				"buffer": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.0.tgz",
-					"integrity": "sha512-Xpgy0IwHK2N01ncykXTy6FpCWuM+CJSHoPVBLyNqyrWxsedpLvwsYUhf0ME3WRFNUhos0dMamz9cOS/xRDtU5g==",
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4"
-					}
-				}
-			}
-		},
-		"crc32-stream": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-3.0.1.tgz",
-			"integrity": "sha512-mctvpXlbzsvK+6z8kJwSJ5crm7yBwrQMTybJzMw1O4lLGJqjlDCXY2Zw7KheiA6XBEcBmfLx1D88mjRGVJtY9w==",
-			"requires": {
-				"crc": "^3.4.4",
-				"readable-stream": "^3.4.0"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				}
 			}
 		},
 		"create-error-class": {
@@ -1886,6 +1720,7 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
 			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
 			}
@@ -2239,11 +2074,6 @@
 				"map-cache": "^0.2.2"
 			}
 		},
-		"fs-constants": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
-		},
 		"fs-extra": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
@@ -2257,7 +2087,8 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
 		},
 		"gauge": {
 			"version": "1.2.7",
@@ -2402,30 +2233,11 @@
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
 		},
-		"handel-extension-api": {
-			"version": "0.36.0",
-			"resolved": "https://registry.npmjs.org/handel-extension-api/-/handel-extension-api-0.36.0.tgz",
-			"integrity": "sha512-uWS6qUD0dqb6x50Dr9iwlDFfrovY5weG2CidG8aghhTht54OeT9Kz0kZSri9ipO8bTeGOYZhDe4XZGoejQ4Epw=="
-		},
-		"handel-extension-support": {
-			"version": "0.36.0",
-			"resolved": "https://registry.npmjs.org/handel-extension-support/-/handel-extension-support-0.36.0.tgz",
-			"integrity": "sha512-5SLZ5Q6RF8mOIh63+jND0b9/FbFJl5lvXZEbU6FWNqKBANETCkJK2SxM8UCnpEzOHX8gIxfnozUij1imHhTyYA==",
-			"requires": {
-				"ajv": "^5.2.3",
-				"ajv-errors": "^1.0.1",
-				"archiver": "^3.1.0",
-				"handel-extension-api": "^0.36.0",
-				"handlebars": "^4.1.2",
-				"pascal-case": "^2.0.1",
-				"uuid": "^3.0.1",
-				"winston": "2.3.1"
-			}
-		},
 		"handlebars": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
 			"integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+			"dev": true,
 			"requires": {
 				"neo-async": "^2.6.0",
 				"optimist": "^0.6.1",
@@ -2436,7 +2248,8 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
 				}
 			}
 		},
@@ -2561,6 +2374,7 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -3206,14 +3020,6 @@
 				"package-json": "^4.0.0"
 			}
 		},
-		"lazystream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
-			"integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
-			"requires": {
-				"readable-stream": "^2.0.5"
-			}
-		},
 		"lcid": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
@@ -3255,31 +3061,16 @@
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
 			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
 		},
-		"lodash.defaults": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-			"integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
-		},
 		"lodash.difference": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
 			"integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
-		},
-		"lodash.flatten": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
 		},
 		"lodash.flattendeep": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
 			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
 			"dev": true
-		},
-		"lodash.isplainobject": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
 		},
 		"lodash.kebabcase": {
 			"version": "4.1.1",
@@ -3306,11 +3097,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
 			"integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs="
 		},
-		"lodash.union": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
-			"integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
-		},
 		"lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -3331,11 +3117,6 @@
 				"currently-unhandled": "^0.4.1",
 				"signal-exit": "^3.0.0"
 			}
-		},
-		"lower-case": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
 		},
 		"lowercase-keys": {
 			"version": "1.0.1",
@@ -3669,6 +3450,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -3800,7 +3582,8 @@
 		"neo-async": {
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
+			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+			"dev": true
 		},
 		"nested-error-stacks": {
 			"version": "2.0.1",
@@ -3827,14 +3610,6 @@
 				"path-to-regexp": "^1.7.0"
 			}
 		},
-		"no-case": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
-			"integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
-			"requires": {
-				"lower-case": "^1.1.1"
-			}
-		},
 		"normalize-package-data": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -3846,11 +3621,6 @@
 				"semver": "2 || 3 || 4 || 5",
 				"validate-npm-package-license": "^3.0.1"
 			}
-		},
-		"normalize-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
 		},
 		"npm-run-path": {
 			"version": "2.0.2",
@@ -4086,6 +3856,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -4099,6 +3870,7 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+			"dev": true,
 			"requires": {
 				"minimist": "~0.0.1",
 				"wordwrap": "~0.0.2"
@@ -4107,7 +3879,8 @@
 				"minimist": {
 					"version": "0.0.10",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+					"dev": true
 				}
 			}
 		},
@@ -4273,15 +4046,6 @@
 			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
 			"dev": true
 		},
-		"pascal-case": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.1.tgz",
-			"integrity": "sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=",
-			"requires": {
-				"camel-case": "^3.0.0",
-				"upper-case-first": "^1.1.0"
-			}
-		},
 		"pascalcase": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -4303,7 +4067,8 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
@@ -5177,30 +4942,6 @@
 				}
 			}
 		},
-		"tar-stream": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.0.tgz",
-			"integrity": "sha512-+DAn4Nb4+gz6WZigRzKEZl1QuJVOLtAwwF+WUxy1fJ6X63CaGaUAxJRD2KEn1OMfcbCjySTYpNC6WmfQoIEOdw==",
-			"requires": {
-				"bl": "^3.0.0",
-				"end-of-stream": "^1.4.1",
-				"fs-constants": "^1.0.0",
-				"inherits": "^2.0.3",
-				"readable-stream": "^3.1.1"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				}
-			}
-		},
 		"term-size": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
@@ -5517,6 +5258,7 @@
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
 			"integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"commander": "~2.20.0",
@@ -5527,12 +5269,14 @@
 					"version": "2.20.0",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
 					"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+					"dev": true,
 					"optional": true
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true,
 					"optional": true
 				}
 			}
@@ -5656,19 +5400,6 @@
 						"has-flag": "^3.0.0"
 					}
 				}
-			}
-		},
-		"upper-case": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
-			"integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
-		},
-		"upper-case-first": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
-			"integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
-			"requires": {
-				"upper-case": "^1.1.1"
 			}
 		},
 		"urix": {
@@ -5810,7 +5541,8 @@
 		"wordwrap": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+			"dev": true
 		},
 		"wrap-ansi": {
 			"version": "5.1.0",
@@ -5863,7 +5595,8 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		},
 		"write-file-atomic": {
 			"version": "2.3.0",
@@ -6028,28 +5761,6 @@
 			"resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
 			"integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
 			"dev": true
-		},
-		"zip-stream": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-2.1.2.tgz",
-			"integrity": "sha512-ykebHGa2+uzth/R4HZLkZh3XFJzivhVsjJt8bN3GvBzLaqqrUdRacu+c4QtnUgjkkQfsOuNE1JgLKMCPNmkKgg==",
-			"requires": {
-				"archiver-utils": "^2.1.0",
-				"compress-commons": "^2.1.1",
-				"readable-stream": "^3.4.0"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				}
-			}
 		}
 	}
 }

--- a/handel/package-lock.json
+++ b/handel/package-lock.json
@@ -570,6 +570,90 @@
 				"default-require-extensions": "^2.0.0"
 			}
 		},
+		"archiver": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/archiver/-/archiver-3.1.1.tgz",
+			"integrity": "sha512-5Hxxcig7gw5Jod/8Gq0OneVgLYET+oNHcxgWItq4TbhOzRLKNAFUb9edAftiMKXvXfCB0vbGrJdZDNq0dWMsxg==",
+			"requires": {
+				"archiver-utils": "^2.1.0",
+				"async": "^2.6.3",
+				"buffer-crc32": "^0.2.1",
+				"glob": "^7.1.4",
+				"readable-stream": "^3.4.0",
+				"tar-stream": "^2.1.0",
+				"zip-stream": "^2.1.2"
+			},
+			"dependencies": {
+				"async": {
+					"version": "2.6.3",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+					"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+					"requires": {
+						"lodash": "^4.17.14"
+					}
+				},
+				"glob": {
+					"version": "7.1.4",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"readable-stream": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
+		},
+		"archiver-utils": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+			"integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+			"requires": {
+				"glob": "^7.1.4",
+				"graceful-fs": "^4.2.0",
+				"lazystream": "^1.0.0",
+				"lodash.defaults": "^4.2.0",
+				"lodash.difference": "^4.5.0",
+				"lodash.flatten": "^4.4.0",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.union": "^4.6.0",
+				"normalize-path": "^3.0.0",
+				"readable-stream": "^2.0.0"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.4",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+					"integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q=="
+				}
+			}
+		},
 		"archy": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
@@ -692,8 +776,7 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"base": {
 			"version": "0.11.2",
@@ -754,6 +837,26 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
 			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+		},
+		"bl": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
+			"integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
+			"requires": {
+				"readable-stream": "^3.0.1"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
 		},
 		"bluebird": {
 			"version": "3.5.3",
@@ -841,7 +944,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -891,6 +993,11 @@
 				"ieee754": "^1.1.4",
 				"isarray": "^1.0.0"
 			}
+		},
+		"buffer-crc32": {
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
 		},
 		"buffer-from": {
 			"version": "1.1.1",
@@ -972,6 +1079,15 @@
 			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
 			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
 			"dev": true
+		},
+		"camel-case": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+			"integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+			"requires": {
+				"no-case": "^2.2.0",
+				"upper-case": "^1.1.1"
+			}
 		},
 		"camelcase": {
 			"version": "4.1.0",
@@ -1234,11 +1350,21 @@
 			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
 			"dev": true
 		},
+		"compress-commons": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-2.1.1.tgz",
+			"integrity": "sha512-eVw6n7CnEMFzc3duyFVrQEuY1BlHR3rYsSztyG32ibGMW722i3C6IizEGMFmfMU+A+fALvBIwxN3czffTcdA+Q==",
+			"requires": {
+				"buffer-crc32": "^0.2.13",
+				"crc32-stream": "^3.0.1",
+				"normalize-path": "^3.0.0",
+				"readable-stream": "^2.3.6"
+			}
+		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"concat-stream": {
 			"version": "1.6.2",
@@ -1318,6 +1444,46 @@
 			"requires": {
 				"cpy": "^7.0.0",
 				"meow": "^5.0.0"
+			}
+		},
+		"crc": {
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+			"integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+			"requires": {
+				"buffer": "^5.1.0"
+			},
+			"dependencies": {
+				"buffer": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.0.tgz",
+					"integrity": "sha512-Xpgy0IwHK2N01ncykXTy6FpCWuM+CJSHoPVBLyNqyrWxsedpLvwsYUhf0ME3WRFNUhos0dMamz9cOS/xRDtU5g==",
+					"requires": {
+						"base64-js": "^1.0.2",
+						"ieee754": "^1.1.4"
+					}
+				}
+			}
+		},
+		"crc32-stream": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-3.0.1.tgz",
+			"integrity": "sha512-mctvpXlbzsvK+6z8kJwSJ5crm7yBwrQMTybJzMw1O4lLGJqjlDCXY2Zw7KheiA6XBEcBmfLx1D88mjRGVJtY9w==",
+			"requires": {
+				"crc": "^3.4.4",
+				"readable-stream": "^3.4.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
 		},
 		"create-error-class": {
@@ -1720,7 +1886,6 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
 			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
 			}
@@ -2074,6 +2239,11 @@
 				"map-cache": "^0.2.2"
 			}
 		},
+		"fs-constants": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+		},
 		"fs-extra": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
@@ -2087,8 +2257,7 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"gauge": {
 			"version": "1.2.7",
@@ -2233,11 +2402,30 @@
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
 		},
+		"handel-extension-api": {
+			"version": "0.36.0",
+			"resolved": "https://registry.npmjs.org/handel-extension-api/-/handel-extension-api-0.36.0.tgz",
+			"integrity": "sha512-uWS6qUD0dqb6x50Dr9iwlDFfrovY5weG2CidG8aghhTht54OeT9Kz0kZSri9ipO8bTeGOYZhDe4XZGoejQ4Epw=="
+		},
+		"handel-extension-support": {
+			"version": "0.36.0",
+			"resolved": "https://registry.npmjs.org/handel-extension-support/-/handel-extension-support-0.36.0.tgz",
+			"integrity": "sha512-5SLZ5Q6RF8mOIh63+jND0b9/FbFJl5lvXZEbU6FWNqKBANETCkJK2SxM8UCnpEzOHX8gIxfnozUij1imHhTyYA==",
+			"requires": {
+				"ajv": "^5.2.3",
+				"ajv-errors": "^1.0.1",
+				"archiver": "^3.1.0",
+				"handel-extension-api": "^0.36.0",
+				"handlebars": "^4.1.2",
+				"pascal-case": "^2.0.1",
+				"uuid": "^3.0.1",
+				"winston": "2.3.1"
+			}
+		},
 		"handlebars": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
 			"integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
-			"dev": true,
 			"requires": {
 				"neo-async": "^2.6.0",
 				"optimist": "^0.6.1",
@@ -2248,8 +2436,7 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -2374,7 +2561,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -3020,6 +3206,14 @@
 				"package-json": "^4.0.0"
 			}
 		},
+		"lazystream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+			"integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+			"requires": {
+				"readable-stream": "^2.0.5"
+			}
+		},
 		"lcid": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
@@ -3061,16 +3255,31 @@
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
 			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
 		},
+		"lodash.defaults": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+			"integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+		},
 		"lodash.difference": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
 			"integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
+		},
+		"lodash.flatten": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
 		},
 		"lodash.flattendeep": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
 			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
 			"dev": true
+		},
+		"lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
 		},
 		"lodash.kebabcase": {
 			"version": "4.1.1",
@@ -3097,6 +3306,11 @@
 			"resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
 			"integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs="
 		},
+		"lodash.union": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+			"integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
+		},
 		"lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -3117,6 +3331,11 @@
 				"currently-unhandled": "^0.4.1",
 				"signal-exit": "^3.0.0"
 			}
+		},
+		"lower-case": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
 		},
 		"lowercase-keys": {
 			"version": "1.0.1",
@@ -3450,7 +3669,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -3582,8 +3800,7 @@
 		"neo-async": {
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
-			"dev": true
+			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
 		},
 		"nested-error-stacks": {
 			"version": "2.0.1",
@@ -3610,6 +3827,14 @@
 				"path-to-regexp": "^1.7.0"
 			}
 		},
+		"no-case": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+			"integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+			"requires": {
+				"lower-case": "^1.1.1"
+			}
+		},
 		"normalize-package-data": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -3621,6 +3846,11 @@
 				"semver": "2 || 3 || 4 || 5",
 				"validate-npm-package-license": "^3.0.1"
 			}
+		},
+		"normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
 		},
 		"npm-run-path": {
 			"version": "2.0.2",
@@ -3856,7 +4086,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -3870,7 +4099,6 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-			"dev": true,
 			"requires": {
 				"minimist": "~0.0.1",
 				"wordwrap": "~0.0.2"
@@ -3879,8 +4107,7 @@
 				"minimist": {
 					"version": "0.0.10",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-					"dev": true
+					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
 				}
 			}
 		},
@@ -4046,6 +4273,15 @@
 			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
 			"dev": true
 		},
+		"pascal-case": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.1.tgz",
+			"integrity": "sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=",
+			"requires": {
+				"camel-case": "^3.0.0",
+				"upper-case-first": "^1.1.0"
+			}
+		},
 		"pascalcase": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -4067,8 +4303,7 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
@@ -4942,6 +5177,30 @@
 				}
 			}
 		},
+		"tar-stream": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.0.tgz",
+			"integrity": "sha512-+DAn4Nb4+gz6WZigRzKEZl1QuJVOLtAwwF+WUxy1fJ6X63CaGaUAxJRD2KEn1OMfcbCjySTYpNC6WmfQoIEOdw==",
+			"requires": {
+				"bl": "^3.0.0",
+				"end-of-stream": "^1.4.1",
+				"fs-constants": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
+		},
 		"term-size": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
@@ -5258,7 +5517,6 @@
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
 			"integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"commander": "~2.20.0",
@@ -5269,14 +5527,12 @@
 					"version": "2.20.0",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
 					"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-					"dev": true,
 					"optional": true
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true,
 					"optional": true
 				}
 			}
@@ -5400,6 +5656,19 @@
 						"has-flag": "^3.0.0"
 					}
 				}
+			}
+		},
+		"upper-case": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+			"integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
+		},
+		"upper-case-first": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
+			"integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
+			"requires": {
+				"upper-case": "^1.1.1"
 			}
 		},
 		"urix": {
@@ -5541,8 +5810,7 @@
 		"wordwrap": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-			"dev": true
+			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
 		},
 		"wrap-ansi": {
 			"version": "5.1.0",
@@ -5595,8 +5863,7 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write-file-atomic": {
 			"version": "2.3.0",
@@ -5761,6 +6028,28 @@
 			"resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
 			"integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
 			"dev": true
+		},
+		"zip-stream": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-2.1.2.tgz",
+			"integrity": "sha512-ykebHGa2+uzth/R4HZLkZh3XFJzivhVsjJt8bN3GvBzLaqqrUdRacu+c4QtnUgjkkQfsOuNE1JgLKMCPNmkKgg==",
+			"requires": {
+				"archiver-utils": "^2.1.0",
+				"compress-commons": "^2.1.1",
+				"readable-stream": "^3.4.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
 		}
 	}
 }

--- a/handel/src/common/ecs-containers.ts
+++ b/handel/src/common/ecs-containers.ts
@@ -14,13 +14,12 @@
  * limitations under the License.
  *
  */
-import { DeployContext, EnvironmentVariables, ServiceContext } from 'handel-extension-api';
-import { deployPhase } from 'handel-extension-support';
-import * as _ from 'lodash';
-import { FargateServiceConfig } from '../services/ecs-fargate/config-types';
-import { EcsServiceConfig } from '../services/ecs/config-types';
+import {DeployContext, ExtraSecrets, isAppSecret, isGlobalSecret, ServiceContext} from 'handel-extension-api';
+import {awsCalls, deployPhase} from 'handel-extension-support';
+import {FargateServiceConfig} from '../services/ecs-fargate/config-types';
+import {EcsServiceConfig} from '../services/ecs/config-types';
 import * as routingSection from './ecs-routing';
-import { ContainerConfig, HandlebarsEcsTemplateContainer } from './ecs-shared-config-types';
+import {ContainerConfig, HandlebarsEcsTemplateContainer} from './ecs-shared-config-types';
 import * as volumesSection from './ecs-volumes';
 
 function serviceDefinitionHasContainer(serviceParams: EcsServiceConfig, containerName: string) {
@@ -62,12 +61,10 @@ function getImageName(container: ContainerConfig, ownServiceContext: ServiceCont
         if (customImageName.startsWith('<account>')) { // Comes from own account registry
             const imageNameAndTag = customImageName.substring(9);
             return `${accountConfig.account_id}.dkr.ecr.${accountConfig.region}.amazonaws.com${imageNameAndTag}`;
-        }
-        else { // Must come from somewhere else (Docker Hub, Quay.io, etc.)
+        } else { // Must come from somewhere else (Docker Hub, Quay.io, etc.)
             return customImageName;
         }
-    }
-    else { // Else try to use default image name
+    } else { // Else try to use default image name
         return `${accountConfig.account_id}.dkr.ecr.${accountConfig.region}.amazonaws.com/${ownServiceContext.appName}-${ownServiceContext.serviceName}-${container.name}:${ownServiceContext.environmentName}`;
     }
 }
@@ -97,16 +94,32 @@ function getLinksForContainer(container: ContainerConfig): string[] | undefined 
  * Users may specify from 1 to n containers in their configuration, so this function will return
  * a list of 1 to n containers.
  */
-export function getContainersConfig(ownServiceContext: ServiceContext<EcsServiceConfig>, dependenciesDeployContexts: DeployContext[], clusterName: string): HandlebarsEcsTemplateContainer[] {
+export async function getContainersConfig(
+    ownServiceContext: ServiceContext<EcsServiceConfig>,
+    dependenciesDeployContexts: DeployContext[],
+    clusterName: string
+): Promise<HandlebarsEcsTemplateContainer[]> {
     const serviceParams = ownServiceContext.params;
     const containerConfigs: HandlebarsEcsTemplateContainer[] = [];
+
+    const dependencySecrets = await getDependencySecretMappings(dependenciesDeployContexts);
+
     let albPriority = 1;
     for (const container of serviceParams.containers) {
+        let secrets: SecretEnvMapping | undefined = Object.assign({}, dependencySecrets);
+        if (container.secrets) {
+            const resolved = await getCustomSecretMappings(ownServiceContext, container.secrets);
+            Object.assign(secrets, resolved);
+        }
+        if (Object.keys(secrets).length === 0) {
+            secrets = undefined;
+        }
         const containerConfig: HandlebarsEcsTemplateContainer = {
             name: container.name,
             maxMb: container.max_mb || 128,
             cpuUnits: container.cpu_units || 100,
             environmentVariables: deployPhase.getEnvVarsForDeployedService(ownServiceContext, dependenciesDeployContexts, container.environment_variables),
+            secrets,
             portMappings: [], // This is filled up below if any mappings present
             imageName: getImageName(container, ownServiceContext),
             mountPoints: volumesSection.getMountPointsForContainer(dependenciesDeployContexts), // Add mount points if present
@@ -133,6 +146,26 @@ export function getContainersConfig(ownServiceContext: ServiceContext<EcsService
     return containerConfigs;
 }
 
+export function getExecutionRuleSecretStatements(serviceContext: ServiceContext<EcsServiceConfig | FargateServiceConfig>, containers: HandlebarsEcsTemplateContainer[]) {
+    const secretArns = containers.reduce((set, c) => {
+        if (c.secrets) {
+            Object.values(c.secrets).forEach(it => set.add(it));
+        }
+        return set;
+    }, new Set());
+    return [{
+        Effect: 'Allow',
+        Action: [
+            'ssm:GetParameters',
+            'ssm:GetParameter',
+            'ssm:GetParametersByPath',
+            // We don't actually support finding params for secrets manager yet, but let's add the permission anyway
+            'secretsmanager:GetSecretValue'
+        ],
+        Resource: [...secretArns]
+    }];
+}
+
 /**
  * This function is called by the "check" lifecycle phase to check the information in the
  * "containers" section in the Handel service configuration
@@ -142,16 +175,14 @@ export function checkContainers(serviceContext: ServiceContext<EcsServiceConfig 
     // Require at least one container definition
     if (!params.containers || params.containers.length === 0) {
         errors.push(`You must specify at least one container in the 'containers' section`);
-    }
-    else {
+    } else {
         let alreadyHasOneRouting = false;
         for (const container of params.containers) {
             if (container.routing) {
                 // Only allow one 'routing' section currently
                 if (alreadyHasOneRouting) {
                     errors.push(`You may not specify a 'routing' section in more than one container. This is due to a current limitation in ECS load balancing`);
-                }
-                else {
+                } else {
                     alreadyHasOneRouting = true;
                 }
 
@@ -163,5 +194,70 @@ export function checkContainers(serviceContext: ServiceContext<EcsServiceConfig 
 
             checkLinks(serviceContext, container, errors);
         }
+    }
+}
+
+interface SecretEnvMapping {
+    [SecretEnvName: string]: SecretArn;
+}
+
+type SecretArn = string;
+
+async function getCustomSecretMappings(
+    serviceContext: ServiceContext<any>,
+    extraSecrets: ExtraSecrets
+): Promise<SecretEnvMapping> {
+    const nameToEnv: Record<string, string> = Object.entries(extraSecrets).reduce((agg, [env, source]) => {
+        let base: string;
+        let name: string;
+        if (isAppSecret(source)) {
+            base = serviceContext.ssmApplicationPath();
+            name = source.app;
+        } else if (isGlobalSecret(source)) {
+            base = '/handel/global/';
+            name = source.global;
+        } else {
+            return agg;
+        }
+        const fullName = `${base}/${name}`.replace(/\/+/g, '/');
+        return Object.assign(agg, {[fullName]: env});
+    }, {});
+    const arns = await awsCalls.ssm.getArnsForNames(Object.keys(nameToEnv));
+    return arns.reduce((agg, it) => {
+        return Object.assign(agg, {
+            [nameToEnv[it.name]]: it.arn
+        });
+    }, {});
+}
+
+async function getDependencySecretMappings(dependencies: DeployContext[]): Promise<SecretEnvMapping> {
+    const results = await Promise.all(dependencies.map(getSingle));
+    return results.reduce((agg, it) => Object.assign(agg, it));
+
+    async function getSingle(dependency: DeployContext) {
+        const path = dependency.ssmServicePath;
+        const fixedPath = path.endsWith('/') ? path : path + '/';
+        const dots = dependency.ssmServicePrefix + '.';
+
+        const [pathResult, dotResult] = await Promise.all([
+            getForPrefix(dependency, fixedPath),
+            getForPrefix(dependency, dots)
+        ]);
+        return Object.assign({} as SecretEnvMapping, dotResult, pathResult);
+    }
+
+    async function getForPrefix(dependency: DeployContext, prefix: string) {
+        const names = await awsCalls.ssm.listParameterNamesStartingWith(prefix);
+        if (names.length === 0) {
+            return {};
+        }
+        const r = await awsCalls.ssm.getArnsForNames(names);
+        return r.reduce((agg, it) => {
+            const suffix = it.name.substring(prefix.length);
+            const envName = dependency.getInjectedEnvVarName(suffix);
+            return Object.assign(agg, {
+                [envName]: it.arn
+            });
+        }, {});
     }
 }

--- a/handel/src/common/ecs-containers.ts
+++ b/handel/src/common/ecs-containers.ts
@@ -248,7 +248,7 @@ async function getDependencySecretMappings(dependencies: DeployContext[]): Promi
 
     async function getForPrefix(dependency: DeployContext, prefix: string) {
         const names = await awsCalls.ssm.listParameterNamesStartingWith(prefix);
-        if (names.length === 0) {
+        if (!names || names.length === 0) {
             return {};
         }
         const r = await awsCalls.ssm.getArnsForNames(names);

--- a/handel/src/common/ecs-shared-config-types.ts
+++ b/handel/src/common/ecs-shared-config-types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
-import { EnvironmentVariables } from 'handel-extension-api';
+import {EnvironmentVariables, ExtraSecrets} from 'handel-extension-api';
 
 export interface ContainerConfig {
     name: string;
@@ -25,6 +25,7 @@ export interface ContainerConfig {
     links?: string[];
     routing?: ContainerRoutingConfig;
     environment_variables?: EnvironmentVariables;
+    secrets?: ExtraSecrets;
 }
 
 export interface ContainerRoutingConfig {
@@ -89,6 +90,7 @@ export interface HandlebarsEcsTemplateContainer {
     maxMb: number;
     cpuUnits: number;
     environmentVariables: EnvironmentVariables;
+    secrets?: Record<string, string>;
     routingInfo?: HandlebarsEcsTemplateRoutingInfo;
     portMappings: number[];
     imageName: string;

--- a/handel/src/services/ecs-fargate/config-types.ts
+++ b/handel/src/services/ecs-fargate/config-types.ts
@@ -46,6 +46,7 @@ export interface HandlebarsFargateTemplateConfig {
     minimumHealthyPercentDeployment: string;
     vpcId: string;
     policyStatements: any[];
+    executionPolicyStatements: any[];
     deploymentSuffix: number;
     tags: Tags;
     containerConfigs: HandlebarsEcsTemplateContainer[];

--- a/handel/src/services/ecs-fargate/ecs-fargate-template.yml
+++ b/handel/src/services/ecs-fargate/ecs-fargate-template.yml
@@ -53,6 +53,22 @@ Resources:
             - ecs-tasks.amazonaws.com
           Action:
           - sts:AssumeRole
+      Policies:
+        - PolicyName: AllowFetchSecrets
+          PolicyDocument:
+            Version: "2012-10-17"
+            {{#each executionPolicyStatements}}
+            Statement:
+            - Effect: {{Effect}}
+              Action:
+              {{#each Action}}
+              - '{{{this}}}'
+              {{/each}}
+              Resource:
+              {{#each Resource}}
+              - '{{{this}}}'
+              {{/each}}
+            {{/each}}
       ManagedPolicyArns:
       - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
 
@@ -144,6 +160,13 @@ Resources:
         - Name: {{@key}}
           Value: {{this}}
         {{/each}}
+        {{#if secrets}}
+        Secrets:
+        {{#each secrets}}
+        - Name: {{@key}}
+          ValueFrom: {{this}}
+        {{/each}}
+        {{/if}}
         {{#if mountPoints}}
         MountPoints:
         {{#each mountPoints}}

--- a/handel/src/services/ecs-fargate/params-schema.json
+++ b/handel/src/services/ecs-fargate/params-schema.json
@@ -79,6 +79,31 @@
                         },
                         "errorMessage": "Must contain 1 or more simple key/value pairs where the values are strings or numbers",
                         "additionalProperties": false
+                    },
+                    "secrets": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "oneOf": [
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "app": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": ["app"]
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "global": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": ["global"]
+                                }
+                            ]
+                        }
                     }
                 },
                 "required": [

--- a/handel/src/services/ecs/config-types.ts
+++ b/handel/src/services/ecs/config-types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
-import { ServiceConfig, Tags } from 'handel-extension-api';
+import {ExtraSecrets, HasInjectableSecrets, ServiceConfig, Tags} from 'handel-extension-api';
 import {
     AutoScalingConfig,
     ContainerConfig,
@@ -56,6 +56,7 @@ export interface HandlebarsEcsTemplateConfig {
     vpcId: string;
     serviceRoleName: string;
     policyStatements: any[];
+    executionPolicyStatements: any[];
     deploymentSuffix: number;
     tags: Tags;
     containerConfigs: HandlebarsEcsTemplateContainer[];

--- a/handel/src/services/ecs/ecs-service-template.yml
+++ b/handel/src/services/ecs/ecs-service-template.yml
@@ -95,7 +95,38 @@ Resources:
       Path: "/"
       Roles:
       - Ref: EcsIamRole
-  
+  TaskExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Path: "/services/"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ecs-tasks.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: AllowFetchSecrets
+          PolicyDocument:
+            Version: "2012-10-17"
+            {{#each executionPolicyStatements}}
+            Statement:
+            - Effect: {{Effect}}
+              Action:
+              {{#each Action}}
+               - '{{{this}}}'
+              {{/each}}
+              Resource:
+              {{#each Resource}}
+               - '{{{this}}}'
+              {{/each}}
+            {{/each}}
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+
   #
   # Configure ECS Cluster
   #
@@ -247,6 +278,7 @@ Resources:
     Properties:
       Family: {{clusterName}}
       TaskRoleArn: !GetAtt TaskRole.Arn
+      ExecutionRoleArn: !GetAtt TaskExecutionRole.Arn
       NetworkMode: bridge
       {{#if volumes}}
       Volumes:
@@ -291,6 +323,13 @@ Resources:
         - Name: {{@key}}
           Value: {{this}}
         {{/each}}
+        {{#if secrets}}
+        Secrets:
+        {{#each secrets}}
+        - Name: {{@key}}
+          ValueFrom: {{this}}
+        {{/each}}
+        {{/if}}
         {{#if mountPoints}}
         MountPoints:
         {{#each mountPoints}}

--- a/handel/src/services/ecs/params-schema.json
+++ b/handel/src/services/ecs/params-schema.json
@@ -79,6 +79,31 @@
                         },
                         "errorMessage": "Must contain 1 or more simple key/value pairs where the values are strings or numbers",
                         "additionalProperties": false
+                    },
+                    "secrets": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "oneOf": [
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "app": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": ["app"]
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "global": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": ["global"]
+                                }
+                            ]
+                        }
                     }
                 },
                 "required": [

--- a/handel/test/common/ecs-containers-test.ts
+++ b/handel/test/common/ecs-containers-test.ts
@@ -115,8 +115,8 @@ describe('ecs containers common module', () => {
             let dep2: DeployContext;
 
             beforeEach(() => {
-                dep1 = new DeployContext(new ServiceContext(appName, envName, 'Dep1', new ServiceType(STDLIB_PREFIX, 'rds'), {type: 'rds'}, accountConfig));
-                dep2 = new DeployContext(new ServiceContext(appName, envName, 'Dep2', new ServiceType(STDLIB_PREFIX, 'rds'), {type: 'rds'}, accountConfig));
+                dep1 = new DeployContext(new ServiceContext(appName, envName, 'dep1', new ServiceType(STDLIB_PREFIX, 'rds'), {type: 'rds'}, accountConfig));
+                dep2 = new DeployContext(new ServiceContext(appName, envName, 'dep2', new ServiceType(STDLIB_PREFIX, 'rds'), {type: 'rds'}, accountConfig));
             });
 
             it('detects dependency secrets and injects them', async () => {

--- a/handel/test/common/ecs-containers-test.ts
+++ b/handel/test/common/ecs-containers-test.ts
@@ -14,16 +14,17 @@
  * limitations under the License.
  *
  */
-import { expect } from 'chai';
-import { AccountConfig, DeployContext, ServiceContext, ServiceType } from 'handel-extension-api';
+import {expect} from 'chai';
+import {AccountConfig, DeployContext, ServiceContext, ServiceType} from 'handel-extension-api';
+import {awsCalls} from 'handel-extension-support';
 import 'mocha';
 import * as sinon from 'sinon';
 import config from '../../src/account-config/account-config';
 import * as ecsContainers from '../../src/common/ecs-containers';
 import * as ecsRouting from '../../src/common/ecs-routing';
 import * as ecsVolumes from '../../src/common/ecs-volumes';
-import { FargateServiceConfig } from '../../src/services/ecs-fargate/config-types';
-import { STDLIB_PREFIX } from '../../src/services/stdlib';
+import {FargateServiceConfig} from '../../src/services/ecs-fargate/config-types';
+import {STDLIB_PREFIX} from '../../src/services/stdlib';
 
 describe('ecs containers common module', () => {
     let sandbox: sinon.SinonSandbox;
@@ -72,18 +73,89 @@ describe('ecs containers common module', () => {
     });
 
     describe('getContainersConfig', () => {
-        it('should return the configuration for containers from the Handel file', () => {
+        it('should return the configuration for containers from the Handel file', async () => {
             const getMountPointsStub = sandbox.stub(ecsVolumes, 'getMountPointsForContainer').returns([]);
             const getRoutingInfoStub = sandbox.stub(ecsRouting, 'getRoutingInformationForContainer').returns([]);
 
             const dependencyServiceContext = new ServiceContext(appName, envName, 'FakeOtherService', new ServiceType(STDLIB_PREFIX, 'efs'), {type: 'efs'}, accountConfig);
             const dependencyDeployContext = new DeployContext(dependencyServiceContext);
-            const containerConfigs = ecsContainers.getContainersConfig(serviceContext, [dependencyDeployContext], 'FakeClusterName');
+            const containerConfigs = await ecsContainers.getContainersConfig(serviceContext, [dependencyDeployContext], 'FakeClusterName');
 
             expect(getRoutingInfoStub.callCount).to.equal(1);
             expect(getMountPointsStub.callCount).to.equal(2);
             expect(containerConfigs.length).to.equal(2);
             expect(containerConfigs[0].name).to.equal('mycontainername');
+        });
+        describe('secrets injection', () => {
+            function arnIt(name: string) {
+                return `arn:aws:ssm:us-west-2:123456789012:parameter/${name}`.replace(/\/+/g, '/');
+            }
+            function nameAndArn(name: string) {
+                return {
+                    name,
+                    arn: arnIt(name)
+                };
+            }
+
+            const dep1Path1 = `/${appName}/${envName}/dep1/foo`;
+            const dep1Path2 = `/${appName}/${envName}/dep1/bar`;
+            const dep2Path1 = `/${appName}/${envName}/dep2/baz`;
+            const dep1dot1 = `${appName}.${envName}.dep1.foo`;
+            const dep1dot2 = `${appName}.${envName}.dep1.bar`;
+            const dep2dot1 = `${appName}.${envName}.dep2.baz`;
+
+            const dep1Path1Arn = arnIt(dep1Path1);
+            const dep1Path2Arn = arnIt(dep1Path2);
+            const dep2Path1Arn = arnIt(dep2Path1);
+            const dep1dot1Arn = arnIt(dep1dot1);
+            const dep1dot2Arn = arnIt(dep1dot2);
+            const dep2dot1Arn = arnIt(dep2dot1);
+
+            let dep1: DeployContext;
+            let dep2: DeployContext;
+
+            beforeEach(() => {
+                dep1 = new DeployContext(new ServiceContext(appName, envName, 'Dep1', new ServiceType(STDLIB_PREFIX, 'rds'), {type: 'rds'}, accountConfig));
+                dep2 = new DeployContext(new ServiceContext(appName, envName, 'Dep2', new ServiceType(STDLIB_PREFIX, 'rds'), {type: 'rds'}, accountConfig));
+            });
+
+            it('detects dependency secrets and injects them', async () => {
+                sandbox.stub(awsCalls.ssm, 'listParameterNamesStartingWith')
+                    .withArgs(dep1.ssmServicePath).resolves([dep1Path1, dep1Path2])
+                    .withArgs(dep2.ssmServicePath).resolves([dep2Path1]);
+                sandbox.stub(awsCalls.ssm, 'getArnsForNames').callsFake(a => a.map(nameAndArn));
+
+                const result = await ecsContainers.getContainersConfig(serviceContext, [dep1, dep2], 'FakeClusterName');
+
+                expect(result).to.have.lengthOf(2);
+                result.forEach(value => expect(value).to.haveOwnProperty('secrets')
+                    .which.eql({
+                        DEP1_FOO: dep1Path1Arn,
+                        DEP1_BAR: dep1Path2Arn,
+                        DEP2_BAZ: dep2Path1Arn
+                    })
+                );
+            });
+            it('handles mixed dot-style and path-style dependency secrets', async () => {
+                sandbox.stub(awsCalls.ssm, 'listParameterNamesStartingWith')
+                    .withArgs(dep1.ssmServicePath).resolves([dep1Path1, dep1Path2])
+                    .withArgs(dep1.ssmServicePrefix + '.').resolves([dep1dot1, dep1dot2])
+                    .withArgs(dep2.ssmServicePath).resolves([])
+                    .withArgs(dep2.ssmServicePrefix + '.').resolves([dep2dot1]);
+                sandbox.stub(awsCalls.ssm, 'getArnsForNames').callsFake(a => a.map(nameAndArn));
+
+                const result = await ecsContainers.getContainersConfig(serviceContext, [dep1, dep2], 'FakeClusterName');
+
+                expect(result).to.have.lengthOf(2);
+                result.forEach(value => expect(value).to.haveOwnProperty('secrets')
+                    .which.eql({
+                        DEP1_FOO: dep1Path1Arn,
+                        DEP1_BAR: dep1Path2Arn,
+                        DEP2_BAZ: dep2dot1Arn
+                    })
+                );
+            });
+            it('injects secrets specified in the config');
         });
     });
 
@@ -118,7 +190,7 @@ describe('ecs containers common module', () => {
         });
 
         it('should require container links to be valid', () => {
-            serviceParams.containers = [ serviceParams.containers[0] ];
+            serviceParams.containers = [serviceParams.containers[0]];
             const errors: string[] = [];
             ecsContainers.checkContainers(serviceContext, errors);
             expect(errors.length).to.equal(1);

--- a/handel/test/services/ecs/ecs-test.ts
+++ b/handel/test/services/ecs/ecs-test.ts
@@ -237,6 +237,7 @@ describe('ecs deployer', () => {
                 Name: 'myapp.internal.'
             }]);
             const getStackStub = sandbox.stub(awsCalls.cloudFormation, 'getStack').resolves(null);
+            const ssmStub = sandbox.stub(awsCalls.ssm, 'listParameterNamesStartingWith').resolves([]);
             const uploadDirStub = sandbox.stub(deployPhase, 'uploadDirectoryToHandelBucket').resolves({});
             const createStackStub = sandbox.stub(awsCalls.cloudFormation, 'createStack').resolves({});
             const deployStackStub = sandbox.stub(deployPhase, 'deployCloudFormationStack').resolves({});
@@ -291,7 +292,9 @@ describe('ecs deployer', () => {
             const cycleInstancesStub = sandbox.stub(asgCycling, 'cycleInstances').resolves({});
 
             // Run the test
+            console.log('starting deploy');
             const deployContext = await ecs.deploy!(serviceContext, ownPreDeployContext, dependenciesDeployContexts);
+            console.log('finished deploy');
             expect(clusterAutoScalingStub.callCount).to.equal(1);
             expect(deployContext).to.be.instanceof(DeployContext);
             expect(getStackStub.callCount).to.equal(2);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2553,10 +2553,13 @@
 			}
 		},
 		"eslint-utils": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-			"integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-			"dev": true
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+			"integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+			"dev": true,
+			"requires": {
+				"eslint-visitor-keys": "^1.0.0"
+			}
 		},
 		"eslint-visitor-keys": {
 			"version": "1.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
         "declaration": true,
         "moduleResolution": "node",
         "lib": [
-            "es7", "es2017.object"
+            "es7", "es2017.object", "esnext.asynciterable"
         ]
     },
     "compileOnSave": false


### PR DESCRIPTION
ECS added this a while back: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html

It lets you specify SSM parameters to be injected as environment variables.  This makes life So. Much. Easier. for most of our applications.

This change will auto-inject any parameters from declared dependencies and also allows for the injection of custom parameters, either from the application's SSM namespace or the global Handel namespace.

Also changes the SSM injection code to inject both dots- and path-style names.