### PR TITLE
Feature permissions boundary

### DIFF
--- a/docs/handel-basics/account-config-file.rst
+++ b/docs/handel-basics/account-config-file.rst
@@ -63,6 +63,7 @@ The account config file is a YAML file that must contain the following informati
   handel_resource_tags: # Optional. Sets tags to be applied to any generic resources, such as lambda functions, that Handel uses internally.
     <key>: <value>
     <key>: <value>
+  permissions_boundary: # Optional. The arn of an IAM Policy that should be added as a permissions boundary to any IAM Roles created by Handel.
 
 .. IMPORTANT::
 

--- a/handel/src/services/apigateway/proxy/apigateway-proxy-template.yml
+++ b/handel/src/services/apigateway/proxy/apigateway-proxy-template.yml
@@ -18,6 +18,9 @@ Resources:
               - "lambda.amazonaws.com"
             Action:
             - "sts:AssumeRole"
+      {{#if permissionsBoundary}}
+      PermissionsBoundary: {{permissionsBoundary}}
+      {{/if}}
   LambdaPolicy:
     Type: AWS::IAM::Policy
     Properties:

--- a/handel/src/services/apigateway/proxy/proxy-passthrough-deploy-type.ts
+++ b/handel/src/services/apigateway/proxy/proxy-passthrough-deploy-type.ts
@@ -57,6 +57,10 @@ async function getCompiledApiGatewayTemplate(stackName: string, ownServiceContex
         tags: tagging.getTags(ownServiceContext)
     };
 
+    if (accountConfig.permissions_boundary) {
+        handlebarsParams.permissionsBoundary = accountConfig.permissions_boundary
+    }
+
     // Add binary media types if specified
     const binaryMediaTypes = serviceParams.binary_media_types;
     if (binaryMediaTypes) {

--- a/handel/src/services/apigateway/swagger/apigateway-swagger-template.yml
+++ b/handel/src/services/apigateway/swagger/apigateway-swagger-template.yml
@@ -18,6 +18,9 @@ Resources:
               - "lambda.amazonaws.com"
             Action:
             - "sts:AssumeRole"
+      {{#if permissionsBoundary}}
+      PermissionsBoundary: {{permissionsBoundary}}
+      {{/if}}
   LambdaPolicy:
     Type: AWS::IAM::Policy
     Properties:

--- a/handel/src/services/apigateway/swagger/swagger-deploy-type.ts
+++ b/handel/src/services/apigateway/swagger/swagger-deploy-type.ts
@@ -120,6 +120,10 @@ async function getCompiledApiGatewayTemplate(stackName: string, ownServiceContex
         deploymentIdSuffix: Math.floor(Math.random() * 10000) // This is required because CF won't update an API deployment unless the resource has a different name
     };
 
+    if (accountConfig.permissions_boundary) {
+        handlebarsParams.permissionsBoundary = accountConfig.permissions_boundary
+    }
+
     // Add binary media types if specified
     const binaryMediaTypes = params.binary_media_types;
     if (binaryMediaTypes) {

--- a/handel/src/services/beanstalk/beanstalk-template.yml
+++ b/handel/src/services/beanstalk/beanstalk-template.yml
@@ -21,6 +21,9 @@ Resources:
               - "elasticbeanstalk.amazonaws.com"
             Action:
             - "sts:AssumeRole"
+      {{#if permissionsBoundary}}
+      PermissionsBoundary: {{permissionsBoundary}}
+      {{/if}}
   ServiceRolePolicy:
     Type: AWS::IAM::Policy
     Properties:
@@ -171,6 +174,9 @@ Resources:
               - "ec2.amazonaws.com"
             Action:
             - "sts:AssumeRole"
+      {{#if permissionsBoundary}}
+      PermissionsBoundary: {{permissionsBoundary}}
+      {{/if}}
   Policy:
     Type: AWS::IAM::Policy
     Properties:

--- a/handel/src/services/beanstalk/config-types.ts
+++ b/handel/src/services/beanstalk/config-types.ts
@@ -57,6 +57,7 @@ export interface HandlebarsBeanstalkTemplate {
     policyStatements: any[];
     serviceRoleName: string;
     tags: Tags;
+    permissionsBoundary?: string;
 }
 
 export interface HandlebarsBeanstalkOptionSetting {

--- a/handel/src/services/beanstalk/index.ts
+++ b/handel/src/services/beanstalk/index.ts
@@ -88,6 +88,10 @@ async function getCompiledBeanstalkTemplate(stackName: string, preDeployContext:
         tags: tagging.getTags(serviceContext)
     };
 
+    if (accountConfig.permissions_boundary) {
+        handlebarsParams.permissionsBoundary = accountConfig.permissions_boundary;
+    }
+
     // Configure min and max size of ASG
     let minInstances;
     let maxInstances;

--- a/handel/src/services/codedeploy/codedeploy-asg-template.handlebars
+++ b/handel/src/services/codedeploy/codedeploy-asg-template.handlebars
@@ -68,6 +68,9 @@ Resources:
             - elasticloadbalancing:DeregisterTargets
             Resource:
             - "*" # This is the role used by the AWS service itself, so it doesn't really need to have a granular resource like those used by our applications 
+      {{#if permissionsBoundary}}
+      PermissionsBoundary: {{permissionsBoundary}}
+      {{/if}}
 
   #
   # Role used by CodeDeploy
@@ -86,6 +89,9 @@ Resources:
             - ec2.amazonaws.com
           Action:
           - sts:AssumeRole
+      {{#if permissionsBoundary}}
+      PermissionsBoundary: {{permissionsBoundary}}
+      {{/if}}
   Policy:
     Type: AWS::IAM::Policy
     Properties:

--- a/handel/src/services/codedeploy/config-types.ts
+++ b/handel/src/services/codedeploy/config-types.ts
@@ -61,6 +61,7 @@ export interface HandlebarsCodeDeployTemplate {
     serviceRoleName: string;
     sshKeyName?: string;
     assignPublicIp: boolean;
+    permissionsBoundary?: string;
 }
 
 export interface HandlebarsCodeDeployAutoScalingConfig {

--- a/handel/src/services/codedeploy/index.ts
+++ b/handel/src/services/codedeploy/index.ts
@@ -61,6 +61,10 @@ async function getCompiledCodeDeployTemplate(stackName: string, ownServiceContex
         assignPublicIp: await ec2Calls.shouldAssignPublicIp(accountConfig.private_subnets)
     };
 
+    if (accountConfig.permissions_boundary) {
+        handlebarsParams.permissionsBoundary = accountConfig.permissions_boundary
+    }
+
     // Add ssh key name if present
     if (params.key_name) {
         handlebarsParams.sshKeyName = params.key_name;

--- a/handel/src/services/dynamodb/autoscaling.ts
+++ b/handel/src/services/dynamodb/autoscaling.ts
@@ -123,11 +123,16 @@ function getAutoscalingStackName(ownServiceContext: types.DynamoDBContext) {
 
 function getCompiledAutoscalingTemplate(tableName: string, ownServiceContext: types.DynamoDBContext): Promise<string> {
     const serviceParams = ownServiceContext.params;
+    const accountConfig = ownServiceContext.accountConfig;
 
-    const handlebarsParams = {
+    const handlebarsParams: any = {
         tableName,
         targets: getScalingTargets(serviceParams, tableName)
     };
+
+    if (accountConfig.permissions_boundary) {
+        handlebarsParams.permissionsBoundary = accountConfig.permissions_boundary
+    }
 
     return handlebars.compileTemplate(`${__dirname}/dynamodb-autoscaling-template.yml`, handlebarsParams);
 }

--- a/handel/src/services/dynamodb/dynamodb-autoscaling-template.yml
+++ b/handel/src/services/dynamodb/dynamodb-autoscaling-template.yml
@@ -38,6 +38,9 @@ Resources:
                   - "dynamodb:UpdateTable"
                 Resource: !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/{{tableName}}"
 
+      {{#if permissionsBoundary}}
+      PermissionsBoundary: {{permissionsBoundary}}
+      {{/if}}
   {{#each targets}}
   {{logicalIdPrefix}}CapacityScalableTarget:
     Type: "AWS::ApplicationAutoScaling::ScalableTarget"

--- a/handel/src/services/ecs-fargate/config-types.ts
+++ b/handel/src/services/ecs-fargate/config-types.ts
@@ -56,4 +56,5 @@ export interface HandlebarsFargateTemplateConfig {
     logRetentionInDays: number | null;
     loadBalancer?: HandlebarsEcsTemplateLoadBalancer;
     volumes?: HandlebarsEcsTemplateVolume[];
+    permissionsBoundary?: string;
 }

--- a/handel/src/services/ecs-fargate/ecs-fargate-template.yml
+++ b/handel/src/services/ecs-fargate/ecs-fargate-template.yml
@@ -20,6 +20,9 @@ Resources:
               - "ecs-tasks.amazonaws.com"
             Action:
             - "sts:AssumeRole"
+      {{#if permissionsBoundary}}
+      PermissionsBoundary: {{permissionsBoundary}}
+      {{/if}}
   TaskRolePolicy:
     Type: AWS::IAM::Policy
     Properties:
@@ -55,6 +58,9 @@ Resources:
           - sts:AssumeRole
       ManagedPolicyArns:
       - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+      {{#if permissionsBoundary}}
+      PermissionsBoundary: {{permissionsBoundary}}
+      {{/if}}
 
   #
   # Configure ECS Service that runs on the cluster
@@ -180,6 +186,9 @@ Resources:
             - application-autoscaling.amazonaws.com
           Action:
           - 'sts:AssumeRole'
+      {{#if permissionsBoundary}}
+      PermissionsBoundary: {{permissionsBoundary}}
+      {{/if}}
   ServiceAutoScalingPolicy:
     Type: AWS::IAM::Policy
     Properties:

--- a/handel/src/services/ecs-fargate/index.ts
+++ b/handel/src/services/ecs-fargate/index.ts
@@ -102,6 +102,10 @@ async function getCompiledEcsFargateTemplate(serviceName: string, ownServiceCont
         assignPublicIp: shouldAssignPublicIp ? 'ENABLED' : 'DISABLED'
     };
 
+    if (accountConfig.permissions_boundary) {
+        handlebarsParams.permissionsBoundary = accountConfig.permissions_boundary
+    }
+
     // Configure routing if present in any of the containers
     if (oneOrMoreTasksHasRouting) {
         const hostedZones = await route53.listHostedZones();

--- a/handel/src/services/ecs/cluster-auto-scaling.ts
+++ b/handel/src/services/ecs/cluster-auto-scaling.ts
@@ -39,10 +39,15 @@ export async function createAutoScalingLambdaIfNotExists(accountConfig: AccountC
     const stack = await awsCalls.cloudFormation.getStack(stackName);
     if (!stack) {
         const s3ObjectInfo = await deployPhase.uploadDirectoryToHandelBucket(`${__dirname}/cluster-scaling-lambda/`, 'handel/ecs-cluster-auto-scaling-lambda', 'lambda-code', accountConfig);
-        const handlebarsParams = {
+        const handlebarsParams: any = {
             s3Bucket: s3ObjectInfo.Bucket,
             s3Key: s3ObjectInfo.Key
         };
+
+        if (accountConfig.permissions_boundary) {
+            handlebarsParams.permissionsBoundary = accountConfig.permissions_boundary
+        }
+
         const compiledTemplate = await handlebars.compileTemplate(`${__dirname}/cluster-scaling-lambda/scaling-lambda-template.yml`, handlebarsParams);
         winston.info(`Creating Lambda for ECS auto-scaling`);
         return awsCalls.cloudFormation.createStack(stackName, compiledTemplate, [], 30, accountConfig.handel_resource_tags);
@@ -64,10 +69,14 @@ export async function createDrainingLambdaIfNotExists(accountConfig: AccountConf
     if (!stack) {
         // Stack doesn't exist, create it
         const s3ObjectInfo = await deployPhase.uploadDirectoryToHandelBucket(`${__dirname}/cluster-draining-lambda/`, 'handel/ecs-cluster-draining-lambda', 'lambda-code', accountConfig);
-        const handlebarsParams = {
+        const handlebarsParams: any = {
             s3Bucket: s3ObjectInfo.Bucket,
             s3Key: s3ObjectInfo.Key
         };
+
+        if (accountConfig.permissions_boundary) {
+            handlebarsParams.permissionsBoundary = accountConfig.permissions_boundary
+        }
 
         const compiledTemplate = await handlebars.compileTemplate(`${__dirname}/cluster-draining-lambda/cluster-draining-template.yml`, handlebarsParams);
         winston.info(`Creating Lambda for ECS draining`);

--- a/handel/src/services/ecs/cluster-draining-lambda/cluster-draining-template.yml
+++ b/handel/src/services/ecs/cluster-draining-lambda/cluster-draining-template.yml
@@ -17,6 +17,9 @@ Resources:
               - "lambda.amazonaws.com"
             Action:
             - "sts:AssumeRole"
+      {{#if permissionsBoundary}}
+      PermissionsBoundary: {{permissionsBoundary}}
+      {{/if}}
   Policy:
     Type: AWS::IAM::Policy
     Properties:

--- a/handel/src/services/ecs/cluster-scaling-lambda/scaling-lambda-template.yml
+++ b/handel/src/services/ecs/cluster-scaling-lambda/scaling-lambda-template.yml
@@ -27,6 +27,9 @@ Resources:
               - "lambda.amazonaws.com"
             Action:
             - "sts:AssumeRole"
+      {{#if permissionsBoundary}}
+      PermissionsBoundary: {{permissionsBoundary}}
+      {{/if}}
   Policy:
     Type: AWS::IAM::Policy
     Properties:

--- a/handel/src/services/ecs/config-types.ts
+++ b/handel/src/services/ecs/config-types.ts
@@ -67,4 +67,5 @@ export interface HandlebarsEcsTemplateConfig {
     loadBalancer?: HandlebarsEcsTemplateLoadBalancer;
     sshKeyName?: string;
     volumes?: HandlebarsEcsTemplateVolume[];
+    permissionsBoundary?: string;
 }

--- a/handel/src/services/ecs/ecs-service-template.yml
+++ b/handel/src/services/ecs/ecs-service-template.yml
@@ -36,6 +36,9 @@ Resources:
             - "elasticloadbalancing:RegisterTargets"
             Resource:
             - "*"
+      {{#if permissionsBoundary}}
+      PermissionsBoundary: {{permissionsBoundary}}
+      {{/if}}
 
   #
   # Configure IAM resources for ECS resources
@@ -54,6 +57,9 @@ Resources:
               - "ecs-tasks.amazonaws.com"
             Action:
             - "sts:AssumeRole"
+      {{#if permissionsBoundary}}
+      PermissionsBoundary: {{permissionsBoundary}}
+      {{/if}}
   TaskRolePolicy:
     Type: AWS::IAM::Policy
     Properties:
@@ -89,6 +95,9 @@ Resources:
           - sts:AssumeRole
       ManagedPolicyArns:
       - arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role
+      {{#if permissionsBoundary}}
+      PermissionsBoundary: {{permissionsBoundary}}
+      {{/if}}
   EcsInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
@@ -327,6 +336,9 @@ Resources:
             - application-autoscaling.amazonaws.com
           Action: 
           - 'sts:AssumeRole'
+      {{#if permissionsBoundary}}
+      PermissionsBoundary: {{permissionsBoundary}}
+      {{/if}}
   ServiceAutoScalingPolicy:
     Type: AWS::IAM::Policy
     Properties:

--- a/handel/src/services/ecs/index.ts
+++ b/handel/src/services/ecs/index.ts
@@ -120,6 +120,10 @@ async function getCompiledEcsTemplate(stackName: string, clusterName: string, ow
     // Add volumes if present (these are consumed by one or more container mount points)
     handlebarsParams.volumes = volumesSection.getVolumes(dependenciesDeployContexts);
 
+    if (accountConfig.permissions_boundary) {
+        handlebarsParams.permissionsBoundary = accountConfig.permissions_boundary
+    }
+
     return handlebars.compileTemplate(`${__dirname}/ecs-service-template.yml`, handlebarsParams);
 }
 

--- a/handel/src/services/lambda/config-types.ts
+++ b/handel/src/services/lambda/config-types.ts
@@ -47,6 +47,7 @@ export interface HandlebarsLambdaTemplate {
     vpc?: boolean;
     vpcSecurityGroupIds?: string[];
     vpcSubnetIds?: string[];
+    permissionsBoundary?: string[];
 }
 
 export interface LambdaEventSourceConfig extends ServiceEventConsumer {

--- a/handel/src/services/lambda/config-types.ts
+++ b/handel/src/services/lambda/config-types.ts
@@ -47,7 +47,7 @@ export interface HandlebarsLambdaTemplate {
     vpc?: boolean;
     vpcSecurityGroupIds?: string[];
     vpcSubnetIds?: string[];
-    permissionsBoundary?: string[];
+    permissionsBoundary?: string;
 }
 
 export interface LambdaEventSourceConfig extends ServiceEventConsumer {

--- a/handel/src/services/lambda/index.ts
+++ b/handel/src/services/lambda/index.ts
@@ -81,6 +81,10 @@ async function getCompiledLambdaTemplate(stackName: string, ownServiceContext: S
         handlebarsParams.vpcSecurityGroupIds = securityGroups;
         handlebarsParams.vpcSubnetIds = accountConfig.private_subnets;
     }
+
+    if (accountConfig.permissions_boundary) {
+        handlebarsParams.permissionsBoundary = accountConfig.permissions_boundary
+    }
     return handlebars.compileTemplate(`${__dirname}/lambda-template.yml`, handlebarsParams);
 }
 

--- a/handel/src/services/lambda/lambda-template.yml
+++ b/handel/src/services/lambda/lambda-template.yml
@@ -17,6 +17,9 @@ Resources:
               - "lambda.amazonaws.com"
             Action:
             - "sts:AssumeRole"
+      {{#if permissionsBoundary}}
+      PermissionsBoundary: {{permissionsBoundary}}
+      {{/if}}
   Policy:
     Type: AWS::IAM::Policy
     Properties:

--- a/handel/src/services/stepfunctions/config-types.ts
+++ b/handel/src/services/stepfunctions/config-types.ts
@@ -20,6 +20,7 @@ export interface HandlebarsStepFunctionsTemplate {
     stateMachineName: string;
     definitionString: string;
     policyStatements: any[];
+    permissionsBoundary?: string;
 }
 
 export interface StepFunctionsConfig extends ServiceConfig {

--- a/handel/src/services/stepfunctions/index.ts
+++ b/handel/src/services/stepfunctions/index.ts
@@ -62,6 +62,10 @@ function getCompiledStepFunctionsTemplate(stackName: string, ownServiceContext: 
         definitionString,
         policyStatements
     };
+    const accountConfig = ownServiceContext.accountConfig;
+    if (accountConfig.permissions_boundary) {
+        handlebarsParams.permissionsBoundary = accountConfig.permissions_boundary
+    }
     return handlebars.compileTemplate(`${__dirname}/stepfunctions-template.yml`, handlebarsParams);
 }
 

--- a/handel/src/services/stepfunctions/stepfunctions-template.yml
+++ b/handel/src/services/stepfunctions/stepfunctions-template.yml
@@ -16,6 +16,9 @@ Resources:
               - "states.amazonaws.com"
             Action:
             - "sts:AssumeRole"
+      {{#if permissionsBoundary}}
+      PermissionsBoundary: {{permissionsBoundary}}
+      {{/if}}
   Policy:
     Type: AWS::IAM::Policy
     Properties:


### PR DESCRIPTION
If `permissions_boundary` is in the account config, Handel will add that permissions boundary to each role it creates.